### PR TITLE
feat(infra): update K8s manifests and deploy script for FE images (STA-79)

### DIFF
--- a/infra/k8s/base/merchant-portal/deployment.yaml
+++ b/infra/k8s/base/merchant-portal/deployment.yaml
@@ -19,26 +19,27 @@ spec:
     spec:
       containers:
         - name: merchant-portal
-          image: nginx:alpine
+          image: stablebridge/merchant-portal:latest
+          imagePullPolicy: Never
           ports:
-            - containerPort: 80
+            - containerPort: 3000
               protocol: TCP
           resources:
             requests:
-              memory: "64Mi"
-              cpu: "50m"
-            limits:
               memory: "128Mi"
-              cpu: "200m"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 3000
             initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 3000
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/infra/k8s/base/merchant-portal/service.yaml
+++ b/infra/k8s/base/merchant-portal/service.yaml
@@ -11,6 +11,6 @@ spec:
     app: merchant-portal
   ports:
     - port: 3000
-      targetPort: 80
+      targetPort: 3000
       protocol: TCP
       name: http

--- a/infra/terraform/k8s-local/run.sh
+++ b/infra/terraform/k8s-local/run.sh
@@ -6,36 +6,61 @@
 #   ./run.sh up      # Build images, create kind cluster, deploy services
 #   ./run.sh down    # Destroy kind cluster
 #   ./run.sh deploy  # Re-build images, reload into kind, re-deploy manifests
-#   ./run.sh build   # Build container images only (Jib → local Docker daemon)
+#   ./run.sh build   # Build all container images (BE via Jib, FE via Docker)
 #   ./run.sh status  # Show cluster and pod status
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+FE_ROOT="$(cd "$PROJECT_ROOT/../stablebridge-web" 2>/dev/null && pwd || echo "")"
 INFRA_TF_DIR="$SCRIPT_DIR/../local"
 K8S_TF_DIR="$SCRIPT_DIR"
 
 CLUSTER_NAME="stablebridge-local"
 
-# Service images built by Jib
+# All images to load into kind
 IMAGES=(
   "stablebridge/api-gateway-iam:latest"
   "stablebridge/merchant-onboarding:latest"
   "stablebridge/merchant-iam:latest"
+  "stablebridge/merchant-portal:latest"
 )
 
 # ─────────────────────────────────────────────
-# Build container images via Jib
+# Build BE container images via Jib
 # ─────────────────────────────────────────────
-build_images() {
-  echo "==> Building container images via Jib..."
+build_be_images() {
+  echo "==> Building BE container images via Jib..."
   cd "$PROJECT_ROOT"
   ./gradlew :api-gateway-iam:api-gateway-iam:jibDockerBuild \
             :merchant-onboarding:merchant-onboarding:jibDockerBuild \
             :merchant-iam:merchant-iam:jibDockerBuild \
             --parallel --no-daemon
-  echo "==> Container images built successfully"
+  echo "==> BE images built successfully"
+}
+
+# ─────────────────────────────────────────────
+# Build FE container images via Docker
+# ─────────────────────────────────────────────
+build_fe_images() {
+  if [ -z "$FE_ROOT" ]; then
+    echo "==> WARN: stablebridge-web repo not found at $PROJECT_ROOT/../stablebridge-web — skipping FE build"
+    return 0
+  fi
+  echo "==> Building FE container images via Docker..."
+  docker build --build-arg APP_NAME=merchant-portal \
+    -t stablebridge/merchant-portal:latest \
+    "$FE_ROOT"
+  echo "==> FE images built successfully"
+}
+
+# ─────────────────────────────────────────────
+# Build all images
+# ─────────────────────────────────────────────
+build_images() {
+  build_be_images
+  build_fe_images
 }
 
 # ─────────────────────────────────────────────
@@ -44,7 +69,11 @@ build_images() {
 load_images() {
   echo "==> Loading images into kind cluster..."
   for img in "${IMAGES[@]}"; do
-    kind load docker-image "$img" --name "$CLUSTER_NAME"
+    if docker image inspect "$img" >/dev/null 2>&1; then
+      kind load docker-image "$img" --name "$CLUSTER_NAME"
+    else
+      echo "    WARN: $img not found locally — skipping"
+    fi
   done
   echo "==> Images loaded into kind"
 }
@@ -139,10 +168,10 @@ show_status() {
   kubectl get ingress -n stablebridge
   echo ""
   echo "=== Access URLs (path-based routing) ==="
+  echo "  Merchant Portal:       http://localhost"
   echo "  API Gateway (S10):     http://localhost/gateway"
   echo "  Onboarding (S11):      http://localhost/onboarding"
   echo "  IAM (S13):             http://localhost/iam"
-  echo "  Merchant Portal:       http://localhost"
   echo ""
   echo "  OpenAPI docs:"
   echo "    http://localhost/gateway/swagger-ui.html"


### PR DESCRIPTION
## Summary
- Update merchant-portal K8s deployment from `nginx:alpine` placeholder to `stablebridge/merchant-portal:latest` with `imagePullPolicy: Never`
- Fix service `targetPort` from 80 to 3000 (matching Next.js standalone server)
- Update `run.sh` to build FE images via `docker build` alongside BE Jib builds
- Gracefully skip FE build if `stablebridge-web` repo not found

## Dependencies
- **FE**: Requires [stablebridge-web#8](https://github.com/Puneethkumarck/stablebridge-web/pull/8) for the Dockerfile

## Test plan
- [x] Kustomize renders correct image refs for all 4 services
- [x] Service targetPort matches container port (3000)
- [x] `run.sh` gracefully handles missing FE repo
- [ ] `./run.sh up` deploys all services including merchant-portal (manual)

Closes STA-79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated merchant portal deployment configuration and service port settings to align with application requirements
  * Enhanced deployment pipeline to integrate frontend build process alongside backend builds with conditional execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->