### PR TITLE
feat(s10): S10 ↔ S13 JWKS integration — gateway validates user JWTs

### DIFF
--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/AuditLogFilter.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/AuditLogFilter.java
@@ -35,29 +35,37 @@ public class AuditLogFilter extends OncePerRequestFilter {
 
     private void writeAuditLog(HttpServletRequest request, HttpServletResponse response) {
         var auth = SecurityContextHolder.getContext().getAuthentication();
-        if (!(auth instanceof MerchantAuthentication merchantAuth)) {
-            return;
-        }
 
+        if (auth instanceof MerchantAuthentication merchantAuth) {
+            writeEntry(request, response, merchantAuth.merchantId(),
+                    Map.of("status_code", response.getStatus(),
+                            "auth_method", merchantAuth.authMethod().name(),
+                            "client_id", merchantAuth.clientId().toString()));
+        } else if (auth instanceof UserAuthentication userAuth) {
+            writeEntry(request, response, userAuth.merchantId(),
+                    Map.of("status_code", response.getStatus(),
+                            "auth_method", "USER_JWT",
+                            "user_id", userAuth.userId().toString(),
+                            "role", userAuth.role()));
+        }
+    }
+
+    private void writeEntry(HttpServletRequest request, HttpServletResponse response,
+                            UUID merchantId, Map<String, Object> detail) {
         try {
             var entry = AuditLogEntry.builder()
                     .logId(UUID.randomUUID())
-                    .merchantId(merchantAuth.merchantId())
+                    .merchantId(merchantId)
                     .action(request.getMethod())
                     .resource(request.getRequestURI())
                     .sourceIp(request.getRemoteAddr())
-                    .detail(Map.of(
-                            "status_code", response.getStatus(),
-                            "auth_method", merchantAuth.authMethod().name(),
-                            "client_id", merchantAuth.clientId().toString()
-                    ))
+                    .detail(detail)
                     .occurredAt(Instant.now())
                     .build();
 
             auditLogRepository.save(entry);
         } catch (Exception e) {
-            log.error("Failed to write audit log for merchantId={}: {}",
-                    merchantAuth.merchantId(), e.getMessage());
+            log.error("Failed to write audit log for merchantId={}: {}", merchantId, e.getMessage());
         }
     }
 }

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/RateLimitFilter.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/RateLimitFilter.java
@@ -37,12 +37,11 @@ public class RateLimitFilter extends OncePerRequestFilter {
                                     FilterChain chain) throws ServletException, IOException {
         var auth = SecurityContextHolder.getContext().getAuthentication();
 
-        if (!(auth instanceof MerchantAuthentication merchantAuth)) {
+        var merchantId = extractMerchantId(auth);
+        if (merchantId == null) {
             chain.doFilter(request, response);
             return;
         }
-
-        var merchantId = merchantAuth.merchantId();
         var endpoint = request.getMethod() + " " + normalizePath(request.getRequestURI());
 
         var merchant = merchantRepository.findById(merchantId).orElse(null);
@@ -99,6 +98,16 @@ public class RateLimitFilter extends OncePerRequestFilter {
             }
         }
         return String.join("/", segments);
+    }
+
+    private static UUID extractMerchantId(org.springframework.security.core.Authentication auth) {
+        if (auth instanceof MerchantAuthentication merchantAuth) {
+            return merchantAuth.merchantId();
+        }
+        if (auth instanceof UserAuthentication userAuth) {
+            return userAuth.merchantId();
+        }
+        return null;
     }
 
     private void persistRateLimitEvent(UUID merchantId, String endpoint, RateLimitTier tier,

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/UserAuthentication.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/UserAuthentication.java
@@ -1,0 +1,70 @@
+package com.stablecoin.payments.gateway.iam.application.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Spring Security principal for S13-authenticated users accessing S10 gateway.
+ * Distinct from {@link MerchantAuthentication} which represents merchant/client-level auth.
+ */
+public class UserAuthentication extends AbstractAuthenticationToken {
+
+    private final UUID userId;
+    private final UUID merchantId;
+    private final UUID roleId;
+    private final String role;
+    private final List<String> permissions;
+    private final boolean mfaVerified;
+
+    public UserAuthentication(UUID userId, UUID merchantId, UUID roleId,
+                              String role, List<String> permissions, boolean mfaVerified) {
+        super(Objects.requireNonNull(permissions, "permissions must not be null").stream()
+                .map(p -> new SimpleGrantedAuthority("PERM_" + p))
+                .toList());
+        this.userId = Objects.requireNonNull(userId, "userId must not be null");
+        this.merchantId = Objects.requireNonNull(merchantId, "merchantId must not be null");
+        this.roleId = Objects.requireNonNull(roleId, "roleId must not be null");
+        this.role = Objects.requireNonNull(role, "role must not be null");
+        this.permissions = List.copyOf(permissions);
+        this.mfaVerified = mfaVerified;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    public UUID userId() {
+        return userId;
+    }
+
+    public UUID merchantId() {
+        return merchantId;
+    }
+
+    public UUID roleId() {
+        return roleId;
+    }
+
+    public String role() {
+        return role;
+    }
+
+    public List<String> permissions() {
+        return permissions;
+    }
+
+    public boolean mfaVerified() {
+        return mfaVerified;
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/UserJwtAuthenticationFilter.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/security/UserJwtAuthenticationFilter.java
@@ -1,0 +1,151 @@
+package com.stablecoin.payments.gateway.iam.application.security;
+
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.stablecoin.payments.gateway.iam.domain.exception.UserJwksUnavailableException;
+import com.stablecoin.payments.gateway.iam.domain.port.UserJwksProvider;
+import com.stablecoin.payments.gateway.iam.infrastructure.config.MerchantIamProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Validates S13-issued user JWTs at the S10 gateway.
+ * Fetches S13's JWKS to verify ES256 signatures, then extracts user claims
+ * into a {@link UserAuthentication} principal.
+ *
+ * <p>Runs after the S10 merchant JWT filter. If the token's issuer doesn't match
+ * the S13 issuer, this filter passes through (the token may be an S10 merchant JWT
+ * that was already handled or will be rejected upstream).</p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class UserJwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final UserJwksProvider userJwksProvider;
+    private final MerchantIamProperties merchantIamProperties;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        var authHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        var token = authHeader.substring(BEARER_PREFIX.length());
+
+        try {
+            var jwt = SignedJWT.parse(token);
+            var claims = jwt.getJWTClaimsSet();
+
+            // Only handle tokens issued by S13
+            if (!merchantIamProperties.issuer().equals(claims.getIssuer())) {
+                chain.doFilter(request, response);
+                return;
+            }
+
+            // Validate audience
+            if (claims.getAudience() == null
+                    || !claims.getAudience().contains(merchantIamProperties.audience())) {
+                sendUnauthorized(response, "JWT audience mismatch");
+                return;
+            }
+
+            // Validate expiration
+            if (claims.getExpirationTime() == null
+                    || claims.getExpirationTime().before(new Date())) {
+                sendUnauthorized(response, "JWT has expired");
+                return;
+            }
+
+            // Verify signature against S13 JWKS
+            var jwksJson = userJwksProvider.fetchJwks();
+            var jwkSet = JWKSet.parse(jwksJson);
+            var kid = jwt.getHeader().getKeyID();
+            var jwk = jwkSet.getKeyByKeyId(kid);
+
+            if (jwk == null) {
+                sendUnauthorized(response, "Unknown signing key");
+                return;
+            }
+
+            var verifier = new ECDSAVerifier((ECKey) jwk);
+            if (!jwt.verify(verifier)) {
+                sendUnauthorized(response, "JWT signature verification failed");
+                return;
+            }
+
+            // Extract claims
+            var userId = UUID.fromString(claims.getStringClaim("user_id"));
+            var merchantId = UUID.fromString(claims.getStringClaim("merchant_id"));
+            var roleId = UUID.fromString(claims.getStringClaim("role_id"));
+            var role = claims.getStringClaim("role");
+            var mfaVerified = claims.getBooleanClaim("mfa_verified");
+
+            var permissionsClaim = claims.getStringListClaim("permissions");
+            var permissions = permissionsClaim != null ? permissionsClaim : List.<String>of();
+
+            var auth = new UserAuthentication(userId, merchantId, roleId,
+                    role, permissions, Boolean.TRUE.equals(mfaVerified));
+
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            log.debug("S13 user JWT authenticated userId={} merchantId={} role={}",
+                    userId, merchantId, role);
+
+        } catch (UserJwksUnavailableException e) {
+            log.error("S13 JWKS unavailable: {}", e.getMessage());
+            sendServiceUnavailable(response);
+            return;
+        } catch (IllegalArgumentException e) {
+            log.info("S13 user JWT authentication failed: {}", e.getMessage());
+            sendUnauthorized(response, "Invalid or expired token");
+            return;
+        } catch (Exception e) {
+            log.info("S13 user JWT authentication failed: {}", e.getMessage());
+            sendUnauthorized(response, "Invalid or expired token");
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private void sendUnauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write(
+                "{\"code\":\"GW-1001\",\"status\":\"Unauthorized\",\"message\":\"%s\"}".formatted(message)
+        );
+    }
+
+    private void sendServiceUnavailable(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        response.setContentType("application/json");
+        response.getWriter().write(
+                "{\"code\":\"GW-5001\",\"status\":\"Service Unavailable\","
+                        + "\"message\":\"Authentication service temporarily unavailable\"}");
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/exception/UserJwksUnavailableException.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/exception/UserJwksUnavailableException.java
@@ -1,0 +1,8 @@
+package com.stablecoin.payments.gateway.iam.domain.exception;
+
+public class UserJwksUnavailableException extends RuntimeException {
+
+    public UserJwksUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/port/UserJwksProvider.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/port/UserJwksProvider.java
@@ -1,0 +1,17 @@
+package com.stablecoin.payments.gateway.iam.domain.port;
+
+import com.stablecoin.payments.gateway.iam.domain.exception.UserJwksUnavailableException;
+
+/**
+ * Outbound port for fetching the JWKS (JSON Web Key Set) from the Merchant IAM service (S13).
+ * Infrastructure decides caching strategy and failover behaviour.
+ */
+public interface UserJwksProvider {
+
+    /**
+     * Returns the JWKS JSON from S13.
+     *
+     * @throws UserJwksUnavailableException if S13 is unreachable and no cached value is available
+     */
+    String fetchJwks();
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/CachedUserJwksProvider.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/CachedUserJwksProvider.java
@@ -1,0 +1,43 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.auth;
+
+import com.stablecoin.payments.gateway.iam.domain.exception.UserJwksUnavailableException;
+import com.stablecoin.payments.gateway.iam.domain.port.UserJwksProvider;
+import com.stablecoin.payments.gateway.iam.infrastructure.client.MerchantIamClient;
+import com.stablecoin.payments.gateway.iam.infrastructure.config.MerchantIamProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CachedUserJwksProvider implements UserJwksProvider {
+
+    private static final String CACHE_KEY = "jwks:merchant-iam";
+
+    private final MerchantIamClient merchantIamClient;
+    private final StringRedisTemplate redis;
+    private final MerchantIamProperties properties;
+
+    @Override
+    public String fetchJwks() {
+        var cached = redis.opsForValue().get(CACHE_KEY);
+
+        try {
+            var jwks = merchantIamClient.fetchJwks();
+            redis.opsForValue().set(CACHE_KEY, jwks, Duration.ofHours(properties.jwksCacheTtlHours()));
+            log.debug("Fetched and cached JWKS from S13");
+            return jwks;
+        } catch (Exception e) {
+            if (cached != null) {
+                log.warn("S13 JWKS fetch failed, using cached value: {}", e.getMessage());
+                return cached;
+            }
+            throw new UserJwksUnavailableException(
+                    "S13 JWKS endpoint unreachable and no cached value available", e);
+        }
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/client/MerchantIamClient.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/client/MerchantIamClient.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "merchant-iam",
+        url = "${api-gateway-iam.merchant-iam.base-url}"
+)
+public interface MerchantIamClient {
+
+    @GetMapping("/v1/.well-known/jwks.json")
+    String fetchJwks();
+
+    @GetMapping("/v1/auth/permissions/check")
+    PermissionCheckResponse checkPermission(
+            @RequestParam("user_id") UUID userId,
+            @RequestParam("merchant_id") UUID merchantId,
+            @RequestParam("permission") String permission);
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/client/PermissionCheckResponse.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/client/PermissionCheckResponse.java
@@ -1,0 +1,3 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.client;
+
+public record PermissionCheckResponse(boolean allowed, String role, String via) {}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/MerchantIamProperties.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/MerchantIamProperties.java
@@ -1,0 +1,13 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "api-gateway-iam.merchant-iam")
+public record MerchantIamProperties(
+        @NotBlank String baseUrl,
+        @NotBlank String issuer,
+        @NotBlank String audience,
+        @Positive int jwksCacheTtlHours
+) {}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/SecurityConfig.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/SecurityConfig.java
@@ -4,12 +4,14 @@ import com.stablecoin.payments.gateway.iam.application.security.ApiKeyAuthentica
 import com.stablecoin.payments.gateway.iam.application.security.AuditLogFilter;
 import com.stablecoin.payments.gateway.iam.application.security.JwtAuthenticationFilter;
 import com.stablecoin.payments.gateway.iam.application.security.RateLimitFilter;
+import com.stablecoin.payments.gateway.iam.application.security.UserJwtAuthenticationFilter;
 import com.stablecoin.payments.gateway.iam.domain.port.AuditLogRepository;
 import com.stablecoin.payments.gateway.iam.domain.port.MerchantRepository;
 import com.stablecoin.payments.gateway.iam.domain.port.RateLimitEventRepository;
 import com.stablecoin.payments.gateway.iam.domain.port.RateLimiter;
 import com.stablecoin.payments.gateway.iam.domain.port.TokenIssuer;
 import com.stablecoin.payments.gateway.iam.domain.port.TokenRevocationCache;
+import com.stablecoin.payments.gateway.iam.domain.port.UserJwksProvider;
 import com.stablecoin.payments.gateway.iam.domain.service.ApiKeyService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +32,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
                                                    JwtAuthenticationFilter jwtFilter,
                                                    ApiKeyAuthenticationFilter apiKeyFilter,
+                                                   UserJwtAuthenticationFilter userJwtFilter,
                                                    RateLimitFilter rateLimitFilter,
                                                    AuditLogFilter auditLogFilter) throws Exception {
         return http
@@ -43,7 +46,8 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(apiKeyFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(jwtFilter, ApiKeyAuthenticationFilter.class)
-                .addFilterAfter(rateLimitFilter, JwtAuthenticationFilter.class)
+                .addFilterAfter(userJwtFilter, JwtAuthenticationFilter.class)
+                .addFilterAfter(rateLimitFilter, UserJwtAuthenticationFilter.class)
                 .addFilterAfter(auditLogFilter, RateLimitFilter.class)
                 .build();
     }
@@ -64,6 +68,13 @@ public class SecurityConfig {
                                            MerchantRepository merchantRepository,
                                            RateLimitEventRepository rateLimitEventRepository) {
         return new RateLimitFilter(rateLimiter, merchantRepository, rateLimitEventRepository);
+    }
+
+    @Bean
+    public UserJwtAuthenticationFilter userJwtAuthenticationFilter(
+            UserJwksProvider userJwksProvider,
+            MerchantIamProperties merchantIamProperties) {
+        return new UserJwtAuthenticationFilter(userJwksProvider, merchantIamProperties);
     }
 
     @Bean

--- a/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
+++ b/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
@@ -60,6 +60,11 @@ api-gateway-iam:
     issuer: ${JWT_ISSUER:https://gateway.stablecoin-payments.dev}
     audience: ${JWT_AUDIENCE:payment-platform}
     access-token-ttl-seconds: ${JWT_ACCESS_TTL:3600}
+  merchant-iam:
+    base-url: ${MERCHANT_IAM_BASE_URL:http://localhost:8083}
+    issuer: ${MERCHANT_IAM_ISSUER:https://api.stablecoin-payments.dev}
+    audience: ${MERCHANT_IAM_AUDIENCE:payment-platform}
+    jwks-cache-ttl-hours: ${MERCHANT_IAM_JWKS_CACHE_TTL_HOURS:24}
   rate-limit:
     default-tier: STARTER
   jobs:

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/security/UserAuthenticationTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/security/UserAuthenticationTest.java
@@ -1,0 +1,50 @@
+package com.stablecoin.payments.gateway.iam.application.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserAuthenticationTest {
+
+    @Test
+    void shouldCreateWithAllFields() {
+        var userId = UUID.randomUUID();
+        var merchantId = UUID.randomUUID();
+        var roleId = UUID.randomUUID();
+        var permissions = List.of("payments:read", "team:manage");
+
+        var auth = new UserAuthentication(userId, merchantId, roleId,
+                "ADMIN", permissions, true);
+
+        assertThat(auth.userId()).isEqualTo(userId);
+        assertThat(auth.merchantId()).isEqualTo(merchantId);
+        assertThat(auth.roleId()).isEqualTo(roleId);
+        assertThat(auth.role()).isEqualTo("ADMIN");
+        assertThat(auth.permissions()).containsExactly("payments:read", "team:manage");
+        assertThat(auth.mfaVerified()).isTrue();
+        assertThat(auth.isAuthenticated()).isTrue();
+        assertThat(auth.getPrincipal()).isEqualTo(userId);
+        assertThat(auth.getCredentials()).isNull();
+    }
+
+    @Test
+    void shouldMapPermissionsToAuthorities() {
+        var auth = new UserAuthentication(UUID.randomUUID(), UUID.randomUUID(),
+                UUID.randomUUID(), "VIEWER", List.of("payments:read"), false);
+
+        assertThat(auth.getAuthorities())
+                .extracting(Object::toString)
+                .containsExactly("PERM_payments:read");
+    }
+
+    @Test
+    void shouldRejectNullUserId() {
+        assertThatThrownBy(() -> new UserAuthentication(null, UUID.randomUUID(),
+                UUID.randomUUID(), "ADMIN", List.of(), false))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/security/UserJwtAuthenticationFilterTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/security/UserJwtAuthenticationFilterTest.java
@@ -1,0 +1,280 @@
+package com.stablecoin.payments.gateway.iam.application.security;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.stablecoin.payments.gateway.iam.domain.exception.UserJwksUnavailableException;
+import com.stablecoin.payments.gateway.iam.domain.port.UserJwksProvider;
+import com.stablecoin.payments.gateway.iam.infrastructure.config.MerchantIamProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserJwtAuthenticationFilterTest {
+
+    private static final String S13_ISSUER = "https://api.stablecoin-payments.dev";
+    private static final String AUDIENCE = "payment-platform";
+
+    @Mock
+    private UserJwksProvider userJwksProvider;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private UserJwtAuthenticationFilter filter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    private ECKey signingKey;
+    private ECDSASigner signer;
+    private String jwksJson;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var properties = new MerchantIamProperties(
+                "http://localhost:8083", S13_ISSUER, AUDIENCE, 24);
+        filter = new UserJwtAuthenticationFilter(userJwksProvider, properties);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        SecurityContextHolder.clearContext();
+
+        signingKey = new ECKeyGenerator(Curve.P_256)
+                .keyUse(KeyUse.SIGNATURE)
+                .keyID("test-kid")
+                .algorithm(JWSAlgorithm.ES256)
+                .generate();
+        signer = new ECDSASigner(signingKey);
+        jwksJson = new JWKSet(signingKey.toPublicJWK()).toString();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private String buildToken(String issuer, String audience, Instant expiry,
+                              UUID userId, UUID merchantId) throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .issuer(issuer)
+                .subject(userId.toString())
+                .audience(audience)
+                .jwtID(UUID.randomUUID().toString())
+                .issueTime(new Date())
+                .expirationTime(Date.from(expiry))
+                .claim("user_id", userId.toString())
+                .claim("merchant_id", merchantId.toString())
+                .claim("role_id", UUID.randomUUID().toString())
+                .claim("role", "ADMIN")
+                .claim("permissions", List.of("payments:read", "team:manage"))
+                .claim("mfa_verified", true)
+                .build();
+
+        var header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .keyID(signingKey.getKeyID())
+                .build();
+
+        var jwt = new SignedJWT(header, claims);
+        jwt.sign(signer);
+        return jwt.serialize();
+    }
+
+    @Nested
+    class WhenNoBearerToken {
+
+        @Test
+        void shouldPassThroughWithoutAuthHeader() throws ServletException, IOException {
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        void shouldPassThroughWithNonBearerHeader() throws ServletException, IOException {
+            request.addHeader("Authorization", "Basic abc123");
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+        }
+    }
+
+    @Nested
+    class WhenAlreadyAuthenticated {
+
+        @Test
+        void shouldSkipWhenAlreadyAuthenticated() throws ServletException, IOException {
+            request.addHeader("Authorization", "Bearer some-token");
+            SecurityContextHolder.getContext().setAuthentication(
+                    new MerchantAuthentication(UUID.randomUUID(), UUID.randomUUID(),
+                            List.of(), MerchantAuthentication.AuthMethod.API_KEY));
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(SecurityContextHolder.getContext().getAuthentication())
+                    .isInstanceOf(MerchantAuthentication.class);
+        }
+    }
+
+    @Nested
+    class WhenValidS13Token {
+
+        @Test
+        void shouldAuthenticateWithValidUserJwt() throws Exception {
+            var userId = UUID.randomUUID();
+            var merchantId = UUID.randomUUID();
+            var token = buildToken(S13_ISSUER, AUDIENCE,
+                    Instant.now().plusSeconds(3600), userId, merchantId);
+            request.addHeader("Authorization", "Bearer " + token);
+            when(userJwksProvider.fetchJwks()).thenReturn(jwksJson);
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(auth).isInstanceOf(UserAuthentication.class);
+            var userAuth = (UserAuthentication) auth;
+            assertThat(userAuth.userId()).isEqualTo(userId);
+            assertThat(userAuth.merchantId()).isEqualTo(merchantId);
+            assertThat(userAuth.role()).isEqualTo("ADMIN");
+            assertThat(userAuth.permissions()).containsExactly("payments:read", "team:manage");
+            assertThat(userAuth.mfaVerified()).isTrue();
+        }
+    }
+
+    @Nested
+    class WhenDifferentIssuer {
+
+        @Test
+        void shouldPassThroughForNonS13Issuer() throws Exception {
+            var token = buildToken("https://gateway.stablecoin-payments.dev", AUDIENCE,
+                    Instant.now().plusSeconds(3600), UUID.randomUUID(), UUID.randomUUID());
+            request.addHeader("Authorization", "Bearer " + token);
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+
+    @Nested
+    class WhenInvalidToken {
+
+        @Test
+        void shouldRejectExpiredToken() throws Exception {
+            var token = buildToken(S13_ISSUER, AUDIENCE,
+                    Instant.now().minusSeconds(60), UUID.randomUUID(), UUID.randomUUID());
+            request.addHeader("Authorization", "Bearer " + token);
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+
+        @Test
+        void shouldRejectWrongAudience() throws Exception {
+            var token = buildToken(S13_ISSUER, "wrong-audience",
+                    Instant.now().plusSeconds(3600), UUID.randomUUID(), UUID.randomUUID());
+            request.addHeader("Authorization", "Bearer " + token);
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+
+        @Test
+        void shouldRejectTokenSignedByDifferentKey() throws Exception {
+            var otherKey = new ECKeyGenerator(Curve.P_256)
+                    .keyUse(KeyUse.SIGNATURE)
+                    .keyID("other-kid")
+                    .algorithm(JWSAlgorithm.ES256)
+                    .generate();
+
+            var claims = new JWTClaimsSet.Builder()
+                    .issuer(S13_ISSUER)
+                    .audience(AUDIENCE)
+                    .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+                    .claim("user_id", UUID.randomUUID().toString())
+                    .claim("merchant_id", UUID.randomUUID().toString())
+                    .claim("role_id", UUID.randomUUID().toString())
+                    .claim("role", "ADMIN")
+                    .claim("permissions", List.of())
+                    .claim("mfa_verified", false)
+                    .build();
+
+            var jwt = new SignedJWT(
+                    new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(signingKey.getKeyID()).build(),
+                    claims);
+            jwt.sign(new ECDSASigner(otherKey));
+
+            request.addHeader("Authorization", "Bearer " + jwt.serialize());
+            when(userJwksProvider.fetchJwks()).thenReturn(jwksJson);
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+
+        @Test
+        void shouldRejectGarbageToken() throws ServletException, IOException {
+            request.addHeader("Authorization", "Bearer not-a-jwt");
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+    }
+
+    @Nested
+    class WhenJwksUnavailable {
+
+        @Test
+        void shouldReturn503WhenJwksUnavailable() throws Exception {
+            var token = buildToken(S13_ISSUER, AUDIENCE,
+                    Instant.now().plusSeconds(3600), UUID.randomUUID(), UUID.randomUUID());
+            request.addHeader("Authorization", "Bearer " + token);
+            when(userJwksProvider.fetchJwks())
+                    .thenThrow(new UserJwksUnavailableException("S13 down", new RuntimeException()));
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(503);
+            assertThat(response.getContentAsString()).contains("GW-5001");
+        }
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/CachedUserJwksProviderTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/CachedUserJwksProviderTest.java
@@ -1,0 +1,99 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.auth;
+
+import com.stablecoin.payments.gateway.iam.domain.exception.UserJwksUnavailableException;
+import com.stablecoin.payments.gateway.iam.infrastructure.client.MerchantIamClient;
+import com.stablecoin.payments.gateway.iam.infrastructure.config.MerchantIamProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CachedUserJwksProviderTest {
+
+    private static final String CACHE_KEY = "jwks:merchant-iam";
+    private static final String JWKS_JSON = "{\"keys\":[{\"kty\":\"EC\"}]}";
+
+    @Mock
+    private MerchantIamClient merchantIamClient;
+
+    @Mock
+    private StringRedisTemplate redis;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    private CachedUserJwksProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        var properties = new MerchantIamProperties(
+                "http://localhost:8083",
+                "https://api.stablecoin-payments.dev",
+                "payment-platform",
+                24);
+        provider = new CachedUserJwksProvider(merchantIamClient, redis, properties);
+        when(redis.opsForValue()).thenReturn(valueOps);
+    }
+
+    @Nested
+    class WhenS13Available {
+
+        @Test
+        void shouldFetchAndCacheJwks() {
+            when(valueOps.get(CACHE_KEY)).thenReturn(null);
+            when(merchantIamClient.fetchJwks()).thenReturn(JWKS_JSON);
+
+            var result = provider.fetchJwks();
+
+            assertThat(result).isEqualTo(JWKS_JSON);
+            verify(valueOps).set(CACHE_KEY, JWKS_JSON, Duration.ofHours(24));
+        }
+
+        @Test
+        void shouldRefreshCacheEvenWhenCachedValueExists() {
+            when(valueOps.get(CACHE_KEY)).thenReturn("old-jwks");
+            when(merchantIamClient.fetchJwks()).thenReturn(JWKS_JSON);
+
+            var result = provider.fetchJwks();
+
+            assertThat(result).isEqualTo(JWKS_JSON);
+            verify(valueOps).set(CACHE_KEY, JWKS_JSON, Duration.ofHours(24));
+        }
+    }
+
+    @Nested
+    class WhenS13Unavailable {
+
+        @Test
+        void shouldReturnCachedValueWhenAvailable() {
+            when(valueOps.get(CACHE_KEY)).thenReturn(JWKS_JSON);
+            when(merchantIamClient.fetchJwks()).thenThrow(new RuntimeException("Connection refused"));
+
+            var result = provider.fetchJwks();
+
+            assertThat(result).isEqualTo(JWKS_JSON);
+        }
+
+        @Test
+        void shouldThrowWhenNoCachedValue() {
+            when(valueOps.get(CACHE_KEY)).thenReturn(null);
+            when(merchantIamClient.fetchJwks()).thenThrow(new RuntimeException("Connection refused"));
+
+            assertThatThrownBy(() -> provider.fetchJwks())
+                    .isInstanceOf(UserJwksUnavailableException.class)
+                    .hasMessageContaining("no cached value available");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **UserJwtAuthenticationFilter** validates S13-issued user JWTs at the S10 gateway by fetching and caching S13's JWKS (ES256 public key, 24h Redis TTL)
- **CachedUserJwksProvider** implements stale-while-revalidate: if S13 is down but cache is valid, uses cached JWKS; if both unavailable, returns 503 (fail-closed)
- **RateLimitFilter** and **AuditLogFilter** now handle both `MerchantAuthentication` (API key/OAuth) and `UserAuthentication` (S13 user JWT) principals
- Filter chain order: ApiKey → S10 JWT → S13 UserJWT → RateLimit → AuditLog
- 178 unit tests green (17 new)

## New Files
| File | Purpose |
|------|---------|
| `UserAuthentication` | Spring Security principal for S13 users |
| `UserJwtAuthenticationFilter` | Validates S13 JWTs (issuer, audience, expiry, ES256 sig) |
| `UserJwksProvider` | Domain port for JWKS fetching |
| `CachedUserJwksProvider` | Redis-cached JWKS with failover |
| `MerchantIamClient` | Feign client for S13 JWKS + permission check |
| `MerchantIamProperties` | S13 connection config |

## Test plan
- [x] UserAuthenticationTest (3 tests) — constructor, authorities, null rejection
- [x] UserJwtAuthenticationFilterTest (10 tests) — no bearer, already auth'd, valid S13 JWT, wrong issuer pass-through, expired, wrong audience, different key, garbage, JWKS unavailable 503
- [x] CachedUserJwksProviderTest (4 tests) — cache hit, cache miss, S13 down + cache valid, S13 down + no cache
- [x] All 178 existing + new tests pass
- [x] No regression on existing MerchantAuthentication flow

Closes STA-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User authentication via JWT tokens with role-based access control and permission validation
  * User MFA verification and identity tracking in authentication flow
  * Comprehensive audit logging for user authentication events

* **Improvements**
  * Rate limiting extended to user authentication requests
  * Audit logging refactored for consistent handling across authentication types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->