### PR TITLE
feat(s13): make session revocation authoritative (STA-70)

### DIFF
--- a/merchant-iam/merchant-iam/src/business-test/java/com/stablecoin/payments/merchant/iam/SessionRevocationFlowTest.java
+++ b/merchant-iam/merchant-iam/src/business-test/java/com/stablecoin/payments/merchant/iam/SessionRevocationFlowTest.java
@@ -1,0 +1,247 @@
+package com.stablecoin.payments.merchant.iam;
+
+import com.jayway.jsonpath.JsonPath;
+import com.stablecoin.payments.merchant.iam.domain.team.EmailHasher;
+import com.stablecoin.payments.merchant.iam.domain.team.UserSessionRepository;
+import com.stablecoin.payments.merchant.iam.infrastructure.persistence.repository.UserSessionJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Business test for session revocation flows.
+ * Uses real JWT authentication (no TestSecurityConfig) to validate the full login → logout → refresh chain.
+ */
+@Tag("business")
+@DisplayName("Session Revocation Flow")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration-test")
+@AutoConfigureMockMvc
+class SessionRevocationFlowTest {
+
+    @SuppressWarnings("resource")
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("s13_merchant_iam")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
+
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> MAILPIT =
+            new GenericContainer<>(DockerImageName.parse("axllent/mailpit:v1.24"))
+                    .withExposedPorts(1025, 8025);
+
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                    .withExposedPorts(6379);
+
+    static {
+        POSTGRES.start();
+        KAFKA.start();
+        MAILPIT.start();
+        REDIS.start();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        registry.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+        registry.add("spring.mail.host", MAILPIT::getHost);
+        registry.add("spring.mail.port", () -> MAILPIT.getMappedPort(1025));
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private UserSessionJpaRepository sessionJpa;
+
+    @Autowired
+    private UserSessionRepository sessionRepository;
+
+    @Autowired
+    private EmailHasher emailHasher;
+
+    private static final String EMAIL = "admin@acme.com";
+    private static final String PASSWORD = "password123";
+    private static final String PASSWORD_HASH = new BCryptPasswordEncoder(12).encode(PASSWORD);
+
+    private UUID merchantId;
+
+    @BeforeEach
+    void cleanAndSeed() {
+        jdbc.execute("DELETE FROM user_sessions");
+        jdbc.execute("DELETE FROM invitations");
+        jdbc.execute("DELETE FROM merchant_users");
+        jdbc.execute("DELETE FROM role_permissions");
+        jdbc.execute("DELETE FROM roles");
+        jdbc.execute("DELETE FROM permission_audit_log");
+
+        merchantId = UUID.randomUUID();
+        var adminRoleId = UUID.randomUUID();
+
+        jdbc.update("""
+            INSERT INTO roles (role_id, merchant_id, role_name, description, is_builtin, is_active, created_at, updated_at)
+            VALUES (?, ?, 'ADMIN', 'Administrator', true, true, NOW(), NOW())
+            """, adminRoleId, merchantId);
+
+        jdbc.update("""
+            INSERT INTO role_permissions (role_permission_id, role_id, permission, created_at)
+            VALUES (?, ?, '*:*', NOW())
+            """, UUID.randomUUID(), adminRoleId);
+
+        jdbc.update("""
+            INSERT INTO merchant_users (user_id, merchant_id, email, email_hash, full_name, password_hash,
+                status, role_id, mfa_enabled, auth_provider, created_at, updated_at, activated_at, version)
+            VALUES (?, ?, ?, ?, 'Admin User', ?, 'ACTIVE', ?, false, 'LOCAL', NOW(), NOW(), NOW(), 0)
+            """,
+                UUID.randomUUID(), merchantId,
+                EMAIL.getBytes(), emailHasher.hash(EMAIL),
+                PASSWORD_HASH, adminRoleId);
+    }
+
+    private LoginTokens login() throws Exception {
+        var result = mockMvc.perform(post("/v1/merchants/{id}/auth/login", merchantId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email": "%s", "password": "%s"}
+                                """.formatted(EMAIL, PASSWORD)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
+                .andReturn();
+
+        var json = result.getResponse().getContentAsString();
+        return new LoginTokens(
+                JsonPath.read(json, "$.data.accessToken"),
+                JsonPath.read(json, "$.data.refreshToken"));
+    }
+
+    @Nested
+    @DisplayName("Session persistence on login")
+    class SessionPersistence {
+
+        @Test
+        @DisplayName("login should persist a user session in the database")
+        void shouldPersistSessionOnLogin() throws Exception {
+            assertThat(sessionJpa.findAll()).isEmpty();
+
+            login();
+
+            var sessions = sessionJpa.findAll();
+            assertThat(sessions).hasSize(1);
+            var session = sessions.getFirst();
+            assertThat(session.isRevoked()).isFalse();
+            assertThat(session.getExpiresAt()).isNotNull();
+            assertThat(session.getMerchantId()).isEqualTo(merchantId);
+        }
+    }
+
+    @Nested
+    @DisplayName("Logout invalidates refresh token")
+    class LogoutInvalidatesRefresh {
+
+        @Test
+        @DisplayName("login → logout → refresh token rejected")
+        void shouldRejectRefreshAfterLogout() throws Exception {
+            var tokens = login();
+
+            // Logout using access token
+            mockMvc.perform(post("/v1/auth/logout")
+                            .header("Authorization", "Bearer " + tokens.accessToken()))
+                    .andExpect(status().isNoContent());
+
+            // Verify session is revoked in DB
+            assertThat(sessionJpa.findAll()).allMatch(s -> s.isRevoked());
+
+            // Refresh should be rejected — session is revoked
+            mockMvc.perform(post("/v1/auth/refresh")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"refreshToken": "%s"}
+                                    """.formatted(tokens.refreshToken())))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("Merchant suspension cuts off refresh")
+    class MerchantSuspensionCutsOffRefresh {
+
+        @Test
+        @DisplayName("merchant suspended → refresh token rejected")
+        void shouldRejectRefreshAfterMerchantSuspension() throws Exception {
+            var tokens = login();
+
+            // Simulate merchant suspension — revokes all sessions for the merchant
+            sessionRepository.revokeAllByMerchantId(merchantId, "merchant_suspended");
+
+            // Verify sessions revoked
+            assertThat(sessionJpa.findAll()).allMatch(s -> s.isRevoked());
+
+            // Refresh should be rejected
+            mockMvc.perform(post("/v1/auth/refresh")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"refreshToken": "%s"}
+                                    """.formatted(tokens.refreshToken())))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("Valid session allows refresh")
+    class ValidSessionAllowsRefresh {
+
+        @Test
+        @DisplayName("login → refresh token succeeds while session is valid")
+        void shouldAllowRefreshWithValidSession() throws Exception {
+            var tokens = login();
+
+            mockMvc.perform(post("/v1/auth/refresh")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"refreshToken": "%s"}
+                                    """.formatted(tokens.refreshToken())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+        }
+    }
+
+    private record LoginTokens(String accessToken, String refreshToken) {}
+}

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/SecurityConfig.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/application/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                         .requestMatchers("/v1/auth/**").permitAll()
                         .requestMatchers("/v1/invitations/**").permitAll()
                         .requestMatchers("/v1/.well-known/**").permitAll()
-                        .requestMatchers("/v1/*/auth/**").permitAll()
+                        .requestMatchers("/v1/merchants/*/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/domain/team/AuthService.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/domain/team/AuthService.java
@@ -6,12 +6,14 @@ import com.stablecoin.payments.merchant.iam.domain.exceptions.RoleNotFoundExcept
 import com.stablecoin.payments.merchant.iam.domain.exceptions.UserNotFoundException;
 import com.stablecoin.payments.merchant.iam.domain.team.model.MerchantUser;
 import com.stablecoin.payments.merchant.iam.domain.team.model.Role;
+import com.stablecoin.payments.merchant.iam.domain.team.model.UserSession;
 import com.stablecoin.payments.merchant.iam.domain.team.model.core.UserStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -114,11 +116,19 @@ public class AuthService {
 
     /**
      * Exchanges a valid refresh token for a new access token.
-     * Validates the refresh JWT signature, expiry, and that the user is still active.
+     * Validates the refresh JWT signature, expiry, session state, and that the user is still active.
      */
     @Transactional(readOnly = true)
     public RefreshResult refreshToken(String refreshTokenValue) {
         var parsed = jwtTokenIssuer.parseRefreshToken(refreshTokenValue);
+
+        var session = sessionRepository.findById(parsed.sessionId())
+                .orElseThrow(InvalidCredentialsException::invalidEmailOrPassword);
+
+        if (!session.isValid()) {
+            log.info("Refresh rejected — session revoked/expired sessionId={}", parsed.sessionId());
+            throw InvalidCredentialsException.invalidEmailOrPassword();
+        }
 
         var user = userRepository.findById(parsed.userId())
                 .orElseThrow(InvalidCredentialsException::invalidEmailOrPassword);
@@ -182,10 +192,21 @@ public class AuthService {
         var role = roleRepository.findById(user.roleId())
                 .orElseThrow(() -> RoleNotFoundException.withId(user.roleId()));
         var sessionId = UUID.randomUUID();
+        var now = Instant.now();
+        var session = UserSession.builder()
+                .sessionId(sessionId)
+                .userId(user.userId())
+                .merchantId(user.merchantId())
+                .createdAt(now)
+                .expiresAt(now.plusSeconds(jwtTokenIssuer.refreshTokenTtlSeconds()))
+                .lastActiveAt(now)
+                .revoked(false)
+                .build();
+        sessionRepository.save(session);
         var accessToken = jwtTokenIssuer.issueAccessToken(user, role, mfaVerified);
         var refreshToken = jwtTokenIssuer.issueRefreshToken(user.userId(), sessionId);
         var updated = userRepository.save(user.recordLogin());
-        log.info("Tokens issued userId={} mfaVerified={}", user.userId(), mfaVerified);
+        log.info("Tokens issued userId={} sessionId={} mfaVerified={}", user.userId(), sessionId, mfaVerified);
         return new LoginResult(updated, role, accessToken, refreshToken);
     }
 }

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/domain/team/JwtTokenIssuer.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/domain/team/JwtTokenIssuer.java
@@ -38,6 +38,11 @@ public interface JwtTokenIssuer {
     ParsedRefreshToken parseRefreshToken(String token);
 
     /**
+     * Returns the refresh token TTL in seconds (used to set session expiry).
+     */
+    int refreshTokenTtlSeconds();
+
+    /**
      * Returns the public key set in JWK Set JSON format for the JWKS endpoint.
      */
     String jwksJson();

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/NimbusJwtTokenIssuer.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/auth/NimbusJwtTokenIssuer.java
@@ -195,6 +195,11 @@ public class NimbusJwtTokenIssuer implements JwtTokenIssuer {
     }
 
     @Override
+    public int refreshTokenTtlSeconds() {
+        return properties.refreshTokenTtlSeconds();
+    }
+
+    @Override
     public String jwksJson() {
         try {
             var publicKey = signingKey.toPublicJWK();

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/persistence/adapter/UserSessionRepositoryAdapter.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/persistence/adapter/UserSessionRepositoryAdapter.java
@@ -2,8 +2,10 @@ package com.stablecoin.payments.merchant.iam.infrastructure.persistence.adapter;
 
 import com.stablecoin.payments.merchant.iam.domain.team.UserSessionRepository;
 import com.stablecoin.payments.merchant.iam.domain.team.model.UserSession;
+import com.stablecoin.payments.merchant.iam.infrastructure.persistence.entity.MerchantUserEntity;
 import com.stablecoin.payments.merchant.iam.infrastructure.persistence.mapper.UserSessionEntityMapper;
 import com.stablecoin.payments.merchant.iam.infrastructure.persistence.repository.UserSessionJpaRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
@@ -20,6 +22,7 @@ public class UserSessionRepositoryAdapter implements UserSessionRepository {
 
     private final UserSessionJpaRepository jpa;
     private final UserSessionEntityMapper mapper;
+    private final EntityManager entityManager;
 
     @Override
     public Optional<UserSession> findById(UUID sessionId) {
@@ -45,7 +48,9 @@ public class UserSessionRepositoryAdapter implements UserSessionRepository {
             entity.setExpiresAt(session.expiresAt());
             return mapper.toDomain(jpa.save(entity));
         }
-        return mapper.toDomain(jpa.save(mapper.toEntity(session)));
+        var entity = mapper.toEntity(session);
+        entity.setUser(entityManager.getReference(MerchantUserEntity.class, session.userId()));
+        return mapper.toDomain(jpa.save(entity));
     }
 
     @Override

--- a/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/persistence/entity/UserSessionEntity.java
+++ b/merchant-iam/merchant-iam/src/main/java/com/stablecoin/payments/merchant/iam/infrastructure/persistence/entity/UserSessionEntity.java
@@ -36,7 +36,7 @@ public class UserSessionEntity {
     @Column(name = "merchant_id", nullable = false)
     private UUID merchantId;
 
-    @Column(name = "ip_address", nullable = false, length = 45)
+    @Column(name = "ip_address", length = 45)
     private String ipAddress;
 
     @Column(name = "user_agent")

--- a/merchant-iam/merchant-iam/src/main/resources/db/migration/V9__make_session_ip_address_nullable.sql
+++ b/merchant-iam/merchant-iam/src/main/resources/db/migration/V9__make_session_ip_address_nullable.sql
@@ -1,0 +1,3 @@
+-- V9: Make ip_address nullable — sessions are now persisted from domain layer
+-- which has no access to HTTP request metadata. IP can be set later via adapter if needed.
+ALTER TABLE user_sessions ALTER COLUMN ip_address DROP NOT NULL;

--- a/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/domain/team/AuthServiceTest.java
+++ b/merchant-iam/merchant-iam/src/test/java/com/stablecoin/payments/merchant/iam/domain/team/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.stablecoin.payments.merchant.iam.domain.exceptions.InvalidCredentials
 import com.stablecoin.payments.merchant.iam.domain.exceptions.RoleNotFoundException;
 import com.stablecoin.payments.merchant.iam.domain.team.model.MerchantUser;
 import com.stablecoin.payments.merchant.iam.domain.team.model.Role;
+import com.stablecoin.payments.merchant.iam.domain.team.model.UserSession;
 import com.stablecoin.payments.merchant.iam.domain.team.model.core.AuthProvider;
 import com.stablecoin.payments.merchant.iam.domain.team.model.core.BuiltInRole;
 import com.stablecoin.payments.merchant.iam.domain.team.model.core.UserStatus;
@@ -77,14 +78,51 @@ class AuthServiceTest {
     }
 
     @Nested
-    class RefreshToken {
+    class Login {
 
         @Test
-        void shouldRefreshTokenForActiveUser() {
+        void shouldPersistSessionOnSuccessfulLogin() {
+            var user = buildActiveUser();
+            given(emailHasher.hash("admin@test.com")).willReturn("hash");
+            given(loginAttemptTracker.isLockedOut("hash")).willReturn(false);
+            given(userRepository.findByMerchantIdAndEmailHash(MERCHANT_ID, "hash"))
+                    .willReturn(Optional.of(user));
+            given(passwordHasher.verify("password", null)).willReturn(true);
+            given(roleRepository.findById(ROLE_ID)).willReturn(Optional.of(buildRole()));
+            given(jwtTokenIssuer.refreshTokenTtlSeconds()).willReturn(86400);
+            given(jwtTokenIssuer.issueAccessToken(any(), any(), anyBoolean())).willReturn("access");
+            given(jwtTokenIssuer.issueRefreshToken(any(), any())).willReturn("refresh");
+            given(userRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(sessionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            authService.login(MERCHANT_ID, "admin@test.com", "password");
+
+            then(sessionRepository).should().save(any(UserSession.class));
+        }
+    }
+
+    @Nested
+    class RefreshToken {
+
+        private UserSession buildValidSession() {
+            return UserSession.builder()
+                    .sessionId(SESSION_ID)
+                    .userId(USER_ID)
+                    .merchantId(MERCHANT_ID)
+                    .createdAt(Instant.now())
+                    .expiresAt(Instant.now().plusSeconds(86400))
+                    .lastActiveAt(Instant.now())
+                    .revoked(false)
+                    .build();
+        }
+
+        @Test
+        void shouldRefreshTokenForActiveUserWithValidSession() {
             var parsed = new JwtTokenIssuer.ParsedRefreshToken(
                     UUID.randomUUID(), USER_ID, SESSION_ID,
                     Instant.now().plusSeconds(3600).getEpochSecond());
             given(jwtTokenIssuer.parseRefreshToken("refresh-jwt")).willReturn(parsed);
+            given(sessionRepository.findById(SESSION_ID)).willReturn(Optional.of(buildValidSession()));
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(buildActiveUser()));
             given(roleRepository.findById(ROLE_ID)).willReturn(Optional.of(buildRole()));
             given(jwtTokenIssuer.issueAccessToken(any(), any(), anyBoolean())).willReturn("new-access-token");
@@ -95,12 +133,59 @@ class AuthServiceTest {
         }
 
         @Test
+        void shouldRejectRefreshWhenSessionNotFound() {
+            var parsed = new JwtTokenIssuer.ParsedRefreshToken(
+                    UUID.randomUUID(), USER_ID, SESSION_ID,
+                    Instant.now().plusSeconds(3600).getEpochSecond());
+            given(jwtTokenIssuer.parseRefreshToken("refresh-jwt")).willReturn(parsed);
+            given(sessionRepository.findById(SESSION_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.refreshToken("refresh-jwt"))
+                    .isInstanceOf(InvalidCredentialsException.class);
+        }
+
+        @Test
+        void shouldRejectRefreshWhenSessionRevoked() {
+            var parsed = new JwtTokenIssuer.ParsedRefreshToken(
+                    UUID.randomUUID(), USER_ID, SESSION_ID,
+                    Instant.now().plusSeconds(3600).getEpochSecond());
+            given(jwtTokenIssuer.parseRefreshToken("refresh-jwt")).willReturn(parsed);
+            given(sessionRepository.findById(SESSION_ID))
+                    .willReturn(Optional.of(buildValidSession().revoke("logout")));
+
+            assertThatThrownBy(() -> authService.refreshToken("refresh-jwt"))
+                    .isInstanceOf(InvalidCredentialsException.class);
+        }
+
+        @Test
+        void shouldRejectRefreshWhenSessionExpired() {
+            var expired = UserSession.builder()
+                    .sessionId(SESSION_ID)
+                    .userId(USER_ID)
+                    .merchantId(MERCHANT_ID)
+                    .createdAt(Instant.now().minusSeconds(90000))
+                    .expiresAt(Instant.now().minusSeconds(3600))
+                    .lastActiveAt(Instant.now().minusSeconds(90000))
+                    .revoked(false)
+                    .build();
+            var parsed = new JwtTokenIssuer.ParsedRefreshToken(
+                    UUID.randomUUID(), USER_ID, SESSION_ID,
+                    Instant.now().plusSeconds(3600).getEpochSecond());
+            given(jwtTokenIssuer.parseRefreshToken("refresh-jwt")).willReturn(parsed);
+            given(sessionRepository.findById(SESSION_ID)).willReturn(Optional.of(expired));
+
+            assertThatThrownBy(() -> authService.refreshToken("refresh-jwt"))
+                    .isInstanceOf(InvalidCredentialsException.class);
+        }
+
+        @Test
         void shouldRejectRefreshForInactiveUser() {
             var suspended = buildActiveUser().suspend();
             var parsed = new JwtTokenIssuer.ParsedRefreshToken(
                     UUID.randomUUID(), USER_ID, SESSION_ID,
                     Instant.now().plusSeconds(3600).getEpochSecond());
             given(jwtTokenIssuer.parseRefreshToken("refresh-jwt")).willReturn(parsed);
+            given(sessionRepository.findById(SESSION_ID)).willReturn(Optional.of(buildValidSession()));
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(suspended));
 
             assertThatThrownBy(() -> authService.refreshToken("refresh-jwt"))
@@ -113,6 +198,7 @@ class AuthServiceTest {
                     UUID.randomUUID(), USER_ID, SESSION_ID,
                     Instant.now().plusSeconds(3600).getEpochSecond());
             given(jwtTokenIssuer.parseRefreshToken("refresh-jwt")).willReturn(parsed);
+            given(sessionRepository.findById(SESSION_ID)).willReturn(Optional.of(buildValidSession()));
             given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> authService.refreshToken("refresh-jwt"))
@@ -125,6 +211,7 @@ class AuthServiceTest {
                     UUID.randomUUID(), USER_ID, SESSION_ID,
                     Instant.now().plusSeconds(3600).getEpochSecond());
             given(jwtTokenIssuer.parseRefreshToken("refresh-jwt")).willReturn(parsed);
+            given(sessionRepository.findById(SESSION_ID)).willReturn(Optional.of(buildValidSession()));
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(buildActiveUser()));
             given(roleRepository.findById(ROLE_ID)).willReturn(Optional.empty());
 


### PR DESCRIPTION
## Summary

Closes STA-70

- **Persist sessions on login**: `AuthService.issueTokens()` now creates and saves a `UserSession` record bound to the refresh token's session ID
- **Validate sessions on refresh**: `AuthService.refreshToken()` looks up the session by ID and rejects if revoked, expired, or missing — logout and merchant suspension now effectively cut off token refresh
- **Fix SecurityConfig pattern**: `/v1/*/auth/**` → `/v1/merchants/*/auth/**` to correctly match merchant-scoped auth endpoints (was masked by TestSecurityConfig in ITs)
- **Infrastructure fixes**: V9 migration makes `ip_address` nullable (domain layer has no HTTP context), adapter uses `EntityManager.getReference()` for FK resolution

## Changes

| File | Change |
|------|--------|
| `AuthService.java` | Persist `UserSession` in `issueTokens()`, validate session in `refreshToken()` |
| `JwtTokenIssuer.java` | Add `refreshTokenTtlSeconds()` port method |
| `NimbusJwtTokenIssuer.java` | Implement `refreshTokenTtlSeconds()` |
| `UserSessionRepositoryAdapter.java` | Use `EntityManager.getReference()` for user FK on insert |
| `UserSessionEntity.java` | Make `ip_address` nullable |
| `SecurityConfig.java` | Fix auth endpoint pattern |
| `V9__make_session_ip_address_nullable.sql` | New migration |
| `AuthServiceTest.java` | 9 new/updated tests for session-aware refresh |
| `SessionRevocationFlowTest.java` | 4 new business tests |

## Test plan

- [x] Unit tests: 9 refresh token tests covering valid session, revoked session, expired session, missing session, inactive user, unknown user, missing role, invalid token
- [x] Unit test: session persistence on login
- [x] Business test: login persists session in DB
- [x] Business test: login → logout → refresh rejected (401)
- [x] Business test: login → merchant suspended → refresh rejected (401)
- [x] Business test: login → refresh succeeds with valid session
- [x] All existing tests pass (unit + IT + business)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session management system with persistence and validation
  * Sessions are now tracked across login, logout, and token refresh operations
  * Session revocation triggered on logout and merchant suspension
  * Sessions expire and require refresh token validation before issuing new tokens

* **Tests**
  * Added comprehensive integration tests covering session lifecycle flows including login, logout, refresh, and merchant suspension scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->