### PR TITLE
feat(s10,s11,s13): add springdoc-openapi to Phase 1 services (STA-67)

### DIFF
--- a/api-gateway-iam/api-gateway-iam/build.gradle.kts
+++ b/api-gateway-iam/api-gateway-iam/build.gradle.kts
@@ -51,6 +51,7 @@ val flywayVersion: String by project
 val archunitVersion: String by project
 val testcontainersVersion: String by project
 val wiremockVersion: String by project
+val springdocVersion: String by project
 
 dependencies {
     implementation(project(":api-gateway-iam:api-gateway-iam-api"))
@@ -60,6 +61,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // OpenAPI / Swagger UI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/config/OpenApiConfig.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/application/config/OpenApiConfig.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.gateway.iam.application.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI apiGatewayIamOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("S10 API Gateway & IAM API")
+                        .description("OAuth2 authentication, API key management, rate limiting, and merchant registry")
+                        .version("1.0.0")
+                        .contact(new Contact().name("StableBridge Platform")));
+    }
+}

--- a/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/SecurityConfig.java
+++ b/api-gateway-iam/api-gateway-iam/src/main/java/com/stablecoin/payments/gateway/iam/infrastructure/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/v1/auth/**").permitAll()
                         .requestMatchers("/.well-known/**").permitAll()
                         .anyRequest().authenticated()

--- a/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
+++ b/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
@@ -123,6 +123,16 @@ server:
   port: ${SERVER_PORT:8080}
   shutdown: graceful
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+  info:
+    title: S10 API Gateway & IAM API
+    description: OAuth2 authentication, API key management, rate limiting, and merchant registry
+    version: 1.0.0
+
 logging:
   level:
     com.stablecoin.payments: INFO

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,5 @@ flywayVersion=12.0.3
 archunitVersion=1.4.1
 testcontainersVersion=1.21.4
 wiremockVersion=3.13.2
+springdocVersion=2.8.6
 spotlessVersion=7.0.2

--- a/merchant-iam/merchant-iam/build.gradle.kts
+++ b/merchant-iam/merchant-iam/build.gradle.kts
@@ -51,6 +51,7 @@ val flywayVersion: String by project
 val archunitVersion: String by project
 val testcontainersVersion: String by project
 val wiremockVersion: String by project
+val springdocVersion: String by project
 
 dependencies {
     implementation(project(":merchant-iam:merchant-iam-api"))
@@ -60,6 +61,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // OpenAPI / Swagger UI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/OpenApiConfig.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/OpenApiConfig.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.merchant.iam.application.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI merchantIamOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("S13 Merchant IAM API")
+                        .description("User authentication, roles, permissions, and team management")
+                        .version("1.0.0")
+                        .contact(new Contact().name("StableBridge Platform")));
+    }
+}

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/SecurityConfig.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/v1/auth/**").permitAll()
                         .requestMatchers("/v1/invitations/**").permitAll()
                         .requestMatchers("/v1/.well-known/**").permitAll()

--- a/merchant-iam/merchant-iam/src/main/resources/application.yml
+++ b/merchant-iam/merchant-iam/src/main/resources/application.yml
@@ -134,6 +134,16 @@ server:
   port: ${SERVER_PORT:8083}
   shutdown: graceful
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+  info:
+    title: S13 Merchant IAM API
+    description: User authentication, roles, permissions, and team management
+    version: 1.0.0
+
 logging:
   level:
     com.stablecoin.payments: INFO

--- a/merchant-onboarding/merchant-onboarding/build.gradle.kts
+++ b/merchant-onboarding/merchant-onboarding/build.gradle.kts
@@ -52,6 +52,7 @@ val flywayVersion: String by project
 val archunitVersion: String by project
 val testcontainersVersion: String by project
 val wiremockVersion: String by project
+val springdocVersion: String by project
 
 dependencies {
     implementation(project(":merchant-onboarding:merchant-onboarding-api"))
@@ -61,6 +62,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // OpenAPI / Swagger UI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/application/config/OpenApiConfig.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/application/config/OpenApiConfig.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.merchant.onboarding.application.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI merchantOnboardingOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("S11 Merchant Onboarding API")
+                        .description("Merchant onboarding, KYB verification, and lifecycle management")
+                        .version("1.0.0")
+                        .contact(new Contact().name("StableBridge Platform")));
+    }
+}

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/application/config/SecurityConfig.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/application/config/SecurityConfig.java
@@ -18,7 +18,10 @@ public class SecurityConfig {
         // Webhook endpoints use HMAC validation, not JWT
         .requestMatchers("/api/internal/webhooks/**").permitAll()
         // Actuator health/readiness
-        .requestMatchers("/actuator/**").permitAll().anyRequest().authenticated());
+        .requestMatchers("/actuator/**").permitAll()
+        // OpenAPI / Swagger UI
+        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+        .anyRequest().authenticated());
     return http.build();
   }
 }

--- a/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
+++ b/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
@@ -115,6 +115,16 @@ server:
   port: ${SERVER_PORT:8081}
   shutdown: graceful
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+  info:
+    title: S11 Merchant Onboarding API
+    description: Merchant onboarding, KYB verification, and lifecycle management
+    version: 1.0.0
+
 logging:
   level:
     com.stablecoin.payments: INFO


### PR DESCRIPTION
## Summary
- Add `springdoc-openapi-starter-webmvc-ui` (2.8.6) to all Phase 1 services (S10 API Gateway, S11 Merchant Onboarding, S13 Merchant IAM)
- Configure OpenAPI 3.1 spec generation with `OpenApiConfig` bean per service (title, description, version, contact)
- Add `springdoc` YAML config for API docs and Swagger UI paths
- Permit `/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html` in SecurityConfig for each service

## Verified locally
- S10 API Gateway booted with `local` profile
- Swagger UI at `/swagger-ui/index.html` returns 200
- `/v3/api-docs` returns valid OpenAPI 3.1 JSON with correct metadata
- All unit, integration, and business tests pass across all 3 services

## Test plan
- [x] Unit tests pass for all 3 services
- [x] Integration tests pass for all 3 services
- [x] Business tests pass (S11)
- [x] Swagger UI renders at `/swagger-ui/index.html`
- [x] API docs JSON at `/v3/api-docs` includes correct service metadata

Closes STA-67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled interactive API documentation (Swagger UI) for S10 API Gateway & IAM, S13 Merchant IAM, and S11 Merchant Onboarding.
  * API docs are exposed at standard OpenAPI endpoints and are publicly accessible without authentication.
  * Each service now advertises API metadata (title, description, version, contact) for clearer endpoint documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->