### PR TITLE
feat(s11): add GET /api/v1/merchants list endpoint with pagination (STA-74)

### DIFF
--- a/merchant-onboarding/merchant-onboarding-api/src/main/java/com/stablecoin/payments/merchant/onboarding/api/response/PageResponse.java
+++ b/merchant-onboarding/merchant-onboarding-api/src/main/java/com/stablecoin/payments/merchant/onboarding/api/response/PageResponse.java
@@ -1,0 +1,16 @@
+package com.stablecoin.payments.merchant.onboarding.api.response;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> data,
+        Page page
+) {
+
+    public record Page(
+            int number,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {}
+}

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/application/controller/MerchantController.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/application/controller/MerchantController.java
@@ -13,7 +13,10 @@ import com.stablecoin.payments.merchant.onboarding.api.response.DocumentUploadRe
 import com.stablecoin.payments.merchant.onboarding.api.response.KybStatusResponse;
 import com.stablecoin.payments.merchant.onboarding.api.response.MerchantApplicationResponse;
 import com.stablecoin.payments.merchant.onboarding.api.response.MerchantResponse;
+import com.stablecoin.payments.merchant.onboarding.api.response.PageResponse;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.MerchantCommandHandler;
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.MerchantStatus;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,6 +43,21 @@ public class MerchantController {
 
     private final MerchantCommandHandler commandHandler;
     private final MerchantRequestResponseMapper mapper;
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('merchant:read')")
+    @Operation(summary = "List merchants with pagination and optional status filter")
+    public PageResponse<MerchantResponse> listMerchants(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) MerchantStatus status) {
+        var result = commandHandler.listMerchants(status, page, size);
+        var merchants = result.content().stream()
+                .map(mapper::toMerchantResponse)
+                .toList();
+        return new PageResponse<>(merchants, new PageResponse.Page(
+                result.pageNumber(), result.pageSize(), result.totalElements(), result.totalPages()));
+    }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/domain/merchant/MerchantCommandHandler.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/domain/merchant/MerchantCommandHandler.java
@@ -8,6 +8,8 @@ import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.Ap
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.BusinessAddress;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.DocumentUploadResult;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.KybStatusResult;
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.MerchantStatus;
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.PagedResult;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.RateLimitTier;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.events.MerchantActivatedEvent;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.events.MerchantAppliedEvent;
@@ -255,6 +257,14 @@ public class MerchantCommandHandler {
     @Transactional(readOnly = true)
     public Merchant findById(UUID merchantId) {
         return findOrThrow(merchantId);
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResult<Merchant> listMerchants(MerchantStatus status, int page, int size) {
+        if (status != null) {
+            return merchantRepository.findAllByStatus(status, page, size);
+        }
+        return merchantRepository.findAll(page, size);
     }
 
     private Merchant findOrThrow(UUID merchantId) {

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/domain/merchant/MerchantRepository.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/domain/merchant/MerchantRepository.java
@@ -1,5 +1,8 @@
 package com.stablecoin.payments.merchant.onboarding.domain.merchant;
 
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.MerchantStatus;
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.PagedResult;
+
 import java.util.Optional;
 import java.util.UUID;
 
@@ -8,4 +11,6 @@ public interface MerchantRepository {
     Optional<Merchant> findById(UUID merchantId);
     Optional<Merchant> findByRegistrationNumberAndCountry(String registrationNumber, String country);
     boolean existsByRegistrationNumberAndCountry(String registrationNumber, String country);
+    PagedResult<Merchant> findAll(int page, int size);
+    PagedResult<Merchant> findAllByStatus(MerchantStatus status, int page, int size);
 }

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/domain/merchant/model/core/PagedResult.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/domain/merchant/model/core/PagedResult.java
@@ -1,0 +1,11 @@
+package com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core;
+
+import java.util.List;
+
+public record PagedResult<T>(
+        List<T> content,
+        int pageNumber,
+        int pageSize,
+        long totalElements,
+        int totalPages
+) {}

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/persistence/MerchantRepositoryAdapter.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/persistence/MerchantRepositoryAdapter.java
@@ -2,11 +2,15 @@ package com.stablecoin.payments.merchant.onboarding.infrastructure.persistence;
 
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.Merchant;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.MerchantRepository;
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.MerchantStatus;
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.PagedResult;
 import com.stablecoin.payments.merchant.onboarding.infrastructure.persistence.entity.MerchantJpaRepository;
 import com.stablecoin.payments.merchant.onboarding.infrastructure.persistence.mapper.MerchantEntityMapper;
 import com.stablecoin.payments.merchant.onboarding.infrastructure.persistence.mapper.MerchantEntityUpdater;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -45,5 +49,23 @@ public class MerchantRepositoryAdapter implements MerchantRepository {
     @Override
     public boolean existsByRegistrationNumberAndCountry(String registrationNumber, String country) {
         return jpa.existsByRegistrationNumberAndRegistrationCountry(registrationNumber, country);
+    }
+
+    @Override
+    public PagedResult<Merchant> findAll(int page, int size) {
+        var pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        var result = jpa.findAll(pageable);
+        return new PagedResult<>(
+                result.getContent().stream().map(mapper::toDomain).toList(),
+                result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
+    }
+
+    @Override
+    public PagedResult<Merchant> findAllByStatus(MerchantStatus status, int page, int size) {
+        var pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        var result = jpa.findByStatus(status, pageable);
+        return new PagedResult<>(
+                result.getContent().stream().map(mapper::toDomain).toList(),
+                result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
     }
 }

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/persistence/entity/MerchantJpaRepository.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/persistence/entity/MerchantJpaRepository.java
@@ -1,5 +1,8 @@
 package com.stablecoin.payments.merchant.onboarding.infrastructure.persistence.entity;
 
+import com.stablecoin.payments.merchant.onboarding.domain.merchant.model.core.MerchantStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,4 +15,6 @@ public interface MerchantJpaRepository extends JpaRepository<MerchantEntity, UUI
 
     boolean existsByRegistrationNumberAndRegistrationCountry(
             String registrationNumber, String registrationCountry);
+
+    Page<MerchantEntity> findByStatus(MerchantStatus status, Pageable pageable);
 }


### PR DESCRIPTION
## Summary

- Add paginated `GET /api/v1/merchants` endpoint with optional `status` filter to S11 Merchant Onboarding
- Add `PageResponse<T>` DTO in API module (matches S13 pattern)
- Add `PagedResult<T>` domain record to keep Spring types out of domain layer (ArchUnit compliant)

Closes STA-74

## Changes

| File | Change |
|------|--------|
| `PageResponse.java` | New paginated response DTO in API module |
| `PagedResult.java` | New domain pagination record (no Spring imports) |
| `MerchantRepository.java` | Add `findAll` and `findAllByStatus` port methods |
| `MerchantJpaRepository.java` | Add `findByStatus` query |
| `MerchantRepositoryAdapter.java` | Implement pagination with `PageRequest` + `Sort` |
| `MerchantCommandHandler.java` | Add `listMerchants` with optional status filter |
| `MerchantController.java` | Add `GET /api/v1/merchants` endpoint |

## Endpoint

```
GET /api/v1/merchants?page=0&size=20&status=ACTIVE
```

- Requires `merchant:read` authority
- Optional `status` query param (any `MerchantStatus` value)
- Sorted by `createdAt` descending
- Returns `PageResponse<MerchantResponse>` with pagination metadata

## Test plan

- [x] All 80 unit tests pass (including ArchUnit rules)
- [ ] Integration test for list endpoint with status filter
- [ ] Verify OpenAPI spec includes new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)