### PR TITLE
feat(infra): local K8s environment with kind + Kustomize + NGINX Ingress (STA-76)

### DIFF
--- a/infra/k8s/base/ingress.yaml
+++ b/infra/k8s/base/ingress.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stablebridge-ingress
+  namespace: stablebridge
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost,http://localhost:3000"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization,Content-Type,Idempotency-Key,X-Request-ID"
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          # S10 API Gateway — /gateway/*
+          - path: /gateway
+            pathType: Prefix
+            backend:
+              service:
+                name: s10-api-gateway
+                port:
+                  number: 8080
+
+          # S11 Merchant Onboarding — /onboarding/*
+          - path: /onboarding
+            pathType: Prefix
+            backend:
+              service:
+                name: s11-merchant-onboarding
+                port:
+                  number: 8081
+
+          # S13 Merchant IAM — /iam/*
+          - path: /iam
+            pathType: Prefix
+            backend:
+              service:
+                name: s13-merchant-iam
+                port:
+                  number: 8083
+
+          # Merchant Portal — / (default, must be last)
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: merchant-portal
+                port:
+                  number: 3000

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - s10/
+  - s11/
+  - s13/
+  - merchant-portal/
+  - ingress.yaml

--- a/infra/k8s/base/merchant-portal/deployment.yaml
+++ b/infra/k8s/base/merchant-portal/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: merchant-portal
+  namespace: stablebridge
+  labels:
+    app: merchant-portal
+    service: merchant-portal
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: merchant-portal
+  template:
+    metadata:
+      labels:
+        app: merchant-portal
+        service: merchant-portal
+    spec:
+      containers:
+        - name: merchant-portal
+          image: nginx:alpine
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/infra/k8s/base/merchant-portal/kustomization.yaml
+++ b/infra/k8s/base/merchant-portal/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/infra/k8s/base/merchant-portal/service.yaml
+++ b/infra/k8s/base/merchant-portal/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: merchant-portal
+  namespace: stablebridge
+  labels:
+    app: merchant-portal
+spec:
+  type: ClusterIP
+  selector:
+    app: merchant-portal
+  ports:
+    - port: 3000
+      targetPort: 80
+      protocol: TCP
+      name: http

--- a/infra/k8s/base/s10/configmap.yaml
+++ b/infra/k8s/base/s10/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s10-config
+  namespace: stablebridge
+  labels:
+    app: s10-api-gateway
+data:
+  SPRING_PROFILES_ACTIVE: "local"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://host.docker.internal:5432/s10_api_gateway_iam"
+  SPRING_DATASOURCE_USERNAME: "dev"
+  SPRING_DATASOURCE_PASSWORD: "dev"
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "host.docker.internal:9092"
+  SPRING_DATA_REDIS_HOST: "host.docker.internal"
+  SPRING_DATA_REDIS_PORT: "6379"
+  MERCHANT_IAM_BASE_URL: "http://s13-merchant-iam:8083/iam"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:4318/v1/traces"

--- a/infra/k8s/base/s10/deployment.yaml
+++ b/infra/k8s/base/s10/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s10-api-gateway
+  namespace: stablebridge
+  labels:
+    app: s10-api-gateway
+    service: api-gateway-iam
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s10-api-gateway
+  template:
+    metadata:
+      labels:
+        app: s10-api-gateway
+        service: api-gateway-iam
+    spec:
+      containers:
+        - name: s10-api-gateway
+          image: eclipse-temurin:25-jre-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              JAR=$(find /libs -name '*.jar' ! -name '*-plain.jar' ! -name '*-test-fixtures.jar' | head -1)
+              exec java -jar $JAR
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: s10-config
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          readinessProbe:
+            httpGet:
+              path: /gateway/actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /gateway/actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          volumeMounts:
+            - name: app-jar
+              mountPath: /libs
+              readOnly: true
+      volumes:
+        - name: app-jar
+          hostPath:
+            path: /app-jars/api-gateway-iam
+            type: Directory

--- a/infra/k8s/base/s10/kustomization.yaml
+++ b/infra/k8s/base/s10/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml

--- a/infra/k8s/base/s10/service.yaml
+++ b/infra/k8s/base/s10/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s10-api-gateway
+  namespace: stablebridge
+  labels:
+    app: s10-api-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: s10-api-gateway
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http

--- a/infra/k8s/base/s11/configmap.yaml
+++ b/infra/k8s/base/s11/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s11-config
+  namespace: stablebridge
+  labels:
+    app: s11-merchant-onboarding
+data:
+  SPRING_PROFILES_ACTIVE: "local,sandbox"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://host.docker.internal:5432/s11_merchant_onboarding"
+  SPRING_DATASOURCE_USERNAME: "dev"
+  SPRING_DATASOURCE_PASSWORD: "dev"
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "host.docker.internal:9092"
+  SPRING_DATA_REDIS_HOST: "host.docker.internal"
+  SPRING_DATA_REDIS_PORT: "6379"
+  TEMPORAL_HOST: "host.docker.internal"
+  TEMPORAL_PORT: "7233"
+  ONFIDO_BASE_URL: "http://host.docker.internal:4444/v3.6"
+  ONFIDO_API_TOKEN: "sandbox-token"
+  ONFIDO_WEBHOOK_SECRET: "sandbox-webhook-secret"
+  COMPANIES_HOUSE_BASE_URL: "http://host.docker.internal:4444"
+  COMPANIES_HOUSE_API_KEY: "sandbox-key"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:4318/v1/traces"

--- a/infra/k8s/base/s11/deployment.yaml
+++ b/infra/k8s/base/s11/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s11-merchant-onboarding
+  namespace: stablebridge
+  labels:
+    app: s11-merchant-onboarding
+    service: merchant-onboarding
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s11-merchant-onboarding
+  template:
+    metadata:
+      labels:
+        app: s11-merchant-onboarding
+        service: merchant-onboarding
+    spec:
+      containers:
+        - name: s11-merchant-onboarding
+          image: eclipse-temurin:25-jre-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              JAR=$(find /libs -name '*.jar' ! -name '*-plain.jar' ! -name '*-test-fixtures.jar' | head -1)
+              exec java -jar $JAR
+          ports:
+            - containerPort: 8081
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: s11-config
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          readinessProbe:
+            httpGet:
+              path: /onboarding/actuator/health/readiness
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /onboarding/actuator/health/liveness
+              port: 8081
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          volumeMounts:
+            - name: app-jar
+              mountPath: /libs
+              readOnly: true
+      volumes:
+        - name: app-jar
+          hostPath:
+            path: /app-jars/merchant-onboarding
+            type: Directory

--- a/infra/k8s/base/s11/kustomization.yaml
+++ b/infra/k8s/base/s11/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml

--- a/infra/k8s/base/s11/service.yaml
+++ b/infra/k8s/base/s11/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s11-merchant-onboarding
+  namespace: stablebridge
+  labels:
+    app: s11-merchant-onboarding
+spec:
+  type: ClusterIP
+  selector:
+    app: s11-merchant-onboarding
+  ports:
+    - port: 8081
+      targetPort: 8081
+      protocol: TCP
+      name: http

--- a/infra/k8s/base/s13/configmap.yaml
+++ b/infra/k8s/base/s13/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s13-config
+  namespace: stablebridge
+  labels:
+    app: s13-merchant-iam
+data:
+  SPRING_PROFILES_ACTIVE: "local"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://host.docker.internal:5432/s13_merchant_iam"
+  SPRING_DATASOURCE_USERNAME: "dev"
+  SPRING_DATASOURCE_PASSWORD: "dev"
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "host.docker.internal:9092"
+  SPRING_DATA_REDIS_HOST: "host.docker.internal"
+  SPRING_DATA_REDIS_PORT: "6379"
+  SPRING_MAIL_HOST: "host.docker.internal"
+  SPRING_MAIL_PORT: "1025"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:4318/v1/traces"

--- a/infra/k8s/base/s13/deployment.yaml
+++ b/infra/k8s/base/s13/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s13-merchant-iam
+  namespace: stablebridge
+  labels:
+    app: s13-merchant-iam
+    service: merchant-iam
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s13-merchant-iam
+  template:
+    metadata:
+      labels:
+        app: s13-merchant-iam
+        service: merchant-iam
+    spec:
+      containers:
+        - name: s13-merchant-iam
+          image: eclipse-temurin:25-jre-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              JAR=$(find /libs -name '*.jar' ! -name '*-plain.jar' ! -name '*-test-fixtures.jar' | head -1)
+              exec java -jar $JAR
+          ports:
+            - containerPort: 8083
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: s13-config
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          readinessProbe:
+            httpGet:
+              path: /iam/actuator/health/readiness
+              port: 8083
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /iam/actuator/health/liveness
+              port: 8083
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          volumeMounts:
+            - name: app-jar
+              mountPath: /libs
+              readOnly: true
+      volumes:
+        - name: app-jar
+          hostPath:
+            path: /app-jars/merchant-iam
+            type: Directory

--- a/infra/k8s/base/s13/kustomization.yaml
+++ b/infra/k8s/base/s13/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml

--- a/infra/k8s/base/s13/service.yaml
+++ b/infra/k8s/base/s13/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s13-merchant-iam
+  namespace: stablebridge
+  labels:
+    app: s13-merchant-iam
+spec:
+  type: ClusterIP
+  selector:
+    app: s13-merchant-iam
+  ports:
+    - port: 8083
+      targetPort: 8083
+      protocol: TCP
+      name: http

--- a/infra/k8s/overlays/local/kustomization.yaml
+++ b/infra/k8s/overlays/local/kustomization.yaml
@@ -1,0 +1,66 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  # S10 — reduce resources + add JVM opts for local dev
+  - target:
+      kind: Deployment
+      name: s10-api-gateway
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            memory: "384Mi"
+            cpu: "200m"
+          limits:
+            memory: "768Mi"
+            cpu: "500m"
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: JAVA_TOOL_OPTIONS
+            value: "-Xms256m -Xmx512m -XX:+UseZGC"
+
+  # S11 — reduce resources + add JVM opts for local dev
+  - target:
+      kind: Deployment
+      name: s11-merchant-onboarding
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            memory: "384Mi"
+            cpu: "200m"
+          limits:
+            memory: "768Mi"
+            cpu: "500m"
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: JAVA_TOOL_OPTIONS
+            value: "-Xms256m -Xmx512m -XX:+UseZGC"
+
+  # S13 — reduce resources + add JVM opts for local dev
+  - target:
+      kind: Deployment
+      name: s13-merchant-iam
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            memory: "384Mi"
+            cpu: "200m"
+          limits:
+            memory: "768Mi"
+            cpu: "500m"
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: JAVA_TOOL_OPTIONS
+            value: "-Xms256m -Xmx512m -XX:+UseZGC"

--- a/infra/terraform/k8s-local/.gitignore
+++ b/infra/terraform/k8s-local/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl
+terraform.tfvars

--- a/infra/terraform/k8s-local/main.tf
+++ b/infra/terraform/k8s-local/main.tf
@@ -1,0 +1,155 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# StableBridge Platform — Local K8s (kind + NGINX Ingress)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────
+# kind Cluster — single-node with ingress port mappings
+# ─────────────────────────────────────────────
+resource "kind_cluster" "local" {
+  name           = var.cluster_name
+  node_image     = "kindest/node:${var.kubernetes_version}"
+  wait_for_ready = true
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+
+      # Map host ports to ingress controller
+      extra_port_mappings {
+        container_port = 80
+        host_port      = var.ingress_http_port
+        protocol       = "TCP"
+      }
+
+      extra_port_mappings {
+        container_port = 443
+        host_port      = var.ingress_https_port
+        protocol       = "TCP"
+      }
+
+      # Label for ingress controller nodeSelector
+      kubeadm_config_patches = [
+        <<-EOT
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+        EOT
+      ]
+
+      # Mount JAR build output directories into the kind node
+      extra_mounts {
+        host_path      = "${var.project_root}/api-gateway-iam/api-gateway-iam/build/libs"
+        container_path = "/app-jars/api-gateway-iam"
+        read_only      = true
+      }
+
+      extra_mounts {
+        host_path      = "${var.project_root}/merchant-onboarding/merchant-onboarding/build/libs"
+        container_path = "/app-jars/merchant-onboarding"
+        read_only      = true
+      }
+
+      extra_mounts {
+        host_path      = "${var.project_root}/merchant-iam/merchant-iam/build/libs"
+        container_path = "/app-jars/merchant-iam"
+        read_only      = true
+      }
+    }
+  }
+}
+
+# ─────────────────────────────────────────────
+# Application Namespace
+# ─────────────────────────────────────────────
+resource "kubernetes_namespace" "app" {
+  metadata {
+    name = var.app_namespace
+  }
+
+  depends_on = [kind_cluster.local]
+}
+
+# ─────────────────────────────────────────────
+# NGINX Ingress Controller — via Helm
+# ─────────────────────────────────────────────
+resource "helm_release" "ingress_nginx" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  namespace        = "ingress-nginx"
+  create_namespace = true
+  wait             = true
+  timeout          = 300
+
+  # kind-specific: use hostPort instead of LoadBalancer
+  set {
+    name  = "controller.hostPort.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "controller.service.type"
+    value = "NodePort"
+  }
+
+  set {
+    name  = "controller.nodeSelector.ingress-ready"
+    value = "true"
+  }
+
+  set {
+    name  = "controller.tolerations[0].key"
+    value = "node-role.kubernetes.io/control-plane"
+  }
+
+  set {
+    name  = "controller.tolerations[0].operator"
+    value = "Exists"
+  }
+
+  set {
+    name  = "controller.tolerations[0].effect"
+    value = "NoSchedule"
+  }
+
+  # Enable snippet annotations for CORS
+  set {
+    name  = "controller.allowSnippetAnnotations"
+    value = "true"
+  }
+
+  depends_on = [kind_cluster.local]
+}
+
+# ─────────────────────────────────────────────
+# Deploy application services via Kustomize
+# ─────────────────────────────────────────────
+resource "null_resource" "kustomize_apply" {
+  triggers = {
+    # Re-apply when kustomize files change
+    kustomize_hash = sha256(join("", [
+      for f in fileset("${var.project_root}/${var.kustomize_overlay}", "**") :
+      filesha256("${var.project_root}/${var.kustomize_overlay}/${f}")
+    ]))
+    base_hash = sha256(join("", [
+      for f in fileset("${var.project_root}/infra/k8s/base", "**") :
+      filesha256("${var.project_root}/infra/k8s/base/${f}")
+    ]))
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      export KUBECONFIG="${kind_cluster.local.kubeconfig_path}"
+      kubectl apply -k "${var.project_root}/${var.kustomize_overlay}"
+    EOT
+  }
+
+  depends_on = [
+    kubernetes_namespace.app,
+    helm_release.ingress_nginx,
+  ]
+}

--- a/infra/terraform/k8s-local/outputs.tf
+++ b/infra/terraform/k8s-local/outputs.tf
@@ -1,0 +1,66 @@
+# ─────────────────────────────────────────────
+# Cluster outputs
+# ─────────────────────────────────────────────
+
+output "kubeconfig_path" {
+  description = "Path to the kubeconfig file for the kind cluster"
+  value       = kind_cluster.local.kubeconfig_path
+}
+
+output "cluster_name" {
+  description = "Name of the kind cluster"
+  value       = kind_cluster.local.name
+}
+
+output "app_namespace" {
+  description = "Kubernetes namespace for application services"
+  value       = kubernetes_namespace.app.metadata[0].name
+}
+
+# ─────────────────────────────────────────────
+# Access URLs (path-based routing)
+# ─────────────────────────────────────────────
+
+output "gateway_url" {
+  description = "S10 API Gateway URL"
+  value       = "http://localhost/gateway"
+}
+
+output "onboarding_url" {
+  description = "S11 Merchant Onboarding URL"
+  value       = "http://localhost/onboarding"
+}
+
+output "iam_url" {
+  description = "S13 Merchant IAM URL"
+  value       = "http://localhost/iam"
+}
+
+output "portal_url" {
+  description = "Merchant Portal URL"
+  value       = "http://localhost"
+}
+
+output "usage" {
+  description = "Quick start commands"
+  value       = <<-EOT
+
+    # Set kubeconfig
+    export KUBECONFIG="${kind_cluster.local.kubeconfig_path}"
+
+    # Check cluster
+    kubectl get nodes
+    kubectl get pods -n ${var.app_namespace}
+
+    # Access services (path-based routing):
+    curl http://localhost/gateway/actuator/health
+    curl http://localhost/onboarding/api/v1/merchants
+    curl http://localhost/iam/v1/auth/health
+    curl http://localhost  # merchant portal
+
+    # OpenAPI docs:
+    # http://localhost/gateway/swagger-ui.html
+    # http://localhost/onboarding/swagger-ui.html
+    # http://localhost/iam/swagger-ui.html
+  EOT
+}

--- a/infra/terraform/k8s-local/providers.tf
+++ b/infra/terraform/k8s-local/providers.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = "~> 0.7"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.36"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}
+
+provider "kind" {}
+
+provider "helm" {
+  kubernetes {
+    config_path = kind_cluster.local.kubeconfig_path
+  }
+}
+
+provider "kubernetes" {
+  config_path = kind_cluster.local.kubeconfig_path
+}

--- a/infra/terraform/k8s-local/run.sh
+++ b/infra/terraform/k8s-local/run.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# StableBridge Platform — Local K8s Setup
+#
+# Usage:
+#   ./run.sh up      # Build JARs, create kind cluster, deploy services
+#   ./run.sh down    # Destroy kind cluster
+#   ./run.sh deploy  # Re-deploy kustomize manifests (after code changes)
+#   ./run.sh build   # Build JARs only
+#   ./run.sh status  # Show cluster and pod status
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INFRA_TF_DIR="$SCRIPT_DIR/../local"
+K8S_TF_DIR="$SCRIPT_DIR"
+
+# ─────────────────────────────────────────────
+# Build application JARs
+# ─────────────────────────────────────────────
+build_jars() {
+  echo "==> Building application JARs..."
+  cd "$PROJECT_ROOT"
+  ./gradlew :merchant-onboarding:merchant-onboarding:bootJar \
+            :merchant-iam:merchant-iam:bootJar \
+            :api-gateway-iam:api-gateway-iam:bootJar \
+            --parallel --no-daemon
+  echo "==> JARs built successfully"
+}
+
+# ─────────────────────────────────────────────
+# Start infra (Terraform Docker provider)
+# ─────────────────────────────────────────────
+start_infra() {
+  echo "==> Starting infrastructure containers..."
+  cd "$INFRA_TF_DIR"
+  terraform init -input=false
+  terraform apply -auto-approve
+  echo "==> Infrastructure running"
+}
+
+# ─────────────────────────────────────────────
+# Create kind cluster + deploy
+# ─────────────────────────────────────────────
+create_cluster() {
+  echo "==> Creating kind cluster + NGINX Ingress..."
+  cd "$K8S_TF_DIR"
+  terraform init -input=false
+  terraform apply -auto-approve
+  echo "==> Cluster ready"
+
+  export KUBECONFIG=$(terraform output -raw kubeconfig_path)
+  echo "==> Waiting for ingress controller to be ready..."
+  kubectl wait --namespace ingress-nginx \
+    --for=condition=ready pod \
+    --selector=app.kubernetes.io/component=controller \
+    --timeout=120s
+
+  echo "==> Waiting for application pods to be ready..."
+  kubectl wait --namespace stablebridge \
+    --for=condition=ready pod \
+    --all \
+    --timeout=180s || true
+
+  show_status
+}
+
+# ─────────────────────────────────────────────
+# Re-deploy kustomize manifests
+# ─────────────────────────────────────────────
+deploy() {
+  cd "$K8S_TF_DIR"
+  export KUBECONFIG=$(terraform output -raw kubeconfig_path)
+  echo "==> Applying kustomize manifests..."
+  kubectl apply -k "$PROJECT_ROOT/infra/k8s/overlays/local"
+  echo "==> Restarting deployments..."
+  kubectl rollout restart deployment -n stablebridge
+  kubectl rollout status deployment -n stablebridge --timeout=120s || true
+  show_status
+}
+
+# ─────────────────────────────────────────────
+# Destroy kind cluster
+# ─────────────────────────────────────────────
+destroy_cluster() {
+  echo "==> Destroying kind cluster..."
+  cd "$K8S_TF_DIR"
+  terraform destroy -auto-approve
+  echo "==> Cluster destroyed"
+}
+
+# ─────────────────────────────────────────────
+# Show status
+# ─────────────────────────────────────────────
+show_status() {
+  cd "$K8S_TF_DIR"
+  export KUBECONFIG=$(terraform output -raw kubeconfig_path)
+  echo ""
+  echo "=== Cluster Nodes ==="
+  kubectl get nodes
+  echo ""
+  echo "=== Pods (stablebridge) ==="
+  kubectl get pods -n stablebridge -o wide
+  echo ""
+  echo "=== Services (stablebridge) ==="
+  kubectl get svc -n stablebridge
+  echo ""
+  echo "=== Ingress ==="
+  kubectl get ingress -n stablebridge
+  echo ""
+  echo "=== Access URLs (path-based routing) ==="
+  echo "  API Gateway (S10):     http://localhost/gateway"
+  echo "  Onboarding (S11):      http://localhost/onboarding"
+  echo "  IAM (S13):             http://localhost/iam"
+  echo "  Merchant Portal:       http://localhost"
+  echo ""
+  echo "  OpenAPI docs:"
+  echo "    http://localhost/gateway/swagger-ui.html"
+  echo "    http://localhost/onboarding/swagger-ui.html"
+  echo "    http://localhost/iam/swagger-ui.html"
+}
+
+# ─────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────
+case "${1:-help}" in
+  up)
+    build_jars
+    start_infra
+    create_cluster
+    ;;
+  down)
+    destroy_cluster
+    ;;
+  deploy)
+    deploy
+    ;;
+  build)
+    build_jars
+    ;;
+  status)
+    show_status
+    ;;
+  *)
+    echo "Usage: $0 {up|down|deploy|build|status}"
+    exit 1
+    ;;
+esac

--- a/infra/terraform/k8s-local/variables.tf
+++ b/infra/terraform/k8s-local/variables.tf
@@ -1,0 +1,52 @@
+# ─────────────────────────────────────────────
+# Cluster
+# ─────────────────────────────────────────────
+variable "cluster_name" {
+  description = "Name of the kind cluster"
+  type        = string
+  default     = "stablebridge-local"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version (kind node image tag)"
+  type        = string
+  default     = "v1.32.3"
+}
+
+# ─────────────────────────────────────────────
+# Ingress
+# ─────────────────────────────────────────────
+variable "ingress_http_port" {
+  description = "Host port mapped to ingress controller HTTP"
+  type        = number
+  default     = 80
+}
+
+variable "ingress_https_port" {
+  description = "Host port mapped to ingress controller HTTPS"
+  type        = number
+  default     = 443
+}
+
+# ─────────────────────────────────────────────
+# Namespace
+# ─────────────────────────────────────────────
+variable "app_namespace" {
+  description = "Kubernetes namespace for application services"
+  type        = string
+  default     = "stablebridge"
+}
+
+# ─────────────────────────────────────────────
+# Project paths
+# ─────────────────────────────────────────────
+variable "project_root" {
+  description = "Absolute path to the stablebridge-platform repository root"
+  type        = string
+}
+
+variable "kustomize_overlay" {
+  description = "Path to kustomize overlay relative to project_root"
+  type        = string
+  default     = "infra/k8s/overlays/local"
+}


### PR DESCRIPTION
## Summary

- Terraform-managed kind cluster with NGINX Ingress Controller as single entry point
- Path-based routing: `/gateway/*` → S10, `/onboarding/*` → S11, `/iam/*` → S13, `/` → portal
- Kustomize base + local overlay for K8s manifests
- Services connect to Docker-hosted infra via `host.docker.internal`

## Architecture

```
NGINX Ingress (:80/:443)
├── /gateway/*     → S10 API Gateway (:8080)
├── /onboarding/*  → S11 Merchant Onboarding (:8081)
├── /iam/*         → S13 Merchant IAM (:8083)
└── /              → merchant-portal (:3000)

Services → host.docker.internal → Docker containers (PG, Redis, Redpanda, etc.)
```

## Files added

**Terraform** (`infra/terraform/k8s-local/`):
- `providers.tf` — kind, helm, kubernetes, null
- `main.tf` — kind cluster + NGINX Ingress Helm + namespace + kustomize apply
- `variables.tf` / `outputs.tf` — config and access URLs
- `run.sh` — helper script (`up|down|deploy|build|status`)

**Kustomize** (`infra/k8s/`):
- `base/` — per-service deployment + service + configmap + ingress
- `overlays/local/` — resource limit patches + JVM opts

## Usage

```bash
cd infra/terraform/k8s-local
./run.sh up       # Build JARs → start infra → create cluster → deploy
./run.sh status   # Show pods, services, ingress
./run.sh deploy   # Re-deploy after code changes
./run.sh down     # Destroy cluster
```

## Test plan

- [x] `kubectl kustomize` renders correctly with path-based routing
- [x] `terraform validate` passes
- [x] Health probes include context-path prefixes
- [x] Inter-service URL (S10→S13) includes `/iam` context path
- [ ] Manual: `terraform apply` creates cluster and deploys services

> **Note:** This PR targets `feature/STA-77-servlet-context-path` (not main) since it depends on the servlet context-path changes for path-based routing.

Closes STA-76

🤖 Generated with [Claude Code](https://claude.com/claude-code)