### PR TITLE
feat(s10): OAuth client auto-provisioning, admin endpoint, and Feign clients (STA-49)

### DIFF
--- a/api-gateway-iam/api-gateway-iam-api/src/main/java/com/stablecoin/payments/gateway/iam/api/request/CreateOAuthClientRequest.java
+++ b/api-gateway-iam/api-gateway-iam-api/src/main/java/com/stablecoin/payments/gateway/iam/api/request/CreateOAuthClientRequest.java
@@ -1,0 +1,11 @@
+package com.stablecoin.payments.gateway.iam.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record CreateOAuthClientRequest(
+        @NotBlank String name,
+        List<String> scopes,
+        List<String> grantTypes
+) {}

--- a/api-gateway-iam/api-gateway-iam-api/src/main/java/com/stablecoin/payments/gateway/iam/api/response/OAuthClientResponse.java
+++ b/api-gateway-iam/api-gateway-iam-api/src/main/java/com/stablecoin/payments/gateway/iam/api/response/OAuthClientResponse.java
@@ -1,0 +1,15 @@
+package com.stablecoin.payments.gateway.iam.api.response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record OAuthClientResponse(
+        UUID clientId,
+        String clientSecret,
+        UUID merchantId,
+        String name,
+        List<String> scopes,
+        List<String> grantTypes,
+        Instant createdAt
+) {}

--- a/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayApiKeyClient.java
+++ b/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayApiKeyClient.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.gateway.iam.client;
+
+import com.stablecoin.payments.gateway.iam.api.request.CreateApiKeyRequest;
+import com.stablecoin.payments.gateway.iam.api.response.ApiKeyResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@FeignClient(name = "api-gateway-iam-api-key", url = "${clients.api-gateway-iam.url}")
+public interface GatewayApiKeyClient {
+
+    @PostMapping("/v1/api-keys")
+    ApiKeyResponse createApiKey(@RequestBody CreateApiKeyRequest request);
+
+    @DeleteMapping("/v1/api-keys/{keyId}")
+    void revokeApiKey(@PathVariable UUID keyId);
+}

--- a/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayMerchantClient.java
+++ b/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayMerchantClient.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.gateway.iam.client;
+
+import com.stablecoin.payments.gateway.iam.api.request.CreateMerchantRequest;
+import com.stablecoin.payments.gateway.iam.api.response.MerchantResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@FeignClient(name = "api-gateway-iam-merchant", url = "${clients.api-gateway-iam.url}")
+public interface GatewayMerchantClient {
+
+    @PostMapping("/v1/merchants")
+    MerchantResponse createMerchant(@RequestBody CreateMerchantRequest request);
+
+    @GetMapping("/v1/merchants/{merchantId}")
+    MerchantResponse getMerchant(@PathVariable UUID merchantId);
+}

--- a/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayOAuthClientClient.java
+++ b/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayOAuthClientClient.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.gateway.iam.client;
+
+import com.stablecoin.payments.gateway.iam.api.request.CreateOAuthClientRequest;
+import com.stablecoin.payments.gateway.iam.api.response.OAuthClientResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@FeignClient(name = "api-gateway-iam-oauth", url = "${clients.api-gateway-iam.url}")
+public interface GatewayOAuthClientClient {
+
+    @PostMapping("/v1/merchants/{merchantId}/oauth-clients")
+    OAuthClientResponse createOAuthClient(
+            @PathVariable UUID merchantId,
+            @RequestBody CreateOAuthClientRequest request);
+}

--- a/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayTokenClient.java
+++ b/api-gateway-iam/api-gateway-iam-client/src/main/java/com/stablecoin/payments/gateway/iam/client/GatewayTokenClient.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.gateway.iam.client;
+
+import com.stablecoin.payments.gateway.iam.api.request.TokenRequest;
+import com.stablecoin.payments.gateway.iam.api.request.TokenRevokeRequest;
+import com.stablecoin.payments.gateway.iam.api.response.TokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "api-gateway-iam-token", url = "${clients.api-gateway-iam.url}")
+public interface GatewayTokenClient {
+
+    @PostMapping("/v1/auth/token")
+    TokenResponse issueToken(@RequestBody TokenRequest request);
+
+    @PostMapping("/v1/auth/revoke")
+    void revokeToken(@RequestBody TokenRevokeRequest request);
+
+    @GetMapping(value = "/.well-known/jwks.json", produces = MediaType.APPLICATION_JSON_VALUE)
+    String jwks();
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/controller/OAuthClientController.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/controller/OAuthClientController.java
@@ -1,0 +1,35 @@
+package com.stablecoin.payments.gateway.iam.application.controller;
+
+import com.stablecoin.payments.gateway.iam.api.request.CreateOAuthClientRequest;
+import com.stablecoin.payments.gateway.iam.api.response.OAuthClientResponse;
+import com.stablecoin.payments.gateway.iam.application.service.OAuthClientApplicationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/merchants/{merchantId}/oauth-clients")
+@RequiredArgsConstructor
+public class OAuthClientController {
+
+    private final OAuthClientApplicationService oauthClientApplicationService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public OAuthClientResponse createOAuthClient(
+            @PathVariable UUID merchantId,
+            @Valid @RequestBody CreateOAuthClientRequest request) {
+        log.info("Create OAuth client merchantId={} name={}", merchantId, request.name());
+        return oauthClientApplicationService.createOAuthClient(merchantId, request);
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/service/MerchantApplicationService.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/service/MerchantApplicationService.java
@@ -3,9 +3,13 @@ package com.stablecoin.payments.gateway.iam.application.service;
 import com.stablecoin.payments.gateway.iam.api.request.CreateMerchantRequest;
 import com.stablecoin.payments.gateway.iam.api.response.MerchantResponse;
 import com.stablecoin.payments.gateway.iam.application.controller.mapper.GatewayResponseMapper;
+import com.stablecoin.payments.gateway.iam.domain.event.OAuthClientProvisionedEvent;
 import com.stablecoin.payments.gateway.iam.domain.model.Corridor;
+import com.stablecoin.payments.gateway.iam.domain.port.EventPublisher;
 import com.stablecoin.payments.gateway.iam.domain.service.MerchantService;
+import com.stablecoin.payments.gateway.iam.domain.service.OAuthClientService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,12 +17,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class MerchantApplicationService {
 
     private final MerchantService merchantService;
+    private final OAuthClientService oauthClientService;
+    private final EventPublisher<Object> eventPublisher;
     private final GatewayResponseMapper mapper;
 
     public MerchantResponse createMerchant(CreateMerchantRequest request) {
@@ -42,5 +49,32 @@ public class MerchantApplicationService {
     public MerchantResponse getMerchant(UUID merchantId) {
         var merchant = merchantService.findById(merchantId);
         return mapper.toMerchantResponse(merchant);
+    }
+
+    public void activateAndProvisionOAuthClient(UUID externalId, String companyName,
+                                                 List<String> scopes) {
+        var merchant = merchantService.activate(externalId);
+
+        var effectiveScopes = (scopes != null && !scopes.isEmpty())
+                ? scopes : merchant.getScopes();
+
+        var result = oauthClientService.create(
+                merchant.getMerchantId(),
+                companyName + " Default Client",
+                effectiveScopes,
+                List.of("client_credentials"));
+
+        var client = result.client();
+        eventPublisher.publish(new OAuthClientProvisionedEvent(
+                client.getClientId(),
+                client.getMerchantId(),
+                result.rawSecret(),
+                client.getName(),
+                client.getScopes(),
+                client.getGrantTypes(),
+                client.getCreatedAt()));
+
+        log.info("Activated merchant and provisioned default OAuth client externalId={} clientId={}",
+                externalId, client.getClientId());
     }
 }

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/service/OAuthClientApplicationService.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/service/OAuthClientApplicationService.java
@@ -1,0 +1,51 @@
+package com.stablecoin.payments.gateway.iam.application.service;
+
+import com.stablecoin.payments.gateway.iam.api.request.CreateOAuthClientRequest;
+import com.stablecoin.payments.gateway.iam.api.response.OAuthClientResponse;
+import com.stablecoin.payments.gateway.iam.domain.event.OAuthClientProvisionedEvent;
+import com.stablecoin.payments.gateway.iam.domain.port.EventPublisher;
+import com.stablecoin.payments.gateway.iam.domain.service.OAuthClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OAuthClientApplicationService {
+
+    private final OAuthClientService oauthClientService;
+    private final EventPublisher<Object> eventPublisher;
+
+    public OAuthClientResponse createOAuthClient(UUID merchantId, CreateOAuthClientRequest request) {
+        var result = oauthClientService.create(
+                merchantId,
+                request.name(),
+                request.scopes() != null ? request.scopes() : Collections.emptyList(),
+                request.grantTypes() != null ? request.grantTypes() : List.of("client_credentials"));
+
+        var client = result.client();
+
+        eventPublisher.publish(new OAuthClientProvisionedEvent(
+                client.getClientId(),
+                client.getMerchantId(),
+                result.rawSecret(),
+                client.getName(),
+                client.getScopes(),
+                client.getGrantTypes(),
+                client.getCreatedAt()));
+
+        return new OAuthClientResponse(
+                client.getClientId(),
+                result.rawSecret(),
+                client.getMerchantId(),
+                client.getName(),
+                client.getScopes(),
+                client.getGrantTypes(),
+                client.getCreatedAt());
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/event/OAuthClientProvisionedEvent.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/event/OAuthClientProvisionedEvent.java
@@ -1,0 +1,17 @@
+package com.stablecoin.payments.gateway.iam.domain.event;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record OAuthClientProvisionedEvent(
+        UUID clientId,
+        UUID merchantId,
+        String rawClientSecret,
+        String name,
+        List<String> scopes,
+        List<String> grantTypes,
+        Instant createdAt
+) {
+    public static final String TOPIC = "oauth-client.provisioned";
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/port/ClientSecretGenerator.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/port/ClientSecretGenerator.java
@@ -1,0 +1,6 @@
+package com.stablecoin.payments.gateway.iam.domain.port;
+
+public interface ClientSecretGenerator {
+
+    String generate();
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/service/OAuthClientService.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/domain/service/OAuthClientService.java
@@ -1,0 +1,72 @@
+package com.stablecoin.payments.gateway.iam.domain.service;
+
+import com.stablecoin.payments.gateway.iam.domain.exception.MerchantNotActiveException;
+import com.stablecoin.payments.gateway.iam.domain.exception.MerchantNotFoundException;
+import com.stablecoin.payments.gateway.iam.domain.exception.ScopeExceededException;
+import com.stablecoin.payments.gateway.iam.domain.model.OAuthClient;
+import com.stablecoin.payments.gateway.iam.domain.port.ClientSecretGenerator;
+import com.stablecoin.payments.gateway.iam.domain.port.ClientSecretHasher;
+import com.stablecoin.payments.gateway.iam.domain.port.MerchantRepository;
+import com.stablecoin.payments.gateway.iam.domain.port.OAuthClientRepository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public class OAuthClientService {
+
+    private final OAuthClientRepository oauthClientRepository;
+    private final MerchantRepository merchantRepository;
+    private final ClientSecretGenerator clientSecretGenerator;
+    private final ClientSecretHasher clientSecretHasher;
+
+    public OAuthClientService(OAuthClientRepository oauthClientRepository,
+                              MerchantRepository merchantRepository,
+                              ClientSecretGenerator clientSecretGenerator,
+                              ClientSecretHasher clientSecretHasher) {
+        this.oauthClientRepository = oauthClientRepository;
+        this.merchantRepository = merchantRepository;
+        this.clientSecretGenerator = clientSecretGenerator;
+        this.clientSecretHasher = clientSecretHasher;
+    }
+
+    public CreateOAuthClientResult create(UUID merchantId, String name,
+                                          List<String> scopes, List<String> grantTypes) {
+        var merchant = merchantRepository.findById(merchantId)
+                .orElseThrow(() -> MerchantNotFoundException.byId(merchantId));
+
+        if (!merchant.isActive()) {
+            throw MerchantNotActiveException.of(merchantId);
+        }
+
+        if (scopes != null && !scopes.isEmpty() && !merchant.getScopes().containsAll(scopes)) {
+            throw ScopeExceededException.of(scopes, merchant.getScopes());
+        }
+
+        var rawSecret = clientSecretGenerator.generate();
+        var hash = clientSecretHasher.hash(rawSecret);
+
+        var effectiveScopes = (scopes != null && !scopes.isEmpty())
+                ? List.copyOf(scopes) : List.copyOf(merchant.getScopes());
+        var effectiveGrantTypes = (grantTypes != null && !grantTypes.isEmpty())
+                ? List.copyOf(grantTypes) : List.of("client_credentials");
+
+        var client = OAuthClient.builder()
+                .clientId(UUID.randomUUID())
+                .merchantId(merchantId)
+                .clientSecretHash(hash)
+                .name(name)
+                .scopes(effectiveScopes)
+                .grantTypes(effectiveGrantTypes)
+                .active(true)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .version(0L)
+                .build();
+
+        var saved = oauthClientRepository.save(client);
+        return new CreateOAuthClientResult(saved, rawSecret);
+    }
+
+    public record CreateOAuthClientResult(OAuthClient client, String rawSecret) {}
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/SecureClientSecretGenerator.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/SecureClientSecretGenerator.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.auth;
+
+import com.stablecoin.payments.gateway.iam.domain.port.ClientSecretGenerator;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.HexFormat;
+
+@Component
+public class SecureClientSecretGenerator implements ClientSecretGenerator {
+
+    private static final int SECRET_LENGTH_BYTES = 32;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public String generate() {
+        var bytes = new byte[SECRET_LENGTH_BYTES];
+        secureRandom.nextBytes(bytes);
+        return HexFormat.of().formatHex(bytes);
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/DomainServiceConfig.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/DomainServiceConfig.java
@@ -5,6 +5,7 @@ import com.stablecoin.payments.gateway.iam.domain.port.AccessTokenRepository;
 import com.stablecoin.payments.gateway.iam.domain.port.ApiKeyGenerator;
 import com.stablecoin.payments.gateway.iam.domain.port.ApiKeyHasher;
 import com.stablecoin.payments.gateway.iam.domain.port.ApiKeyRepository;
+import com.stablecoin.payments.gateway.iam.domain.port.ClientSecretGenerator;
 import com.stablecoin.payments.gateway.iam.domain.port.ClientSecretHasher;
 import com.stablecoin.payments.gateway.iam.domain.port.EventPublisher;
 import com.stablecoin.payments.gateway.iam.domain.port.MerchantRepository;
@@ -14,6 +15,7 @@ import com.stablecoin.payments.gateway.iam.domain.port.TokenRevocationCache;
 import com.stablecoin.payments.gateway.iam.domain.service.ApiKeyService;
 import com.stablecoin.payments.gateway.iam.domain.service.AuthService;
 import com.stablecoin.payments.gateway.iam.domain.service.MerchantService;
+import com.stablecoin.payments.gateway.iam.domain.service.OAuthClientService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,5 +53,14 @@ public class DomainServiceConfig {
                                        EventPublisher<?> eventPublisher) {
         return new ApiKeyService(apiKeyRepository, merchantRepository,
                 apiKeyGenerator, apiKeyHasher, (EventPublisher<ApiKeyRevokedEvent>) eventPublisher);
+    }
+
+    @Bean
+    public OAuthClientService oauthClientService(OAuthClientRepository oauthClientRepository,
+                                                  MerchantRepository merchantRepository,
+                                                  ClientSecretGenerator clientSecretGenerator,
+                                                  ClientSecretHasher clientSecretHasher) {
+        return new OAuthClientService(oauthClientRepository, merchantRepository,
+                clientSecretGenerator, clientSecretHasher);
     }
 }

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/messaging/MerchantEventListener.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/messaging/MerchantEventListener.java
@@ -1,5 +1,6 @@
 package com.stablecoin.payments.gateway.iam.infrastructure.messaging;
 
+import com.stablecoin.payments.gateway.iam.application.service.MerchantApplicationService;
 import com.stablecoin.payments.gateway.iam.domain.service.MerchantService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import java.util.UUID;
 public class MerchantEventListener {
 
     private final MerchantService merchantService;
+    private final MerchantApplicationService merchantApplicationService;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "merchant.activated", groupId = "api-gateway-iam-activate")
@@ -25,9 +27,11 @@ public class MerchantEventListener {
             var event = objectMapper.readValue(payload, MerchantActivatedEvent.class);
             log.info("Received merchant.activated merchantId={}", event.merchantId());
 
-            merchantService.activate(event.merchantId());
+            merchantApplicationService.activateAndProvisionOAuthClient(
+                    event.merchantId(), event.companyName(), event.scopes());
 
-            log.info("Activated merchant merchantId={}", event.merchantId());
+            log.info("Activated merchant and provisioned default OAuth client merchantId={}",
+                    event.merchantId());
         } catch (Exception e) {
             log.error("Failed to process merchant.activated: {}", e.getMessage(), e);
             throw new RuntimeException("Failed to process merchant.activated", e);

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/controller/OAuthClientControllerTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/controller/OAuthClientControllerTest.java
@@ -1,0 +1,82 @@
+package com.stablecoin.payments.gateway.iam.application.controller;
+
+import com.stablecoin.payments.gateway.iam.api.request.CreateOAuthClientRequest;
+import com.stablecoin.payments.gateway.iam.api.response.OAuthClientResponse;
+import com.stablecoin.payments.gateway.iam.application.service.OAuthClientApplicationService;
+import com.stablecoin.payments.gateway.iam.domain.exception.MerchantNotActiveException;
+import com.stablecoin.payments.gateway.iam.domain.exception.MerchantNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OAuthClientController")
+class OAuthClientControllerTest {
+
+    @Mock
+    private OAuthClientApplicationService oauthClientApplicationService;
+
+    @InjectMocks
+    private OAuthClientController controller;
+
+    @Test
+    @DisplayName("createOAuthClient should return response with raw secret")
+    void shouldCreateOAuthClient() {
+        var merchantId = UUID.randomUUID();
+        var clientId = UUID.randomUUID();
+        var response = new OAuthClientResponse(
+                clientId, "raw-secret-hex", merchantId, "My Client",
+                List.of("payments:read"), List.of("client_credentials"), Instant.now());
+        given(oauthClientApplicationService.createOAuthClient(eq(merchantId), any()))
+                .willReturn(response);
+
+        var request = new CreateOAuthClientRequest(
+                "My Client", List.of("payments:read"), List.of("client_credentials"));
+
+        var result = controller.createOAuthClient(merchantId, request);
+
+        assertThat(result.clientId()).isEqualTo(clientId);
+        assertThat(result.clientSecret()).isEqualTo("raw-secret-hex");
+        assertThat(result.merchantId()).isEqualTo(merchantId);
+        assertThat(result.name()).isEqualTo("My Client");
+    }
+
+    @Test
+    @DisplayName("createOAuthClient should throw when merchant not found")
+    void shouldThrowWhenMerchantNotFound() {
+        var merchantId = UUID.randomUUID();
+        given(oauthClientApplicationService.createOAuthClient(eq(merchantId), any()))
+                .willThrow(MerchantNotFoundException.byId(merchantId));
+
+        var request = new CreateOAuthClientRequest("Client", null, null);
+
+        assertThatThrownBy(() -> controller.createOAuthClient(merchantId, request))
+                .isInstanceOf(MerchantNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("createOAuthClient should throw when merchant not active")
+    void shouldThrowWhenMerchantNotActive() {
+        var merchantId = UUID.randomUUID();
+        given(oauthClientApplicationService.createOAuthClient(eq(merchantId), any()))
+                .willThrow(MerchantNotActiveException.of(merchantId));
+
+        var request = new CreateOAuthClientRequest("Client", null, null);
+
+        assertThatThrownBy(() -> controller.createOAuthClient(merchantId, request))
+                .isInstanceOf(MerchantNotActiveException.class);
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/domain/service/OAuthClientServiceTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/domain/service/OAuthClientServiceTest.java
@@ -1,0 +1,163 @@
+package com.stablecoin.payments.gateway.iam.domain.service;
+
+import com.stablecoin.payments.gateway.iam.domain.exception.MerchantNotActiveException;
+import com.stablecoin.payments.gateway.iam.domain.exception.MerchantNotFoundException;
+import com.stablecoin.payments.gateway.iam.domain.exception.ScopeExceededException;
+import com.stablecoin.payments.gateway.iam.domain.model.KybStatus;
+import com.stablecoin.payments.gateway.iam.domain.model.Merchant;
+import com.stablecoin.payments.gateway.iam.domain.model.MerchantStatus;
+import com.stablecoin.payments.gateway.iam.domain.model.RateLimitTier;
+import com.stablecoin.payments.gateway.iam.domain.port.ClientSecretGenerator;
+import com.stablecoin.payments.gateway.iam.domain.port.ClientSecretHasher;
+import com.stablecoin.payments.gateway.iam.domain.port.MerchantRepository;
+import com.stablecoin.payments.gateway.iam.domain.port.OAuthClientRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthClientServiceTest {
+
+    @Mock private OAuthClientRepository oauthClientRepository;
+    @Mock private MerchantRepository merchantRepository;
+    @Mock private ClientSecretGenerator clientSecretGenerator;
+    @Mock private ClientSecretHasher clientSecretHasher;
+
+    private OAuthClientService service;
+
+    private static final UUID MERCHANT_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        service = new OAuthClientService(oauthClientRepository, merchantRepository,
+                clientSecretGenerator, clientSecretHasher);
+    }
+
+    private static Merchant activeMerchant() {
+        return Merchant.builder()
+                .merchantId(MERCHANT_ID)
+                .externalId(UUID.randomUUID())
+                .name("Test Corp")
+                .country("US")
+                .scopes(List.of("payments:read", "payments:write"))
+                .corridors(List.of())
+                .status(MerchantStatus.ACTIVE)
+                .kybStatus(KybStatus.VERIFIED)
+                .rateLimitTier(RateLimitTier.STARTER)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .version(0L)
+                .build();
+    }
+
+    private static Merchant pendingMerchant() {
+        return Merchant.builder()
+                .merchantId(MERCHANT_ID)
+                .externalId(UUID.randomUUID())
+                .name("Test Corp")
+                .country("US")
+                .scopes(List.of("payments:read"))
+                .corridors(List.of())
+                .status(MerchantStatus.PENDING)
+                .kybStatus(KybStatus.PENDING)
+                .rateLimitTier(RateLimitTier.STARTER)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .version(0L)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("create()")
+    class Create {
+
+        @Test
+        @DisplayName("should create OAuth client with generated secret")
+        void shouldCreateOAuthClient() {
+            given(merchantRepository.findById(MERCHANT_ID)).willReturn(Optional.of(activeMerchant()));
+            given(clientSecretGenerator.generate()).willReturn("raw-secret-hex");
+            given(clientSecretHasher.hash("raw-secret-hex")).willReturn("$2a$12$hashed");
+            given(oauthClientRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            var result = service.create(MERCHANT_ID, "My Client",
+                    List.of("payments:read"), List.of("client_credentials"));
+
+            assertThat(result.rawSecret()).isEqualTo("raw-secret-hex");
+            assertThat(result.client().getMerchantId()).isEqualTo(MERCHANT_ID);
+            assertThat(result.client().getName()).isEqualTo("My Client");
+            assertThat(result.client().getScopes()).containsExactly("payments:read");
+            assertThat(result.client().getGrantTypes()).containsExactly("client_credentials");
+            assertThat(result.client().getClientSecretHash()).isEqualTo("$2a$12$hashed");
+            assertThat(result.client().isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should use merchant scopes when no scopes provided")
+        void shouldUseMerchantScopesAsDefault() {
+            given(merchantRepository.findById(MERCHANT_ID)).willReturn(Optional.of(activeMerchant()));
+            given(clientSecretGenerator.generate()).willReturn("secret");
+            given(clientSecretHasher.hash("secret")).willReturn("hash");
+            given(oauthClientRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            var result = service.create(MERCHANT_ID, "Client", List.of(), List.of());
+
+            assertThat(result.client().getScopes())
+                    .containsExactly("payments:read", "payments:write");
+        }
+
+        @Test
+        @DisplayName("should default to client_credentials grant type")
+        void shouldDefaultToClientCredentials() {
+            given(merchantRepository.findById(MERCHANT_ID)).willReturn(Optional.of(activeMerchant()));
+            given(clientSecretGenerator.generate()).willReturn("secret");
+            given(clientSecretHasher.hash("secret")).willReturn("hash");
+            given(oauthClientRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            var result = service.create(MERCHANT_ID, "Client", null, null);
+
+            assertThat(result.client().getGrantTypes()).containsExactly("client_credentials");
+        }
+
+        @Test
+        @DisplayName("should throw when merchant not found")
+        void shouldThrowWhenMerchantNotFound() {
+            given(merchantRepository.findById(MERCHANT_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.create(MERCHANT_ID, "Client", List.of(), List.of()))
+                    .isInstanceOf(MerchantNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("should throw when merchant is not active")
+        void shouldThrowWhenMerchantNotActive() {
+            given(merchantRepository.findById(MERCHANT_ID)).willReturn(Optional.of(pendingMerchant()));
+
+            assertThatThrownBy(() -> service.create(MERCHANT_ID, "Client", List.of(), List.of()))
+                    .isInstanceOf(MerchantNotActiveException.class);
+        }
+
+        @Test
+        @DisplayName("should throw when requested scopes exceed merchant scopes")
+        void shouldThrowWhenScopesExceeded() {
+            given(merchantRepository.findById(MERCHANT_ID)).willReturn(Optional.of(activeMerchant()));
+
+            assertThatThrownBy(() -> service.create(MERCHANT_ID, "Client",
+                    List.of("payments:read", "admin:full"), List.of()))
+                    .isInstanceOf(ScopeExceededException.class);
+        }
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/SecureClientSecretGeneratorTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/SecureClientSecretGeneratorTest.java
@@ -1,0 +1,31 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SecureClientSecretGenerator")
+class SecureClientSecretGeneratorTest {
+
+    private final SecureClientSecretGenerator generator = new SecureClientSecretGenerator();
+
+    @Test
+    @DisplayName("should generate non-blank hex secret")
+    void shouldGenerateNonBlankSecret() {
+        var secret = generator.generate();
+
+        assertThat(secret).isNotBlank();
+        assertThat(secret).hasSize(64); // 32 bytes = 64 hex chars
+        assertThat(secret).matches("[0-9a-f]+");
+    }
+
+    @Test
+    @DisplayName("should generate unique secrets")
+    void shouldGenerateUniqueSecrets() {
+        var secret1 = generator.generate();
+        var secret2 = generator.generate();
+
+        assertThat(secret1).isNotEqualTo(secret2);
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/messaging/MerchantEventListenerTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/messaging/MerchantEventListenerTest.java
@@ -1,0 +1,73 @@
+package com.stablecoin.payments.gateway.iam.infrastructure.messaging;
+
+import com.stablecoin.payments.gateway.iam.application.service.MerchantApplicationService;
+import com.stablecoin.payments.gateway.iam.domain.service.MerchantService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MerchantEventListener")
+class MerchantEventListenerTest {
+
+    @Mock private MerchantService merchantService;
+    @Mock private MerchantApplicationService merchantApplicationService;
+
+    @InjectMocks
+    private MerchantEventListener listener;
+
+    private final JsonMapper objectMapper = JsonMapper.builder().build();
+
+    MerchantEventListenerTest() throws Exception {
+        // JsonMapper needs to be set via reflection since @InjectMocks won't match it
+    }
+
+    @Test
+    @DisplayName("onMerchantActivated should activate and provision OAuth client")
+    void shouldActivateAndProvisionOAuthClient() throws Exception {
+        var merchantId = UUID.randomUUID();
+        var payload = """
+                {"merchantId":"%s","companyName":"Acme Corp","country":"US","scopes":["payments:read","payments:write"]}
+                """.formatted(merchantId);
+
+        // Use a real ObjectMapper for deserialization, mock for application service
+        var realListener = new MerchantEventListener(
+                merchantService, merchantApplicationService, objectMapper);
+
+        realListener.onMerchantActivated(payload);
+
+        then(merchantApplicationService).should().activateAndProvisionOAuthClient(
+                merchantId, "Acme Corp", List.of("payments:read", "payments:write"));
+    }
+
+    @Test
+    @DisplayName("onMerchantActivated should propagate exception on failure")
+    void shouldPropagateExceptionOnActivationFailure() {
+        var merchantId = UUID.randomUUID();
+        var payload = """
+                {"merchantId":"%s","companyName":"Acme Corp","country":"US","scopes":[]}
+                """.formatted(merchantId);
+
+        doThrow(new RuntimeException("activation failed"))
+                .when(merchantApplicationService)
+                .activateAndProvisionOAuthClient(merchantId, "Acme Corp", List.of());
+
+        var realListener = new MerchantEventListener(
+                merchantService, merchantApplicationService, objectMapper);
+
+        assertThatThrownBy(() -> realListener.onMerchantActivated(payload))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("merchant.activated");
+    }
+}


### PR DESCRIPTION
## Summary

- **Auto-provisioning**: `MerchantEventListener.onMerchantActivated()` now auto-provisions a default OAuth client with `client_credentials` grant and the merchant's scopes, published via Namastack outbox as `OAuthClientProvisionedEvent`
- **Admin endpoint**: `POST /v1/merchants/{merchantId}/oauth-clients` to create additional OAuth clients with scope validation against merchant scopes
- **Feign clients**: Populated `api-gateway-iam-client` module with `GatewayTokenClient`, `GatewayApiKeyClient`, `GatewayMerchantClient`, `GatewayOAuthClientClient`
- **New domain service**: `OAuthClientService` (pure domain, no Spring) following `ApiKeyService` pattern — handles secret generation, hashing, scope validation, and persistence

Closes STA-49

## Test plan

- [x] `OAuthClientServiceTest` — 6 tests (create, default scopes/grants, merchant not found/inactive, scope exceeded)
- [x] `OAuthClientControllerTest` — 3 tests (201, merchant not found, merchant not active)
- [x] `MerchantEventListenerTest` — 2 tests (activation triggers provisioning, error propagation)
- [x] `SecureClientSecretGeneratorTest` — 2 tests (hex format, uniqueness)
- [x] All 191 unit tests pass
- [x] Integration tests pass
- [x] Business tests pass
- [x] Spotless check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth client creation and management endpoints for merchants
  * Automatic OAuth client provisioning during merchant activation with default scopes
  * Integrated secure cryptographic client secret generation and storage

* **Tests**
  * Added comprehensive unit and integration tests for OAuth client creation, validation, and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->