### PR TITLE
feat(s13): add JWT authentication filter, fix principal extraction, wire logout

### DIFF
--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/SecurityConfig.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.stablecoin.payments.merchant.iam.application.config;
 
+import com.stablecoin.payments.merchant.iam.application.security.JwtAuthenticationFilter;
+import com.stablecoin.payments.merchant.iam.domain.team.JwtTokenIssuer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -15,7 +18,8 @@ public class SecurityConfig {
 
     @Bean
     @ConditionalOnMissingBean(name = "testSecurityFilterChain")
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtFilter) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -27,6 +31,12 @@ public class SecurityConfig {
                         .requestMatchers("/v1/*/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtTokenIssuer jwtTokenIssuer) {
+        return new JwtAuthenticationFilter(jwtTokenIssuer);
     }
 }

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/controller/AuthController.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/controller/AuthController.java
@@ -8,19 +8,23 @@ import com.stablecoin.payments.merchant.iam.api.response.LoginResponse;
 import com.stablecoin.payments.merchant.iam.api.response.MfaChallengeResponse;
 import com.stablecoin.payments.merchant.iam.api.response.UserResponse;
 import com.stablecoin.payments.merchant.iam.application.controller.mapper.IamResponseMapper;
+import com.stablecoin.payments.merchant.iam.application.security.UserAuthentication;
 import com.stablecoin.payments.merchant.iam.domain.exceptions.MfaRequiredException;
 import com.stablecoin.payments.merchant.iam.domain.team.AuthService;
 import com.stablecoin.payments.merchant.iam.domain.team.MerchantTeamService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -93,11 +97,18 @@ public class AuthController {
 
     /**
      * POST /v1/auth/logout
-     * TODO: extract userId from Bearer JWT once M-4 filter is wired.
+     * Revokes all sessions for the authenticated user.
      */
     @PostMapping("/auth/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void logout() {
-        log.info("Logout request — userId extracted from JWT (TODO)");
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof UserAuthentication userAuth) {
+            log.info("Logout request userId={}", userAuth.userId());
+            authService.logout(userAuth.userId());
+        } else {
+            log.warn("Logout called without valid authentication");
+        }
     }
 
     // ── JWKS ──────────────────────────────────────────────────────────────────

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/controller/RolesController.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/controller/RolesController.java
@@ -6,11 +6,13 @@ import com.stablecoin.payments.merchant.iam.api.response.DataResponse;
 import com.stablecoin.payments.merchant.iam.api.response.PageResponse;
 import com.stablecoin.payments.merchant.iam.api.response.RoleResponse;
 import com.stablecoin.payments.merchant.iam.application.controller.mapper.IamResponseMapper;
+import com.stablecoin.payments.merchant.iam.application.security.UserAuthentication;
 import com.stablecoin.payments.merchant.iam.domain.team.MerchantTeamService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -83,8 +85,11 @@ public class RolesController {
         merchantTeamService.deleteRole(merchantId, roleId);
     }
 
-    // TODO: replace with JWT principal extraction once M-4 is implemented
     private UUID resolveCallerId() {
-        return UUID.fromString("00000000-0000-0000-0000-000000000001");
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof UserAuthentication userAuth) {
+            return userAuth.userId();
+        }
+        throw new IllegalStateException("No authenticated user in SecurityContext");
     }
 }

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/controller/UsersController.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/controller/UsersController.java
@@ -12,12 +12,14 @@ import com.stablecoin.payments.merchant.iam.api.response.ReactivateUserResponse;
 import com.stablecoin.payments.merchant.iam.api.response.SuspendUserResponse;
 import com.stablecoin.payments.merchant.iam.api.response.UserResponse;
 import com.stablecoin.payments.merchant.iam.application.controller.mapper.IamResponseMapper;
+import com.stablecoin.payments.merchant.iam.application.security.UserAuthentication;
 import com.stablecoin.payments.merchant.iam.domain.team.MerchantTeamService;
 import com.stablecoin.payments.merchant.iam.domain.team.model.core.UserStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -111,8 +113,11 @@ public class UsersController {
         merchantTeamService.deactivateUser(merchantId, userId, request.reason(), resolveCallerId());
     }
 
-    // TODO: replace with JWT principal extraction once M-4 filter is wired
     private UUID resolveCallerId() {
-        return UUID.fromString("00000000-0000-0000-0000-000000000001");
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof UserAuthentication userAuth) {
+            return userAuth.userId();
+        }
+        throw new IllegalStateException("No authenticated user in SecurityContext");
     }
 }

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/security/JwtAuthenticationFilter.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/security/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.stablecoin.payments.merchant.iam.application.security;
+
+import com.stablecoin.payments.merchant.iam.domain.team.JwtTokenIssuer;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenIssuer jwtTokenIssuer;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        var authHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        var token = authHeader.substring(BEARER_PREFIX.length());
+        try {
+            var parsed = jwtTokenIssuer.parseAndVerify(token);
+
+            var auth = new UserAuthentication(
+                    parsed.userId(),
+                    parsed.merchantId(),
+                    parsed.roleId(),
+                    parsed.role(),
+                    parsed.permissions(),
+                    parsed.mfaVerified());
+
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            chain.doFilter(request, response);
+        } catch (IllegalArgumentException e) {
+            log.debug("JWT validation failed: {}", e.getMessage());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write(
+                    "{\"code\":\"IAM-4010\",\"status\":\"Unauthorized\","
+                            + "\"message\":\"Invalid or expired token\"}");
+        }
+    }
+}

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/security/UserAuthentication.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/security/UserAuthentication.java
@@ -1,0 +1,67 @@
+package com.stablecoin.payments.merchant.iam.application.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Spring Security principal for S13 authenticated users.
+ * Extracted from JWT claims after signature verification.
+ */
+public class UserAuthentication extends AbstractAuthenticationToken {
+
+    private final UUID userId;
+    private final UUID merchantId;
+    private final UUID roleId;
+    private final String role;
+    private final List<String> permissions;
+    private final boolean mfaVerified;
+
+    public UserAuthentication(UUID userId, UUID merchantId, UUID roleId,
+                              String role, List<String> permissions, boolean mfaVerified) {
+        super(permissions.stream().map(p -> new SimpleGrantedAuthority("PERM_" + p)).toList());
+        this.userId = userId;
+        this.merchantId = merchantId;
+        this.roleId = roleId;
+        this.role = role;
+        this.permissions = List.copyOf(permissions);
+        this.mfaVerified = mfaVerified;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    public UUID userId() {
+        return userId;
+    }
+
+    public UUID merchantId() {
+        return merchantId;
+    }
+
+    public UUID roleId() {
+        return roleId;
+    }
+
+    public String role() {
+        return role;
+    }
+
+    public List<String> permissions() {
+        return permissions;
+    }
+
+    public boolean mfaVerified() {
+        return mfaVerified;
+    }
+}

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/domain/team/JwtTokenIssuer.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/domain/team/JwtTokenIssuer.java
@@ -3,6 +3,7 @@ package com.stablecoin.payments.merchant.iam.domain.team;
 import com.stablecoin.payments.merchant.iam.domain.team.model.MerchantUser;
 import com.stablecoin.payments.merchant.iam.domain.team.model.Role;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -23,7 +24,25 @@ public interface JwtTokenIssuer {
     String issueRefreshToken(UUID userId, UUID sessionId);
 
     /**
+     * Parses and verifies a JWT access token. Returns the extracted claims.
+     *
+     * @throws IllegalArgumentException if the token is invalid, expired, or tampered
+     */
+    ParsedAccessToken parseAndVerify(String token);
+
+    /**
      * Returns the public key set in JWK Set JSON format for the JWKS endpoint.
      */
     String jwksJson();
+
+    record ParsedAccessToken(
+            UUID jti,
+            UUID userId,
+            UUID merchantId,
+            UUID roleId,
+            String role,
+            List<String> permissions,
+            boolean mfaVerified,
+            long expiresAtEpochSecond
+    ) {}
 }

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/NimbusJwtTokenIssuer.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/NimbusJwtTokenIssuer.java
@@ -3,6 +3,7 @@ package com.stablecoin.payments.merchant.iam.infrastructure.auth;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWKSet;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -114,6 +116,46 @@ public class NimbusJwtTokenIssuer implements JwtTokenIssuer {
             return jwt.serialize();
         } catch (Exception e) {
             throw new IllegalStateException("Failed to issue refresh token", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ParsedAccessToken parseAndVerify(String token) {
+        try {
+            var jwt = SignedJWT.parse(token);
+            var verifier = new ECDSAVerifier(signingKey.toPublicJWK());
+
+            if (!jwt.verify(verifier)) {
+                throw new IllegalArgumentException("JWT signature verification failed");
+            }
+
+            var claims = jwt.getJWTClaimsSet();
+
+            if (claims.getExpirationTime() == null
+                    || claims.getExpirationTime().before(new Date())) {
+                throw new IllegalArgumentException("JWT has expired");
+            }
+
+            var permissions = claims.getListClaim("permissions");
+            var permissionStrings = permissions != null
+                    ? permissions.stream().map(Object::toString).toList()
+                    : List.<String>of();
+
+            return new ParsedAccessToken(
+                    UUID.fromString(claims.getJWTID()),
+                    UUID.fromString(claims.getStringClaim("user_id")),
+                    UUID.fromString(claims.getStringClaim("merchant_id")),
+                    UUID.fromString(claims.getStringClaim("role_id")),
+                    claims.getStringClaim("role"),
+                    permissionStrings,
+                    Boolean.TRUE.equals(claims.getBooleanClaim("mfa_verified")),
+                    claims.getExpirationTime().toInstant().getEpochSecond()
+            );
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid JWT: " + e.getMessage(), e);
         }
     }
 

--- a/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/application/security/JwtAuthenticationFilterTest.java
+++ b/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/application/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,149 @@
+package com.stablecoin.payments.merchant.iam.application.security;
+
+import com.stablecoin.payments.merchant.iam.domain.team.JwtTokenIssuer;
+import com.stablecoin.payments.merchant.iam.domain.team.JwtTokenIssuer.ParsedAccessToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtTokenIssuer jwtTokenIssuer;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private JwtAuthenticationFilter filter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        filter = new JwtAuthenticationFilter(jwtTokenIssuer);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Nested
+    class WhenNoBearerToken {
+
+        @Test
+        void shouldPassThroughWithoutAuthHeader() throws ServletException, IOException {
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        void shouldPassThroughWithNonBearerAuthHeader() throws ServletException, IOException {
+            request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            verify(jwtTokenIssuer, never()).parseAndVerify(anyString());
+        }
+    }
+
+    @Nested
+    class WhenValidBearerToken {
+
+        private final UUID userId = UUID.randomUUID();
+        private final UUID merchantId = UUID.randomUUID();
+        private final UUID roleId = UUID.randomUUID();
+        private final UUID jti = UUID.randomUUID();
+
+        @Test
+        void shouldAuthenticateWithValidJwt() throws ServletException, IOException {
+            var token = "valid.jwt.token";
+            request.addHeader("Authorization", "Bearer " + token);
+
+            when(jwtTokenIssuer.parseAndVerify(token)).thenReturn(
+                    new ParsedAccessToken(jti, userId, merchantId, roleId,
+                            "ADMIN", List.of("payments:read", "team:manage"), true, 9999999999L));
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(auth).isInstanceOf(UserAuthentication.class);
+            var userAuth = (UserAuthentication) auth;
+            assertThat(userAuth.userId()).isEqualTo(userId);
+            assertThat(userAuth.merchantId()).isEqualTo(merchantId);
+            assertThat(userAuth.roleId()).isEqualTo(roleId);
+            assertThat(userAuth.role()).isEqualTo("ADMIN");
+            assertThat(userAuth.permissions()).containsExactly("payments:read", "team:manage");
+            assertThat(userAuth.mfaVerified()).isTrue();
+        }
+    }
+
+    @Nested
+    class WhenInvalidToken {
+
+        @Test
+        void shouldRejectExpiredToken() throws ServletException, IOException {
+            request.addHeader("Authorization", "Bearer expired.jwt.token");
+            when(jwtTokenIssuer.parseAndVerify("expired.jwt.token"))
+                    .thenThrow(new IllegalArgumentException("JWT has expired"));
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("IAM-4010");
+        }
+
+        @Test
+        void shouldRejectMalformedToken() throws ServletException, IOException {
+            request.addHeader("Authorization", "Bearer not-a-jwt");
+            when(jwtTokenIssuer.parseAndVerify("not-a-jwt"))
+                    .thenThrow(new IllegalArgumentException("Invalid JWT"));
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+    }
+
+    @Test
+    void shouldSkipWhenAlreadyAuthenticated() throws ServletException, IOException {
+        request.addHeader("Authorization", "Bearer some.token");
+        SecurityContextHolder.getContext().setAuthentication(
+                new UserAuthentication(UUID.randomUUID(), UUID.randomUUID(),
+                        UUID.randomUUID(), "ADMIN", List.of(), false));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(jwtTokenIssuer, never()).parseAndVerify(anyString());
+    }
+}

--- a/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/application/security/UserAuthenticationTest.java
+++ b/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/application/security/UserAuthenticationTest.java
@@ -1,0 +1,50 @@
+package com.stablecoin.payments.merchant.iam.application.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserAuthenticationTest {
+
+    @Test
+    void shouldExposeAllFieldsCorrectly() {
+        var userId = UUID.randomUUID();
+        var merchantId = UUID.randomUUID();
+        var roleId = UUID.randomUUID();
+
+        var auth = new UserAuthentication(userId, merchantId, roleId,
+                "ADMIN", List.of("payments:read", "team:manage"), true);
+
+        assertThat(auth.userId()).isEqualTo(userId);
+        assertThat(auth.merchantId()).isEqualTo(merchantId);
+        assertThat(auth.roleId()).isEqualTo(roleId);
+        assertThat(auth.role()).isEqualTo("ADMIN");
+        assertThat(auth.permissions()).containsExactly("payments:read", "team:manage");
+        assertThat(auth.mfaVerified()).isTrue();
+        assertThat(auth.isAuthenticated()).isTrue();
+        assertThat(auth.getPrincipal()).isEqualTo(userId);
+        assertThat(auth.getCredentials()).isNull();
+    }
+
+    @Test
+    void shouldGrantPermissionAuthorities() {
+        var auth = new UserAuthentication(UUID.randomUUID(), UUID.randomUUID(),
+                UUID.randomUUID(), "VIEWER", List.of("payments:read"), false);
+
+        assertThat(auth.getAuthorities()).hasSize(1);
+        assertThat(auth.getAuthorities().iterator().next().getAuthority())
+                .isEqualTo("PERM_payments:read");
+    }
+
+    @Test
+    void shouldHandleEmptyPermissions() {
+        var auth = new UserAuthentication(UUID.randomUUID(), UUID.randomUUID(),
+                UUID.randomUUID(), "VIEWER", List.of(), false);
+
+        assertThat(auth.permissions()).isEmpty();
+        assertThat(auth.getAuthorities()).isEmpty();
+    }
+}

--- a/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/NimbusJwtTokenIssuerTest.java
+++ b/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/NimbusJwtTokenIssuerTest.java
@@ -7,6 +7,7 @@ import com.stablecoin.payments.merchant.iam.domain.team.model.core.AuthProvider;
 import com.stablecoin.payments.merchant.iam.domain.team.model.core.BuiltInRole;
 import com.stablecoin.payments.merchant.iam.domain.team.model.core.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NimbusJwtTokenIssuerTest {
 
@@ -113,5 +115,64 @@ class NimbusJwtTokenIssuerTest {
         var t2 = SignedJWT.parse(issuer.issueAccessToken(buildUser(), buildRole(), false));
         assertThat(t1.getJWTClaimsSet().getJWTID())
                 .isNotEqualTo(t2.getJWTClaimsSet().getJWTID());
+    }
+
+    @Nested
+    class ParseAndVerify {
+
+        @Test
+        void shouldParseIssuedAccessToken() {
+            var token = issuer.issueAccessToken(buildUser(), buildRole(), true);
+            var parsed = issuer.parseAndVerify(token);
+
+            assertThat(parsed.userId()).isEqualTo(userId);
+            assertThat(parsed.merchantId()).isEqualTo(merchantId);
+            assertThat(parsed.roleId()).isEqualTo(roleId);
+            assertThat(parsed.role()).isEqualTo("ADMIN");
+            assertThat(parsed.permissions()).isNotEmpty();
+            assertThat(parsed.mfaVerified()).isTrue();
+            assertThat(parsed.jti()).isNotNull();
+            assertThat(parsed.expiresAtEpochSecond()).isGreaterThan(0);
+        }
+
+        @Test
+        void shouldRejectTamperedToken() {
+            var token = issuer.issueAccessToken(buildUser(), buildRole(), false);
+            var tampered = token.substring(0, token.length() - 4) + "XXXX";
+
+            assertThatThrownBy(() -> issuer.parseAndVerify(tampered))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldRejectExpiredToken() throws Exception {
+            var expiredProps = new JwtProperties(null, "test", "test", 0, 0);
+            var expiredIssuer = new NimbusJwtTokenIssuer(expiredProps);
+            expiredIssuer.init();
+
+            var token = expiredIssuer.issueAccessToken(buildUser(), buildRole(), false);
+
+            assertThatThrownBy(() -> expiredIssuer.parseAndVerify(token))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("expired");
+        }
+
+        @Test
+        void shouldRejectTokenSignedByDifferentKey() throws Exception {
+            var otherProps = new JwtProperties(null, "other", "other", 3600, 86400);
+            var otherIssuer = new NimbusJwtTokenIssuer(otherProps);
+            otherIssuer.init();
+
+            var token = otherIssuer.issueAccessToken(buildUser(), buildRole(), false);
+
+            assertThatThrownBy(() -> issuer.parseAndVerify(token))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldRejectGarbage() {
+            assertThatThrownBy(() -> issuer.parseAndVerify("not-a-jwt"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `JwtAuthenticationFilter` + `UserAuthentication` principal to S13, wired into SecurityConfig
- Extend `JwtTokenIssuer` port with `parseAndVerify` for ES256 JWT verification in `NimbusJwtTokenIssuer`
- Replace hardcoded `resolveCallerId()` in `UsersController` and `RolesController` with JWT principal extraction
- Wire `AuthController.logout()` to revoke all user sessions via `AuthService.logout()`

## What Changed

### New Files
| File | Purpose |
|------|---------|
| `UserAuthentication` | Spring Security principal carrying userId, merchantId, roleId, role, permissions, mfaVerified |
| `JwtAuthenticationFilter` | Validates Bearer JWT via `JwtTokenIssuer.parseAndVerify()`, sets SecurityContext |

### Modified Files
| File | Change |
|------|--------|
| `JwtTokenIssuer` (port) | Added `parseAndVerify()` + `ParsedAccessToken` record |
| `NimbusJwtTokenIssuer` | Implemented `parseAndVerify` with ECDSAVerifier, expiry check, claims extraction |
| `SecurityConfig` | Wires `JwtAuthenticationFilter` bean before `UsernamePasswordAuthenticationFilter` |
| `UsersController` | `resolveCallerId()` extracts userId from `UserAuthentication` (was hardcoded UUID) |
| `RolesController` | `resolveCallerId()` extracts userId from `UserAuthentication` (was hardcoded UUID) |
| `AuthController` | `logout()` extracts userId from JWT, calls `authService.logout()` (was no-op) |

### Tests (14 new)
| Test class | Tests |
|------------|-------|
| `JwtAuthenticationFilterTest` | 6 — passthrough, non-bearer, valid JWT, expired, malformed, skip-if-authenticated |
| `UserAuthenticationTest` | 3 — field exposure, permission authorities, empty permissions |
| `NimbusJwtTokenIssuerTest.ParseAndVerify` | 5 — round-trip, tampered, expired, wrong key, garbage |

All existing 188 unit tests + 14 new = **202 unit tests pass**. Spotless clean.

## Test plan
- [x] All existing 188 unit tests still pass
- [x] 14 new tests covering JWT filter, UserAuthentication, and parseAndVerify
- [x] Spotless formatting clean
- [x] ArchUnit rules pass (domain isolation maintained)

Closes STA-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented JWT token-based authentication and verification.
  * Added session management with logout capability that revokes all active sessions.
  * Enabled role and permission-based access control with MFA support.

* **Bug Fixes**
  * Completed logout endpoint to properly revoke authenticated user sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->