### PR TITLE
feat(s2): Onfido KYC adapter + Redis cache (STA-86)

### DIFF
--- a/compliance-travel-rule/compliance-travel-rule/build.gradle.kts
+++ b/compliance-travel-rule/compliance-travel-rule/build.gradle.kts
@@ -87,6 +87,9 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
     implementation("org.springframework.boot:spring-boot-starter-security")
 
+    // Redis — KYC cache
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     // Kafka via Spring Cloud Stream
     implementation("org.springframework.cloud:spring-cloud-stream")
     implementation("org.springframework.cloud:spring-cloud-stream-binder-kafka")

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoCheckListResponse.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoCheckListResponse.java
@@ -1,0 +1,14 @@
+package com.stablecoin.payments.compliance.infrastructure.provider.onfido;
+
+import java.util.List;
+
+record OnfidoCheckListResponse(List<OnfidoCheck> checks) {
+
+    record OnfidoCheck(
+            String id,
+            String status,
+            String result,
+            String applicantId,
+            List<String> reportIds
+    ) {}
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoKycAdapter.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoKycAdapter.java
@@ -1,0 +1,160 @@
+package com.stablecoin.payments.compliance.infrastructure.provider.onfido;
+
+import com.stablecoin.payments.compliance.domain.model.KycResult;
+import com.stablecoin.payments.compliance.domain.model.KycStatus;
+import com.stablecoin.payments.compliance.domain.model.KycTier;
+import com.stablecoin.payments.compliance.domain.port.KycProvider;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "app.kyc.provider", havingValue = "onfido")
+@EnableConfigurationProperties(OnfidoProperties.class)
+public class OnfidoKycAdapter implements KycProvider {
+
+    private static final String CACHE_KEY_PREFIX = "kyc:status:";
+
+    private final RestClient restClient;
+    private final StringRedisTemplate redisTemplate;
+    private final JsonMapper jsonMapper;
+    private final Duration cacheTtl;
+
+    public OnfidoKycAdapter(OnfidoProperties properties, StringRedisTemplate redisTemplate) {
+        var httpClient = HttpClient.newBuilder()
+                .version(Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
+                .build();
+
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .defaultHeader("Authorization", "Token token=" + properties.apiToken())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .build();
+
+        this.redisTemplate = redisTemplate;
+        this.jsonMapper = JsonMapper.builder().build();
+        this.cacheTtl = Duration.ofMinutes(properties.cacheTtlMinutes());
+    }
+
+    @Override
+    @CircuitBreaker(name = "kyc", fallbackMethod = "verifyFallback")
+    public KycResult verify(UUID senderId, UUID recipientId) {
+        log.info("[ONFIDO] KYC verification sender={} recipient={}", senderId, recipientId);
+
+        var senderResult = resolveCustomerStatus(senderId);
+        var recipientResult = resolveCustomerStatus(recipientId);
+
+        var result = KycResult.builder()
+                .kycResultId(UUID.randomUUID())
+                .senderKycTier(senderResult.tier())
+                .senderStatus(senderResult.status())
+                .recipientStatus(recipientResult.status())
+                .provider("onfido")
+                .providerRef("onfido:" + senderId + "/" + recipientId)
+                .checkedAt(Instant.now())
+                .build();
+
+        log.info("[ONFIDO] KYC result: senderStatus={} recipientStatus={}",
+                senderResult.status(), recipientResult.status());
+        return result;
+    }
+
+    private CustomerKycResult resolveCustomerStatus(UUID customerId) {
+        var cached = getFromCache(customerId);
+        if (cached != null) {
+            log.debug("[ONFIDO] Cache hit for customer={}", customerId);
+            return cached;
+        }
+
+        var kycResult = callOnfido(customerId);
+
+        if (kycResult.status() == KycStatus.VERIFIED) {
+            putInCache(customerId, kycResult);
+        }
+
+        return kycResult;
+    }
+
+    private CustomerKycResult callOnfido(UUID customerId) {
+        var response = restClient.get()
+                .uri("/checks?applicant_id={applicantId}", customerId.toString())
+                .retrieve()
+                .body(OnfidoCheckListResponse.class);
+
+        if (response == null || response.checks() == null || response.checks().isEmpty()) {
+            log.info("[ONFIDO] No checks found for customer={}", customerId);
+            return new CustomerKycResult(KycStatus.UNVERIFIED, KycTier.KYC_TIER_1);
+        }
+
+        var latestCheck = response.checks().getFirst();
+        return mapCheckResult(latestCheck);
+    }
+
+    private CustomerKycResult mapCheckResult(OnfidoCheckListResponse.OnfidoCheck check) {
+        if ("clear".equals(check.result())) {
+            return new CustomerKycResult(KycStatus.VERIFIED, KycTier.KYC_TIER_2);
+        }
+        if ("consider".equals(check.result())) {
+            return new CustomerKycResult(KycStatus.PENDING, KycTier.KYC_TIER_1);
+        }
+        return new CustomerKycResult(KycStatus.UNVERIFIED, KycTier.KYC_TIER_1);
+    }
+
+    private CustomerKycResult getFromCache(UUID customerId) {
+        try {
+            var json = redisTemplate.opsForValue().get(CACHE_KEY_PREFIX + customerId);
+            if (json == null) {
+                return null;
+            }
+            var cached = jsonMapper.readValue(json, CachedKycStatus.class);
+            return new CustomerKycResult(
+                    KycStatus.valueOf(cached.status()),
+                    KycTier.valueOf(cached.tier()));
+        } catch (Exception ex) {
+            log.warn("[ONFIDO] Failed to read KYC cache for customer={}", customerId, ex);
+            return null;
+        }
+    }
+
+    private void putInCache(UUID customerId, CustomerKycResult result) {
+        try {
+            var cached = new CachedKycStatus(
+                    result.status().name(),
+                    result.tier().name(),
+                    Instant.now().toEpochMilli());
+            var json = jsonMapper.writeValueAsString(cached);
+            redisTemplate.opsForValue().set(CACHE_KEY_PREFIX + customerId, json, cacheTtl);
+            log.debug("[ONFIDO] Cached KYC status for customer={} ttl={}min", customerId, cacheTtl.toMinutes());
+        } catch (Exception ex) {
+            log.warn("[ONFIDO] Failed to cache KYC status for customer={}", customerId, ex);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private KycResult verifyFallback(UUID senderId, UUID recipientId, Exception ex) {
+        log.error("[ONFIDO] Circuit breaker open — KYC verification failed sender={} recipient={}",
+                senderId, recipientId, ex);
+        throw new IllegalStateException("KYC verification unavailable", ex);
+    }
+
+    private record CustomerKycResult(KycStatus status, KycTier tier) {}
+
+    record CachedKycStatus(String status, String tier, long cachedAtMs) {}
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoProperties.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoProperties.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.compliance.infrastructure.provider.onfido;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.kyc.onfido")
+public record OnfidoProperties(
+        String baseUrl,
+        String apiToken,
+        int timeoutSeconds,
+        int cacheTtlMinutes
+) {
+    public OnfidoProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            baseUrl = "https://api.eu.onfido.com/v3.6";
+        }
+        if (timeoutSeconds <= 0) {
+            timeoutSeconds = 2;
+        }
+        if (cacheTtlMinutes <= 0) {
+            cacheTtlMinutes = 60;
+        }
+    }
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoKycAdapterTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoKycAdapterTest.java
@@ -1,0 +1,214 @@
+package com.stablecoin.payments.compliance.infrastructure.provider.onfido;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.stablecoin.payments.compliance.domain.model.KycResult;
+import com.stablecoin.payments.compliance.domain.model.KycStatus;
+import com.stablecoin.payments.compliance.domain.model.KycTier;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+class OnfidoKycAdapterTest {
+
+    private static WireMockServer wireMock;
+    private OnfidoKycAdapter adapter;
+    private StringRedisTemplate redisTemplate;
+    private ValueOperations<String, String> valueOps;
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMock.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMock.stop();
+    }
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        wireMock.resetAll();
+        redisTemplate = mock(StringRedisTemplate.class);
+        valueOps = mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+        var properties = new OnfidoProperties(
+                wireMock.baseUrl() + "/v3.6",
+                "test-token",
+                2,
+                60
+        );
+        adapter = new OnfidoKycAdapter(properties, redisTemplate);
+    }
+
+    @Nested
+    @DisplayName("Cache miss — API call")
+    class CacheMiss {
+
+        @Test
+        @DisplayName("should verify both parties and return VERIFIED when checks are clear")
+        void verifiedWhenClear() {
+            given(valueOps.get(anyString())).willReturn(null);
+
+            wireMock.stubFor(get(urlPathEqualTo("/v3.6/checks"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                {
+                                  "checks": [
+                                    {
+                                      "id": "chk-001",
+                                      "status": "complete",
+                                      "result": "clear",
+                                      "applicantId": "app-001",
+                                      "reportIds": ["rpt-001"]
+                                    }
+                                  ]
+                                }
+                                """)));
+
+            var result = adapter.verify(UUID.randomUUID(), UUID.randomUUID());
+
+            var expected = KycResult.builder()
+                    .senderKycTier(KycTier.KYC_TIER_2)
+                    .senderStatus(KycStatus.VERIFIED)
+                    .recipientStatus(KycStatus.VERIFIED)
+                    .provider("onfido")
+                    .build();
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("kycResultId", "checkId", "providerRef", "checkedAt")
+                    .isEqualTo(expected);
+            assertThat(result.providerRef()).startsWith("onfido:");
+
+            // Verify caching happened for both sender and recipient (VERIFIED results are cached)
+            then(valueOps).should(times(2)).set(anyString(), anyString(), eq(Duration.ofMinutes(60)));
+        }
+
+        @Test
+        @DisplayName("should return PENDING when check result is consider")
+        void pendingWhenConsider() {
+            given(valueOps.get(anyString())).willReturn(null);
+
+            wireMock.stubFor(get(urlPathEqualTo("/v3.6/checks"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                {
+                                  "checks": [
+                                    {
+                                      "id": "chk-002",
+                                      "status": "complete",
+                                      "result": "consider",
+                                      "applicantId": "app-002",
+                                      "reportIds": ["rpt-002"]
+                                    }
+                                  ]
+                                }
+                                """)));
+
+            var result = adapter.verify(UUID.randomUUID(), UUID.randomUUID());
+
+            var expected = KycResult.builder()
+                    .senderKycTier(KycTier.KYC_TIER_1)
+                    .senderStatus(KycStatus.PENDING)
+                    .recipientStatus(KycStatus.PENDING)
+                    .provider("onfido")
+                    .build();
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("kycResultId", "checkId", "providerRef", "checkedAt")
+                    .isEqualTo(expected);
+
+            // PENDING should NOT be cached
+            then(valueOps).should(never()).set(anyString(), anyString(), any(Duration.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Cache hit")
+    class CacheHit {
+
+        @Test
+        @DisplayName("should return cached result without calling API")
+        void cachedResultReturned() {
+            var cachedJson = """
+                {"status":"VERIFIED","tier":"KYC_TIER_2","cachedAtMs":1709856000000}
+                """;
+            given(valueOps.get(anyString())).willReturn(cachedJson);
+
+            var result = adapter.verify(UUID.randomUUID(), UUID.randomUUID());
+
+            var expected = KycResult.builder()
+                    .senderKycTier(KycTier.KYC_TIER_2)
+                    .senderStatus(KycStatus.VERIFIED)
+                    .recipientStatus(KycStatus.VERIFIED)
+                    .provider("onfido")
+                    .build();
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("kycResultId", "checkId", "providerRef", "checkedAt")
+                    .isEqualTo(expected);
+
+            // No API calls — all from cache
+            wireMock.verify(0, getRequestedFor(urlPathEqualTo("/v3.6/checks")));
+        }
+    }
+
+    @Nested
+    @DisplayName("Error handling")
+    class ErrorHandling {
+
+        @Test
+        @DisplayName("should throw when API returns server error")
+        void serverError() {
+            given(valueOps.get(anyString())).willReturn(null);
+
+            wireMock.stubFor(get(urlPathEqualTo("/v3.6/checks"))
+                    .willReturn(aResponse().withStatus(500)));
+
+            assertThatThrownBy(() -> adapter.verify(UUID.randomUUID(), UUID.randomUUID()))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("should throw when API returns 401 unauthorized")
+        void unauthorizedError() {
+            given(valueOps.get(anyString())).willReturn(null);
+
+            wireMock.stubFor(get(urlPathEqualTo("/v3.6/checks"))
+                    .willReturn(aResponse().withStatus(401)));
+
+            assertThatThrownBy(() -> adapter.verify(UUID.randomUUID(), UUID.randomUUID()))
+                    .isInstanceOf(Exception.class);
+        }
+    }
+}

--- a/infra/local/wiremock/__files/onfido-checks-verified.json
+++ b/infra/local/wiremock/__files/onfido-checks-verified.json
@@ -1,0 +1,13 @@
+{
+  "checks": [
+    {
+      "id": "check-sandbox-kyc-001",
+      "status": "complete",
+      "result": "clear",
+      "applicantId": "applicant-sandbox-001",
+      "reportIds": [
+        "report-sandbox-001"
+      ]
+    }
+  ]
+}

--- a/infra/local/wiremock/mappings/onfido-list-checks.json
+++ b/infra/local/wiremock/mappings/onfido-list-checks.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/v3\\.6/checks",
+    "queryParameters": {
+      "applicant_id": {
+        "matches": ".*"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "onfido-checks-verified.json"
+  }
+}


### PR DESCRIPTION
## Summary

- **OnfidoKycAdapter** implementing `KycProvider` port with RestClient (HTTP/1.1) + Redis cache (1h TTL)
- Circuit breaker with re-throw fallback (hard KYC block — same pattern as sanctions)
- Redis cache: only VERIFIED results cached, key `kyc:status:{customerId}`
- `CachedKycStatus` package-private record for Redis serialization (Jackson 3 JsonMapper)
- WireMock stubs for local dev (`onfido-list-checks.json`)
- `spring-boot-starter-data-redis` added to S2 dependencies

## Test plan

- [x] 5 new unit tests: cache miss (clear), cache miss (consider), cache hit, 500 error, 401 error
- [x] All 167 S2 unit tests pass (162 existing + 5 new)
- [x] Single-assert pattern with `usingRecursiveComparison().ignoringFields()`

Closes STA-86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Onfido KYC verification to enable customer identity verification with configurable provider settings.
  * Added caching layer for KYC results to improve response performance and reduce external API calls.

* **Chores**
  * Added Redis support dependency for caching infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->