### PR TITLE
feat(s6): Kafka payment consumers + pool seed data (STA-99)

### DIFF
--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/domain/service/LiquidityService.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/domain/service/LiquidityService.java
@@ -2,10 +2,12 @@ package com.stablecoin.payments.fx.domain.service;
 
 import com.stablecoin.payments.fx.domain.model.LiquidityPool;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 
 @Slf4j
+@Service
 public class LiquidityService {
 
     public LiquidityPool createPool(String fromCurrency, String toCurrency,

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/domain/service/LockService.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/domain/service/LockService.java
@@ -4,10 +4,12 @@ import com.stablecoin.payments.fx.domain.model.FxQuote;
 import com.stablecoin.payments.fx.domain.model.FxRateLock;
 import com.stablecoin.payments.fx.domain.model.LiquidityPool;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
 @Slf4j
+@Service
 public class LockService {
 
     public record LockResult(FxQuote lockedQuote, FxRateLock lock, LiquidityPool updatedPool) {}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/infrastructure/messaging/OutboxEventPublisher.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/infrastructure/messaging/OutboxEventPublisher.java
@@ -8,29 +8,38 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OutboxEventPublisher implements EventPublisher<Object> {
+
+    private static final List<String> KEY_FIELDS = List.of("paymentId", "poolId");
 
     private final Outbox outbox;
 
     @Override
     @Transactional(propagation = Propagation.MANDATORY)
     public void publish(Object event) {
-        var key = resolveField(event, "paymentId");
+        var key = resolveKey(event);
         outbox.schedule(event, key);
         log.debug("Scheduled outbox event type={} key={}", event.getClass().getSimpleName(), key);
     }
 
-    private String resolveField(Object event, String fieldName) {
-        try {
-            var method = event.getClass().getMethod(fieldName);
-            return String.valueOf(method.invoke(event));
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "Event class missing accessor for field '" + fieldName + "': "
-                            + event.getClass().getName(), e);
+    private String resolveKey(Object event) {
+        for (String field : KEY_FIELDS) {
+            try {
+                var method = event.getClass().getMethod(field);
+                return String.valueOf(method.invoke(event));
+            } catch (NoSuchMethodException e) {
+                // try next field
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Failed to invoke key accessor '" + field + "' on " + event.getClass().getName(), e);
+            }
         }
+        throw new IllegalArgumentException(
+                "Event class has no key field (paymentId or poolId): " + event.getClass().getName());
     }
 }

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/infrastructure/messaging/PaymentEventConsumer.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/infrastructure/messaging/PaymentEventConsumer.java
@@ -1,0 +1,128 @@
+package com.stablecoin.payments.fx.infrastructure.messaging;
+
+import com.stablecoin.payments.fx.domain.event.LiquidityThresholdBreached;
+import com.stablecoin.payments.fx.domain.model.FxRateLockStatus;
+import com.stablecoin.payments.fx.domain.port.FxRateLockRepository;
+import com.stablecoin.payments.fx.domain.port.LiquidityPoolRepository;
+import com.stablecoin.payments.fx.domain.service.LiquidityService;
+import com.stablecoin.payments.fx.domain.service.LockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventConsumer {
+
+    private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+    private final FxRateLockRepository lockRepository;
+    private final LiquidityPoolRepository poolRepository;
+    private final LockService lockService;
+    private final LiquidityService liquidityService;
+    private final OutboxEventPublisher eventPublisher;
+
+    @KafkaListener(topics = "payment.completed", groupId = "fx-liquidity-engine")
+    @Transactional
+    public void onPaymentCompleted(String message) {
+        var event = parseEvent(message);
+        log.info("[PAYMENT-EVENT] Processing payment.completed paymentId={}", event.paymentId());
+
+        var lockOpt = lockRepository.findByPaymentId(event.paymentId());
+        if (lockOpt.isEmpty()) {
+            log.warn("[PAYMENT-EVENT] No lock found for paymentId={}", event.paymentId());
+            return;
+        }
+
+        var lock = lockOpt.get();
+
+        // Idempotency: already consumed
+        if (lock.status() == FxRateLockStatus.CONSUMED) {
+            log.info("[PAYMENT-EVENT] Lock already consumed lockId={} paymentId={}",
+                    lock.lockId(), event.paymentId());
+            return;
+        }
+
+        // Consume the lock
+        var consumedLock = lockService.consumeLock(lock, event.paymentId());
+        lockRepository.save(consumedLock);
+
+        // Consume pool reservation
+        var pool = poolRepository.findByCorridor(lock.fromCurrency(), lock.toCurrency())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Pool not found for corridor %s:%s".formatted(lock.fromCurrency(), lock.toCurrency())));
+
+        var updatedPool = liquidityService.consumeReservation(pool, lock.targetAmount());
+        poolRepository.save(updatedPool);
+
+        // Publish threshold breach event if needed
+        if (updatedPool.isBelowThreshold()) {
+            log.warn("[PAYMENT-EVENT] Liquidity threshold breached poolId={} available={} threshold={}",
+                    updatedPool.poolId(), updatedPool.availableBalance(), updatedPool.minimumThreshold());
+            eventPublisher.publish(new LiquidityThresholdBreached(
+                    updatedPool.poolId(),
+                    updatedPool.fromCurrency(),
+                    updatedPool.toCurrency(),
+                    updatedPool.availableBalance(),
+                    updatedPool.minimumThreshold(),
+                    Instant.now()));
+        }
+
+        log.info("[PAYMENT-EVENT] Completed payment.completed lockId={} paymentId={}",
+                lock.lockId(), event.paymentId());
+    }
+
+    @KafkaListener(topics = "payment.failed", groupId = "fx-liquidity-engine")
+    @Transactional
+    public void onPaymentFailed(String message) {
+        var event = parseEvent(message);
+        log.info("[PAYMENT-EVENT] Processing payment.failed paymentId={}", event.paymentId());
+
+        var lockOpt = lockRepository.findByPaymentId(event.paymentId());
+        if (lockOpt.isEmpty()) {
+            log.warn("[PAYMENT-EVENT] No lock found for paymentId={}", event.paymentId());
+            return;
+        }
+
+        var lock = lockOpt.get();
+
+        // Idempotency: already expired
+        if (lock.status() == FxRateLockStatus.EXPIRED) {
+            log.info("[PAYMENT-EVENT] Lock already expired lockId={} paymentId={}",
+                    lock.lockId(), event.paymentId());
+            return;
+        }
+
+        // Expire the lock
+        var expiredLock = lockService.expireLock(lock);
+        lockRepository.save(expiredLock);
+
+        // Release pool reservation back to available
+        var pool = poolRepository.findByCorridor(lock.fromCurrency(), lock.toCurrency())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Pool not found for corridor %s:%s".formatted(lock.fromCurrency(), lock.toCurrency())));
+
+        var updatedPool = liquidityService.release(pool, lock.targetAmount());
+        poolRepository.save(updatedPool);
+
+        log.info("[PAYMENT-EVENT] Released reservation lockId={} paymentId={} amount={}",
+                lock.lockId(), event.paymentId(), lock.targetAmount());
+    }
+
+    private PaymentEvent parseEvent(String message) {
+        try {
+            return JSON_MAPPER.readValue(message, PaymentEvent.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse payment event: " + message, e);
+        }
+    }
+
+    record PaymentEvent(UUID paymentId) {}
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/db/migration/V4__seed_liquidity_pools.sql
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/db/migration/V4__seed_liquidity_pools.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- V4: Seed USD-EUR liquidity pool for MVP corridor
+-- ============================================================
+
+INSERT INTO liquidity_pools (pool_id, from_currency, to_currency,
+                             available_balance, reserved_balance,
+                             minimum_threshold, maximum_capacity,
+                             updated_at, version)
+VALUES (gen_random_uuid(), 'USD', 'EUR',
+        1000000.00000000, 0.00000000,
+        100000.00000000, 5000000.00000000,
+        now(), 0)
+ON CONFLICT (from_currency, to_currency) DO NOTHING;

--- a/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/infrastructure/messaging/PaymentEventConsumerTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/infrastructure/messaging/PaymentEventConsumerTest.java
@@ -1,0 +1,204 @@
+package com.stablecoin.payments.fx.infrastructure.messaging;
+
+import com.stablecoin.payments.fx.domain.event.LiquidityThresholdBreached;
+import com.stablecoin.payments.fx.domain.model.FxRateLock;
+import com.stablecoin.payments.fx.domain.model.FxRateLockStatus;
+import com.stablecoin.payments.fx.domain.model.LiquidityPool;
+import com.stablecoin.payments.fx.domain.port.FxRateLockRepository;
+import com.stablecoin.payments.fx.domain.port.LiquidityPoolRepository;
+import com.stablecoin.payments.fx.domain.service.LiquidityService;
+import com.stablecoin.payments.fx.domain.service.LockService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+class PaymentEventConsumerTest {
+
+    private FxRateLockRepository lockRepository;
+    private LiquidityPoolRepository poolRepository;
+    private OutboxEventPublisher eventPublisher;
+    private PaymentEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        lockRepository = mock(FxRateLockRepository.class);
+        poolRepository = mock(LiquidityPoolRepository.class);
+        eventPublisher = mock(OutboxEventPublisher.class);
+
+        // Real domain services — pure logic, no dependencies
+        var lockService = new LockService();
+        var liquidityService = new LiquidityService();
+
+        consumer = new PaymentEventConsumer(
+                lockRepository, poolRepository,
+                lockService, liquidityService, eventPublisher);
+    }
+
+    private static FxRateLock anActiveLock(UUID paymentId) {
+        var now = Instant.now();
+        return new FxRateLock(
+                UUID.randomUUID(), UUID.randomUUID(), paymentId, UUID.randomUUID(),
+                "USD", "EUR",
+                new BigDecimal("1000.00"), new BigDecimal("920.00"), new BigDecimal("0.92"),
+                30, new BigDecimal("3.00"),
+                "US", "DE",
+                FxRateLockStatus.ACTIVE,
+                now, now.plusSeconds(30), null);
+    }
+
+    private static LiquidityPool aPool(BigDecimal available, BigDecimal reserved, BigDecimal threshold) {
+        return new LiquidityPool(
+                UUID.randomUUID(), "USD", "EUR",
+                available, reserved,
+                threshold, new BigDecimal("5000000.00"),
+                Instant.now());
+    }
+
+    private static String paymentEvent(UUID paymentId) {
+        return "{\"paymentId\":\"%s\"}".formatted(paymentId);
+    }
+
+    @Nested
+    @DisplayName("payment.completed")
+    class PaymentCompleted {
+
+        @Test
+        @DisplayName("should consume lock and pool reservation")
+        void consumesLockAndReservation() {
+            var paymentId = UUID.randomUUID();
+            var lock = anActiveLock(paymentId);
+            var pool = aPool(new BigDecimal("500000.00"), new BigDecimal("920.00"), new BigDecimal("100000.00"));
+
+            given(lockRepository.findByPaymentId(paymentId)).willReturn(Optional.of(lock));
+            given(poolRepository.findByCorridor("USD", "EUR")).willReturn(Optional.of(pool));
+            given(lockRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(poolRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            consumer.onPaymentCompleted(paymentEvent(paymentId));
+
+            then(lockRepository).should().save(any(FxRateLock.class));
+            then(poolRepository).should().save(any(LiquidityPool.class));
+            then(eventPublisher).should(never()).publish(any());
+        }
+
+        @Test
+        @DisplayName("should publish threshold event when below minimum")
+        void publishesThresholdEvent() {
+            var paymentId = UUID.randomUUID();
+            var lock = anActiveLock(paymentId);
+            // Pool available=1000 after consuming 920 reservation stays at 1000, threshold=50000 — breach
+            var pool = aPool(new BigDecimal("1000.00"), new BigDecimal("920.00"), new BigDecimal("50000.00"));
+
+            given(lockRepository.findByPaymentId(paymentId)).willReturn(Optional.of(lock));
+            given(poolRepository.findByCorridor("USD", "EUR")).willReturn(Optional.of(pool));
+            given(lockRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(poolRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            consumer.onPaymentCompleted(paymentEvent(paymentId));
+
+            then(eventPublisher).should().publish(any(LiquidityThresholdBreached.class));
+        }
+
+        @Test
+        @DisplayName("should skip already consumed lock (idempotent)")
+        void idempotentConsumed() {
+            var paymentId = UUID.randomUUID();
+            var lock = anActiveLock(paymentId);
+            var consumedLock = new FxRateLock(
+                    lock.lockId(), lock.quoteId(), lock.paymentId(), lock.correlationId(),
+                    lock.fromCurrency(), lock.toCurrency(),
+                    lock.sourceAmount(), lock.targetAmount(), lock.lockedRate(),
+                    lock.feeBps(), lock.feeAmount(),
+                    lock.sourceCountry(), lock.targetCountry(),
+                    FxRateLockStatus.CONSUMED,
+                    lock.lockedAt(), lock.expiresAt(), Instant.now());
+
+            given(lockRepository.findByPaymentId(paymentId)).willReturn(Optional.of(consumedLock));
+
+            consumer.onPaymentCompleted(paymentEvent(paymentId));
+
+            then(lockRepository).should(never()).save(any());
+            then(poolRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("should skip when no lock found")
+        void noLockFound() {
+            var paymentId = UUID.randomUUID();
+            given(lockRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+
+            consumer.onPaymentCompleted(paymentEvent(paymentId));
+
+            then(lockRepository).should(never()).save(any());
+            then(poolRepository).should(never()).findByCorridor(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("payment.failed")
+    class PaymentFailed {
+
+        @Test
+        @DisplayName("should expire lock and release pool reservation")
+        void expiresLockAndReleasesReservation() {
+            var paymentId = UUID.randomUUID();
+            var lock = anActiveLock(paymentId);
+            var pool = aPool(new BigDecimal("500000.00"), new BigDecimal("920.00"), new BigDecimal("100000.00"));
+
+            given(lockRepository.findByPaymentId(paymentId)).willReturn(Optional.of(lock));
+            given(poolRepository.findByCorridor("USD", "EUR")).willReturn(Optional.of(pool));
+            given(lockRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(poolRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            consumer.onPaymentFailed(paymentEvent(paymentId));
+
+            then(lockRepository).should().save(any(FxRateLock.class));
+            then(poolRepository).should().save(any(LiquidityPool.class));
+        }
+
+        @Test
+        @DisplayName("should skip already expired lock (idempotent)")
+        void idempotentExpired() {
+            var paymentId = UUID.randomUUID();
+            var lock = anActiveLock(paymentId);
+            var expiredLock = new FxRateLock(
+                    lock.lockId(), lock.quoteId(), lock.paymentId(), lock.correlationId(),
+                    lock.fromCurrency(), lock.toCurrency(),
+                    lock.sourceAmount(), lock.targetAmount(), lock.lockedRate(),
+                    lock.feeBps(), lock.feeAmount(),
+                    lock.sourceCountry(), lock.targetCountry(),
+                    FxRateLockStatus.EXPIRED,
+                    lock.lockedAt(), lock.expiresAt(), null);
+
+            given(lockRepository.findByPaymentId(paymentId)).willReturn(Optional.of(expiredLock));
+
+            consumer.onPaymentFailed(paymentEvent(paymentId));
+
+            then(lockRepository).should(never()).save(any());
+            then(poolRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("should skip when no lock found")
+        void noLockFoundFailed() {
+            var paymentId = UUID.randomUUID();
+            given(lockRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+
+            consumer.onPaymentFailed(paymentEvent(paymentId));
+
+            then(lockRepository).should(never()).save(any());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **PaymentEventConsumer**: Kafka listeners for `payment.completed` and `payment.failed`
  - `payment.completed` → consume lock + consume pool reservation + threshold breach check
  - `payment.failed` → expire lock + release pool reservation back to available
  - Idempotent: skips already-consumed/expired locks
- **OutboxEventPublisher** updated to resolve `poolId` key (supports `LiquidityThresholdBreached` events)
- **@Service** added to `LockService` and `LiquidityService` (Spring-managed for DI)
- **V4 seed migration**: USD-EUR pool ($1M available, $100K threshold, $5M capacity)

## Test plan

- [x] 7 new unit tests covering all consumer paths
- [x] All 138 S6 unit tests pass (131 existing + 7 new)
- [x] All 30 S6 integration tests pass (V4 migration verified)
- [x] Interaction verification with BDDMockito `then().should()`

Closes STA-99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic liquidity consumption when payments complete; liquidity released when payments fail.
  * System publishes alerts when a liquidity pool falls below its minimum threshold.
  * New payment event consumer to process payment.completed and payment.failed events.

* **Database**
  * Initial seeding of a USD→EUR liquidity pool with default capacity and thresholds.

* **Tests**
  * Added comprehensive tests for payment event processing, threshold alerts, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->