### PR TITLE
chore: rename project to stablebridge-platform

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
-# CodeRabbit Configuration for stablecoin-payments
+# CodeRabbit Configuration for stablebridge-platform
 # Docs: https://docs.coderabbit.ai/configure/coderabbit-yaml
 
 language: "en-US"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a defect or unexpected behaviour in stablecoin-payments
+about: Report a defect or unexpected behaviour in stablebridge-platform
 title: "fix: <short description of the bug>"
 labels: ["bug", "needs-triage"]
 assignees: Puneethkumarck

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Propose a new feature or enhancement for stablecoin-payments
+about: Propose a new feature or enhancement for stablebridge-platform
 title: "feat: <short description of the feature>"
 labels: ["feature", "needs-triage"]
 assignees: Puneethkumarck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to stablecoin-payments
+# Contributing to stablebridge-platform
 
 Thank you for your interest in contributing. This document covers everything you need to get the project running locally, understand the development workflow, and submit high-quality pull requests.
 
@@ -39,8 +39,8 @@ Ensure you have the following installed:
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/Puneethkumarck/stablecoin-payments.git
-cd stablecoin-payments
+git clone https://github.com/Puneethkumarck/stablebridge-platform.git
+cd stablebridge-platform
 
 # 2. Start local infrastructure (Postgres, Temporal, etc.)
 docker compose -f docker-compose.dev.yml up -d
@@ -59,7 +59,7 @@ The service will start on `http://localhost:8080` by default.
 ## Project Structure
 
 ```
-stablecoin-payments/
+stablebridge-platform/
 ├── merchant-onboarding/      # Merchant onboarding service (KYB, onboarding workflows)
 ├── merchant-iam/             # Identity and access management service
 ├── infra/local/              # Local infrastructure configuration (Docker, DB migrations)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stablecoin Payments Platform
+# StableBridge Platform
 
 Cross-border B2B payment platform using a fiat-to-stablecoin-to-fiat ("sandwich") model. Converts sender fiat currency to USDC on-chain, transfers via blockchain, and converts back to recipient fiat currency.
 
@@ -32,7 +32,7 @@ Cross-border B2B payment platform using a fiat-to-stablecoin-to-fiat ("sandwich"
 ## Project Structure
 
 ```
-stablecoin-payments/
+stablebridge-platform/
 ├── merchant-onboarding/           # S11 - Merchant Onboarding
 │   ├── merchant-onboarding-api/   # Request/response DTOs
 │   ├── merchant-onboarding-client/# Feign client for inter-service calls

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We are actively maintaining the following versions of `stablecoin-payments`:
+We are actively maintaining the following versions of `stablebridge-platform`:
 
 | Version | Supported          |
 |---------|--------------------|
@@ -13,7 +13,7 @@ We are actively maintaining the following versions of `stablecoin-payments`:
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-`stablecoin-payments` handles financial transactions and merchant identity data. We take all security disclosures seriously and ask that you follow responsible disclosure practices.
+`stablebridge-platform` handles financial transactions and merchant identity data. We take all security disclosures seriously and ask that you follow responsible disclosure practices.
 
 ### How to Report
 
@@ -21,7 +21,7 @@ We are actively maintaining the following versions of `stablecoin-payments`:
    Go to [Security Advisories](../../security/advisories/new) and submit a private report. This keeps the details confidential until a fix is ready.
 
 2. **Email fallback**: If you are unable to use GitHub's reporting tool, email **punith.564@gmail.com** with:
-   - Subject: `[SECURITY] stablecoin-payments - <brief description>`
+   - Subject: `[SECURITY] stablebridge-platform - <brief description>`
    - A clear description of the vulnerability
    - Steps to reproduce
    - Potential impact assessment

--- a/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
+++ b/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
@@ -57,12 +57,12 @@ spring:
 api-gateway-iam:
   jwt:
     private-key-base64: ${JWT_PRIVATE_KEY_BASE64:}
-    issuer: ${JWT_ISSUER:https://gateway.stablecoin-payments.dev}
+    issuer: ${JWT_ISSUER:https://gateway.stablebridge.dev}
     audience: ${JWT_AUDIENCE:payment-platform}
     access-token-ttl-seconds: ${JWT_ACCESS_TTL:3600}
   merchant-iam:
     base-url: ${MERCHANT_IAM_BASE_URL:http://localhost:8083}
-    issuer: ${MERCHANT_IAM_ISSUER:https://api.stablecoin-payments.dev}
+    issuer: ${MERCHANT_IAM_ISSUER:https://api.stablebridge.dev}
     audience: ${MERCHANT_IAM_AUDIENCE:payment-platform}
     jwks-cache-ttl-hours: ${MERCHANT_IAM_JWKS_CACHE_TTL_HOURS:24}
   rate-limit:

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/security/UserJwtAuthenticationFilterTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/application/security/UserJwtAuthenticationFilterTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class UserJwtAuthenticationFilterTest {
 
-    private static final String S13_ISSUER = "https://api.stablecoin-payments.dev";
+    private static final String S13_ISSUER = "https://api.stablebridge.dev";
     private static final String AUDIENCE = "payment-platform";
 
     @Mock
@@ -176,7 +176,7 @@ class UserJwtAuthenticationFilterTest {
 
         @Test
         void shouldPassThroughForNonS13Issuer() throws Exception {
-            var token = buildToken("https://gateway.stablecoin-payments.dev", AUDIENCE,
+            var token = buildToken("https://gateway.stablebridge.dev", AUDIENCE,
                     Instant.now().plusSeconds(3600), UUID.randomUUID(), UUID.randomUUID());
             request.addHeader("Authorization", "Bearer " + token);
 

--- a/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/CachedUserJwksProviderTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/test/java/com/stablecoin/payments/gateway/iam/infrastructure/auth/CachedUserJwksProviderTest.java
@@ -40,7 +40,7 @@ class CachedUserJwksProviderTest {
     void setUp() {
         var properties = new MerchantIamProperties(
                 "http://localhost:8083",
-                "https://api.stablecoin-payments.dev",
+                "https://api.stablebridge.dev",
                 "payment-platform",
                 24);
         provider = new CachedUserJwksProvider(merchantIamClient, redis, properties);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 sonarqube {
     properties {
-        property("sonar.projectKey", "Puneethkumarck_stablecoin-payments")
+        property("sonar.projectKey", "Puneethkumarck_stablebridge-platform")
         property("sonar.organization", "ranganathasoftware")
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.sourceEncoding", "UTF-8")

--- a/infra/local/postgres/init.sql
+++ b/infra/local/postgres/init.sql
@@ -1,4 +1,4 @@
--- Stablecoin Payments Platform — Local Dev Database Init
+-- StableBridge Platform — Local Dev Database Init
 -- Creates one database per service (mirrors production per-service DB isolation)
 -- Run automatically on first postgres container startup.
 

--- a/infra/postman/Phase1-E2E.postman_collection.json
+++ b/infra/postman/Phase1-E2E.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "f1a2b3c4-d5e6-7890-abcd-ef1234567890",
     "name": "Phase 1 - E2E Integration Tests",
-    "description": "End-to-end integration tests for Stablecoin Payments Platform Phase 1.\n\nCovers the full merchant lifecycle across S11 (Onboarding), S13 (Merchant IAM), and S10 (API Gateway).\n\nPrerequisites:\n- All services running via docker-compose.dev.yml\n- S11 on port 8081, S13 on port 8083, S10 on port 8080\n- Mailpit on port 8025\n- Kafka, PostgreSQL, Redis, Temporal all healthy\n\nRun folders in order (01 through 07). Each folder builds on state created by previous folders.",
+    "description": "End-to-end integration tests for StableBridge Platform Phase 1.\n\nCovers the full merchant lifecycle across S11 (Onboarding), S13 (Merchant IAM), and S10 (API Gateway).\n\nPrerequisites:\n- All services running via docker-compose.dev.yml\n- S11 on port 8081, S13 on port 8083, S10 on port 8080\n- Mailpit on port 8025\n- Kafka, PostgreSQL, Redis, Temporal all healthy\n\nRun folders in order (01 through 07). Each folder builds on state created by previous folders.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [

--- a/infra/terraform/local/main.tf
+++ b/infra/terraform/local/main.tf
@@ -1,12 +1,12 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Stablecoin Payments — Local Infrastructure (mirrors docker-compose.dev.yml)
+# StableBridge Platform — Local Infrastructure (mirrors docker-compose.dev.yml)
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─────────────────────────────────────────────
 # Locals — Docker Desktop project grouping
 # ─────────────────────────────────────────────
 locals {
-  project_name = "stablecoin-payments"
+  project_name = "stablebridge-platform"
 }
 
 # ─────────────────────────────────────────────

--- a/infra/terraform/local/run.sh
+++ b/infra/terraform/local/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 #
-# Stablecoin Payments — Local Infrastructure & Services Manager
+# StableBridge Platform — Local Infrastructure & Services Manager
 #
 # Usage:
 #   ./run.sh up                Start infrastructure + build & launch all services
@@ -58,9 +58,9 @@ ensure_tfvars() {
   if grep -q "REPLACE" "$tfvars" 2>/dev/null; then
     info "Setting project_root in terraform.tfvars..."
     if [[ "$(uname)" == "Darwin" ]]; then
-      sed -i '' "s|/REPLACE/WITH/YOUR/PATH/TO/stablecoin-payments|${PROJECT_ROOT}|g" "$tfvars"
+      sed -i '' "s|/REPLACE/WITH/YOUR/PATH/TO/stablebridge-platform|${PROJECT_ROOT}|g" "$tfvars"
     else
-      sed -i "s|/REPLACE/WITH/YOUR/PATH/TO/stablecoin-payments|${PROJECT_ROOT}|g" "$tfvars"
+      sed -i "s|/REPLACE/WITH/YOUR/PATH/TO/stablebridge-platform|${PROJECT_ROOT}|g" "$tfvars"
     fi
     ok "project_root set to: $PROJECT_ROOT"
   fi
@@ -242,7 +242,7 @@ cmd_down() {
 cmd_status() {
   echo ""
   echo "╔══════════════════════════════════════════════════════════════╗"
-  echo "║           Stablecoin Payments — Infrastructure             ║"
+  echo "║           StableBridge Platform — Infrastructure             ║"
   echo "╚══════════════════════════════════════════════════════════════╝"
   echo ""
 
@@ -291,7 +291,7 @@ cmd_status() {
 
   echo ""
   echo "╔══════════════════════════════════════════════════════════════╗"
-  echo "║           Stablecoin Payments — Application Services       ║"
+  echo "║           StableBridge Platform — Application Services       ║"
   echo "╚══════════════════════════════════════════════════════════════╝"
   echo ""
 

--- a/infra/terraform/local/variables.tf
+++ b/infra/terraform/local/variables.tf
@@ -1,8 +1,8 @@
 # ─────────────────────────────────────────────
-# Project root — must point to the stablecoin-payments repo root
+# Project root — must point to the stablebridge-platform repo root
 # ─────────────────────────────────────────────
 variable "project_root" {
-  description = "Absolute path to the stablecoin-payments repository root"
+  description = "Absolute path to the stablebridge-platform repository root"
   type        = string
 }
 

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/TotpMfaProvider.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/TotpMfaProvider.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class TotpMfaProvider implements MfaProvider {
 
-    private static final String ISSUER = "Stablecoin Payments";
+    private static final String ISSUER = "StableBridge";
     private static final int DIGITS = 6;
     private static final int PERIOD = 30;
 

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/email/SmtpEmailSenderAdapter.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/email/SmtpEmailSenderAdapter.java
@@ -31,18 +31,18 @@ public class SmtpEmailSenderAdapter implements EmailSenderProvider {
         var message = new SimpleMailMessage();
         message.setFrom(emailProperties.from());
         message.setTo(email);
-        message.setSubject("You've been invited to join " + merchantName + " on Stablecoin Payments");
+        message.setSubject("You've been invited to join " + merchantName + " on StableBridge");
         message.setText("""
                 Hi %s,
 
-                You've been invited to join %s on the Stablecoin Payments platform.
+                You've been invited to join %s on the StableBridge platform.
 
                 Accept your invitation before it expires on %s:
                 %s
 
                 If you did not expect this invitation, you can safely ignore this email.
 
-                The Stablecoin Payments Team
+                The StableBridge Team
                 """.formatted(fullName, merchantName, expiryFormatted, acceptUrl));
 
         log.info("Sending invitation email to={} merchant={}", email, merchantName);

--- a/merchant-iam/merchant-iam/src/main/resources/application.yml
+++ b/merchant-iam/merchant-iam/src/main/resources/application.yml
@@ -69,7 +69,7 @@ spring:
 merchant-iam:
   jwt:
     private-key-base64: ${JWT_PRIVATE_KEY_BASE64:}
-    issuer: ${JWT_ISSUER:https://api.stablecoin-payments.dev}
+    issuer: ${JWT_ISSUER:https://api.stablebridge.dev}
     audience: ${JWT_AUDIENCE:payment-platform}
     access-token-ttl-seconds: ${JWT_ACCESS_TTL:3600}
     refresh-token-ttl-seconds: ${JWT_REFRESH_TTL:86400}
@@ -79,7 +79,7 @@ merchant-iam:
     session-cleanup:
       fixed-delay-ms: ${SESSION_CLEANUP_JOB_DELAY_MS:3600000}
   email:
-    from: ${EMAIL_FROM:noreply@stablecoin-payments.dev}
+    from: ${EMAIL_FROM:noreply@stablebridge.dev}
     invitation-base-url: ${INVITATION_BASE_URL:http://localhost:3000/invite}
 
 namastack:

--- a/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/TotpMfaProviderTest.java
+++ b/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/TotpMfaProviderTest.java
@@ -27,7 +27,7 @@ class TotpMfaProviderTest {
 
         assertThat(uri).contains("otpauth://totp/");
         assertThat(uri).contains("user%40test.com");
-        assertThat(uri).contains("Stablecoin");
+        assertThat(uri).contains("StableBridge");
         assertThat(uri).contains("secret=");
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "stablecoin-payments"
+rootProject.name = "stablebridge-platform"
 
 buildCache {
     local {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
-sonar.projectKey=Puneethkumarck_stablecoin-payments
+sonar.projectKey=Puneethkumarck_stablebridge-platform
 sonar.organization=ranganathasoftware
 sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
## Summary
- Rename all references from `stablecoin-payments` → `stablebridge-platform` (repo name, Sonar, Terraform, docs)
- Update domain URLs from `*.stablecoin-payments.dev` → `*.stablebridge.dev`
- Update brand name in emails/MFA from `Stablecoin Payments` → `StableBridge`
- Java package names (`com.stablecoin.payments.*`) intentionally kept as-is

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] All business tests pass
- [x] `TotpMfaProviderTest` updated for new issuer name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated platform branding and references throughout documentation, infrastructure configuration, and application settings.
  * Updated default domain configuration for authentication issuers and platform notification email addresses across services.
  * Updated project identifiers and naming conventions in build configuration and monitoring tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->