### PR TITLE
feat(s2): REST controllers for compliance check + risk profile (STA-90)

### DIFF
--- a/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/AbstractIntegrationTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/AbstractIntegrationTest.java
@@ -1,11 +1,9 @@
 package com.stablecoin.payments.compliance;
 
-import com.stablecoin.payments.compliance.config.TestSecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -18,7 +16,6 @@ import org.testcontainers.utility.DockerImageName;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("integration-test")
 @AutoConfigureMockMvc
-@Import(TestSecurityConfig.class)
 public abstract class AbstractIntegrationTest {
 
     static final PostgreSQLContainer<?> POSTGRES =

--- a/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/application/controller/ComplianceCheckControllerIT.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/application/controller/ComplianceCheckControllerIT.java
@@ -1,0 +1,225 @@
+package com.stablecoin.payments.compliance.application.controller;
+
+import com.stablecoin.payments.compliance.AbstractIntegrationTest;
+import com.stablecoin.payments.compliance.domain.model.ComplianceCheck;
+import com.stablecoin.payments.compliance.domain.model.Money;
+import com.stablecoin.payments.compliance.domain.port.ComplianceCheckRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static com.stablecoin.payments.compliance.application.filter.IdempotencyKeyFilter.IDEMPOTENCY_KEY_HEADER;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("ComplianceCheckController IT")
+class ComplianceCheckControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ComplianceCheckRepository checkRepository;
+
+    @Nested
+    @DisplayName("POST /v1/compliance/check")
+    class InitiateCheck {
+
+        @Test
+        @DisplayName("should return 202 Accepted with check response")
+        void shouldReturn202WithCheckResponse() throws Exception {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "senderId": "%s",
+                        "recipientId": "%s",
+                        "amount": 1000.00,
+                        "currency": "USD",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE",
+                        "targetCurrency": "EUR"
+                    }
+                    """.formatted(paymentId, senderId, recipientId);
+
+            mockMvc.perform(post("/v1/compliance/check")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isAccepted())
+                    .andExpect(jsonPath("$.paymentId", is(paymentId.toString())))
+                    .andExpect(jsonPath("$.checkId", notNullValue()))
+                    .andExpect(jsonPath("$.status", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request for missing required fields")
+        void shouldReturn400ForMissingFields() throws Exception {
+            var requestBody = """
+                    {
+                        "amount": 1000.00,
+                        "currency": "USD"
+                    }
+                    """;
+
+            mockMvc.perform(post("/v1/compliance/check")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code", is("CO-0001")))
+                    .andExpect(jsonPath("$.errors", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request for invalid currency code")
+        void shouldReturn400ForInvalidCurrency() throws Exception {
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "senderId": "%s",
+                        "recipientId": "%s",
+                        "amount": 1000.00,
+                        "currency": "USDX",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE",
+                        "targetCurrency": "EUR"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/compliance/check")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code", is("CO-0001")));
+        }
+
+        @Test
+        @DisplayName("should return 409 Conflict for duplicate payment")
+        void shouldReturn409ForDuplicatePayment() throws Exception {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "senderId": "%s",
+                        "recipientId": "%s",
+                        "amount": 1000.00,
+                        "currency": "USD",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE",
+                        "targetCurrency": "EUR"
+                    }
+                    """.formatted(paymentId, senderId, recipientId);
+
+            // First request should succeed
+            mockMvc.perform(post("/v1/compliance/check")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isAccepted());
+
+            // Second request with same paymentId should return 409
+            mockMvc.perform(post("/v1/compliance/check")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code", is("CO-1002")));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request for negative amount")
+        void shouldReturn400ForNegativeAmount() throws Exception {
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "senderId": "%s",
+                        "recipientId": "%s",
+                        "amount": -100.00,
+                        "currency": "USD",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE",
+                        "targetCurrency": "EUR"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/compliance/check")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code", is("CO-0001")));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request when Idempotency-Key header is missing")
+        void shouldReturn400ForMissingIdempotencyKey() throws Exception {
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "senderId": "%s",
+                        "recipientId": "%s",
+                        "amount": 1000.00,
+                        "currency": "USD",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE",
+                        "targetCurrency": "EUR"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/compliance/check")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code", is("CO-0001")))
+                    .andExpect(jsonPath("$.message", is("Idempotency-Key header is required for mutating requests")));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/compliance/checks/{checkId}")
+    class GetCheck {
+
+        @Test
+        @DisplayName("should return 200 OK with check response for existing check")
+        void shouldReturn200ForExistingCheck() throws Exception {
+            var check = ComplianceCheck.initiate(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                    new Money(new BigDecimal("1000.00"), "USD"), "US", "DE", "EUR");
+            var saved = checkRepository.save(check);
+
+            mockMvc.perform(get("/v1/compliance/checks/{checkId}", saved.checkId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.checkId", is(saved.checkId().toString())))
+                    .andExpect(jsonPath("$.paymentId", is(saved.paymentId().toString())))
+                    .andExpect(jsonPath("$.status", is("PENDING")));
+        }
+
+        @Test
+        @DisplayName("should return 404 Not Found for non-existing check")
+        void shouldReturn404ForNonExistingCheck() throws Exception {
+            var checkId = UUID.randomUUID();
+
+            mockMvc.perform(get("/v1/compliance/checks/{checkId}", checkId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code", is("CO-1001")));
+        }
+    }
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/application/controller/CustomerRiskProfileControllerIT.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/application/controller/CustomerRiskProfileControllerIT.java
@@ -1,0 +1,68 @@
+package com.stablecoin.payments.compliance.application.controller;
+
+import com.stablecoin.payments.compliance.AbstractIntegrationTest;
+import com.stablecoin.payments.compliance.domain.model.CustomerRiskProfile;
+import com.stablecoin.payments.compliance.domain.model.KycTier;
+import com.stablecoin.payments.compliance.domain.model.RiskBand;
+import com.stablecoin.payments.compliance.domain.port.CustomerRiskProfileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CustomerRiskProfileController IT")
+class CustomerRiskProfileControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CustomerRiskProfileRepository profileRepository;
+
+    @Test
+    @DisplayName("should return 200 OK with risk profile for existing customer")
+    void shouldReturn200ForExistingCustomer() throws Exception {
+        var customerId = UUID.randomUUID();
+        var now = Instant.now();
+        var profile = CustomerRiskProfile.builder()
+                .customerId(customerId)
+                .kycTier(KycTier.KYC_TIER_2)
+                .kycVerifiedAt(now)
+                .riskBand(RiskBand.LOW)
+                .riskScore(20)
+                .perTxnLimitUsd(new BigDecimal("10000.00"))
+                .dailyLimitUsd(new BigDecimal("50000.00"))
+                .monthlyLimitUsd(new BigDecimal("500000.00"))
+                .lastScoredAt(now)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+        profileRepository.save(profile);
+
+        mockMvc.perform(get("/v1/customers/{customerId}/risk-profile", customerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customerId", is(customerId.toString())))
+                .andExpect(jsonPath("$.kycTier", is("KYC_TIER_2")))
+                .andExpect(jsonPath("$.riskBand", is("LOW")))
+                .andExpect(jsonPath("$.riskScore", is(20)));
+    }
+
+    @Test
+    @DisplayName("should return 404 Not Found for non-existing customer")
+    void shouldReturn404ForNonExistingCustomer() throws Exception {
+        var customerId = UUID.randomUUID();
+
+        mockMvc.perform(get("/v1/customers/{customerId}/risk-profile", customerId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code", is("CO-2001")));
+    }
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/integration-test/resources/application-integration-test.yml
+++ b/compliance-travel-rule/compliance-travel-rule/src/integration-test/resources/application-integration-test.yml
@@ -26,6 +26,10 @@ outbox:
 server:
   port: 0
 
+app:
+  security:
+    enabled: false
+
 logging:
   level:
     com.stablecoin.payments: DEBUG

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/application/controller/ComplianceCheckController.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/application/controller/ComplianceCheckController.java
@@ -1,0 +1,41 @@
+package com.stablecoin.payments.compliance.application.controller;
+
+import com.stablecoin.payments.compliance.api.request.InitiateComplianceCheckRequest;
+import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse;
+import com.stablecoin.payments.compliance.application.service.ComplianceCheckApplicationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/compliance")
+@RequiredArgsConstructor
+public class ComplianceCheckController {
+
+    private final ComplianceCheckApplicationService complianceCheckApplicationService;
+
+    @PostMapping("/check")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ComplianceCheckResponse initiateCheck(
+            @Valid @RequestBody InitiateComplianceCheckRequest request) {
+        log.info("POST /v1/compliance/check paymentId={}", request.paymentId());
+        return complianceCheckApplicationService.initiateCheck(request);
+    }
+
+    @GetMapping("/checks/{checkId}")
+    public ComplianceCheckResponse getCheck(@PathVariable UUID checkId) {
+        log.info("GET /v1/compliance/checks/{}", checkId);
+        return complianceCheckApplicationService.getCheck(checkId);
+    }
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/application/controller/CustomerRiskProfileController.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/application/controller/CustomerRiskProfileController.java
@@ -1,0 +1,27 @@
+package com.stablecoin.payments.compliance.application.controller;
+
+import com.stablecoin.payments.compliance.api.response.CustomerRiskProfileResponse;
+import com.stablecoin.payments.compliance.application.service.ComplianceCheckApplicationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/customers")
+@RequiredArgsConstructor
+public class CustomerRiskProfileController {
+
+    private final ComplianceCheckApplicationService complianceCheckApplicationService;
+
+    @GetMapping("/{customerId}/risk-profile")
+    public CustomerRiskProfileResponse getRiskProfile(@PathVariable UUID customerId) {
+        log.info("GET /v1/customers/{}/risk-profile", customerId);
+        return complianceCheckApplicationService.getCustomerRiskProfile(customerId);
+    }
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/persistence/ComplianceCheckPersistenceAdapter.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/persistence/ComplianceCheckPersistenceAdapter.java
@@ -59,7 +59,9 @@ public class ComplianceCheckPersistenceAdapter implements ComplianceCheckReposit
             if (existingKyc.isPresent()) {
                 savedKyc = existingKyc.get();
             } else {
-                savedKyc = kycJpa.save(kycMapper.toEntity(check.kycResult()));
+                var kycEntity = kycMapper.toEntity(check.kycResult());
+                kycEntity.setCheckId(check.checkId());
+                savedKyc = kycJpa.save(kycEntity);
             }
         }
 
@@ -69,7 +71,9 @@ public class ComplianceCheckPersistenceAdapter implements ComplianceCheckReposit
             if (existingSanctions.isPresent()) {
                 savedSanctions = existingSanctions.get();
             } else {
-                savedSanctions = sanctionsJpa.save(sanctionsMapper.toEntity(check.sanctionsResult()));
+                var sanctionsEntity = sanctionsMapper.toEntity(check.sanctionsResult());
+                sanctionsEntity.setCheckId(check.checkId());
+                savedSanctions = sanctionsJpa.save(sanctionsEntity);
             }
         }
 
@@ -79,7 +83,9 @@ public class ComplianceCheckPersistenceAdapter implements ComplianceCheckReposit
             if (existingAml.isPresent()) {
                 savedAml = existingAml.get();
             } else {
-                savedAml = amlJpa.save(amlMapper.toEntity(check.amlResult()));
+                var amlEntity = amlMapper.toEntity(check.amlResult());
+                amlEntity.setCheckId(check.checkId());
+                savedAml = amlJpa.save(amlEntity);
             }
         }
 

--- a/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/application/controller/ComplianceCheckControllerTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/application/controller/ComplianceCheckControllerTest.java
@@ -1,0 +1,132 @@
+package com.stablecoin.payments.compliance.application.controller;
+
+import com.stablecoin.payments.compliance.api.request.InitiateComplianceCheckRequest;
+import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse;
+import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse.KycResultResponse;
+import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse.RiskScoreResponse;
+import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse.SanctionsResultResponse;
+import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse.TravelRuleResponse;
+import com.stablecoin.payments.compliance.application.service.ComplianceCheckApplicationService;
+import com.stablecoin.payments.compliance.domain.exception.CheckNotFoundException;
+import com.stablecoin.payments.compliance.domain.exception.DuplicatePaymentException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ComplianceCheckController")
+class ComplianceCheckControllerTest {
+
+    @Mock
+    private ComplianceCheckApplicationService applicationService;
+
+    @InjectMocks
+    private ComplianceCheckController controller;
+
+    @Nested
+    @DisplayName("POST /v1/compliance/check")
+    class InitiateCheck {
+
+        @Test
+        @DisplayName("should delegate to application service and return response")
+        void shouldInitiateCheck() {
+            // given
+            var request = new InitiateComplianceCheckRequest(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                    new BigDecimal("1000.00"), "USD", "US", "DE", "EUR");
+
+            var checkId = UUID.randomUUID();
+            var now = Instant.now();
+            var expectedResponse = new ComplianceCheckResponse(
+                    checkId, request.paymentId(), "PASSED", "PASSED",
+                    new RiskScoreResponse(18, "LOW", List.of("ESTABLISHED_CUSTOMER")),
+                    new KycResultResponse("VERIFIED", "VERIFIED", "KYC_TIER_2"),
+                    new SanctionsResultResponse(false, false, List.of("OFAC", "EU", "UN")),
+                    new TravelRuleResponse("IVMS101", "TRANSMITTED"),
+                    null, null, now, now);
+
+            given(applicationService.initiateCheck(request)).willReturn(expectedResponse);
+
+            // when
+            var result = controller.initiateCheck(request);
+
+            // then
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedResponse);
+        }
+
+        @Test
+        @DisplayName("should propagate DuplicatePaymentException")
+        void shouldPropagateOnDuplicate() {
+            // given
+            var paymentId = UUID.randomUUID();
+            var request = new InitiateComplianceCheckRequest(
+                    paymentId, UUID.randomUUID(), UUID.randomUUID(),
+                    new BigDecimal("1000.00"), "USD", "US", "DE", "EUR");
+
+            given(applicationService.initiateCheck(request))
+                    .willThrow(new DuplicatePaymentException(paymentId));
+
+            // when/then
+            assertThatThrownBy(() -> controller.initiateCheck(request))
+                    .isInstanceOf(DuplicatePaymentException.class)
+                    .hasMessageContaining(paymentId.toString());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/compliance/checks/{checkId}")
+    class GetCheck {
+
+        @Test
+        @DisplayName("should delegate to application service and return response")
+        void shouldGetCheck() {
+            // given
+            var checkId = UUID.randomUUID();
+            var paymentId = UUID.randomUUID();
+            var now = Instant.now();
+            var expectedResponse = new ComplianceCheckResponse(
+                    checkId, paymentId, "PENDING", null,
+                    null, null, null, null,
+                    null, null, now, null);
+
+            given(applicationService.getCheck(checkId)).willReturn(expectedResponse);
+
+            // when
+            var result = controller.getCheck(checkId);
+
+            // then
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedResponse);
+        }
+
+        @Test
+        @DisplayName("should propagate CheckNotFoundException")
+        void shouldPropagateOnNotFound() {
+            // given
+            var checkId = UUID.randomUUID();
+            given(applicationService.getCheck(checkId))
+                    .willThrow(new CheckNotFoundException(checkId));
+
+            // when/then
+            assertThatThrownBy(() -> controller.getCheck(checkId))
+                    .isInstanceOf(CheckNotFoundException.class)
+                    .hasMessageContaining(checkId.toString());
+        }
+    }
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/application/controller/CustomerRiskProfileControllerTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/application/controller/CustomerRiskProfileControllerTest.java
@@ -1,0 +1,66 @@
+package com.stablecoin.payments.compliance.application.controller;
+
+import com.stablecoin.payments.compliance.api.response.CustomerRiskProfileResponse;
+import com.stablecoin.payments.compliance.application.service.ComplianceCheckApplicationService;
+import com.stablecoin.payments.compliance.domain.exception.CustomerNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomerRiskProfileController")
+class CustomerRiskProfileControllerTest {
+
+    @Mock
+    private ComplianceCheckApplicationService applicationService;
+
+    @InjectMocks
+    private CustomerRiskProfileController controller;
+
+    @Test
+    @DisplayName("should delegate to application service and return risk profile")
+    void shouldGetRiskProfile() {
+        // given
+        var customerId = UUID.randomUUID();
+        var now = Instant.now();
+        var expectedResponse = new CustomerRiskProfileResponse(
+                customerId, "KYC_TIER_2", now, "LOW", 20,
+                new BigDecimal("10000.00"), new BigDecimal("50000.00"),
+                new BigDecimal("500000.00"), now);
+
+        given(applicationService.getCustomerRiskProfile(customerId)).willReturn(expectedResponse);
+
+        // when
+        var result = controller.getRiskProfile(customerId);
+
+        // then
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("should propagate CustomerNotFoundException")
+    void shouldPropagateOnNotFound() {
+        // given
+        var customerId = UUID.randomUUID();
+        given(applicationService.getCustomerRiskProfile(customerId))
+                .willThrow(new CustomerNotFoundException(customerId));
+
+        // when/then
+        assertThatThrownBy(() -> controller.getRiskProfile(customerId))
+                .isInstanceOf(CustomerNotFoundException.class)
+                .hasMessageContaining(customerId.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ComplianceCheckController` with `POST /v1/compliance/check` (202) and `GET /v1/compliance/checks/{checkId}` endpoints
- Add `CustomerRiskProfileController` with `GET /v1/customers/{customerId}/risk-profile` endpoint
- Fix null FK violation in `ComplianceCheckPersistenceAdapter` for child entities
- 6 unit tests + 10 integration tests (26 total IT)

## Test plan
- [x] Unit tests pass (210+ total)
- [x] Integration tests pass (26 total)
- [x] Spotless formatting clean
- [x] Full build green

Closes STA-90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added compliance check endpoint to initiate and retrieve compliance checks.
  * Added customer risk profile endpoint to retrieve risk assessment data by customer ID.

* **Tests**
  * Added comprehensive integration test coverage for compliance and risk profile endpoints.
  * Added unit tests for endpoint behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->