### PR TITLE
chore: add MCP config for Linear integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.linear.app/sse"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.mcp.json` with Linear MCP server configuration for Claude Code integration

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behaviour)
- [ ] ♻️ Refactor (no functional change)
- [ ] 🔒 Security fix
- [ ] 📦 Dependency update
- [x] 📝 Documentation only

## What Changed

- `.mcp.json` — MCP server config pointing to Linear's SSE endpoint (no secrets, uses `mcp-remote` for auth)

## How Was It Tested

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Business/acceptance tests added / updated
- [ ] Manually tested locally with Docker Compose

Config-only change — no code impact.

## Checklist

- [x] CI is green (unit, integration, business tests pass)
- [x] Self-reviewed — I have read through the diff carefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)