### PR TITLE
refactor(s2): move pipeline orchestration to domain CommandHandler

### DIFF
--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/application/service/ComplianceCheckApplicationService.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/application/service/ComplianceCheckApplicationService.java
@@ -4,233 +4,41 @@ import com.stablecoin.payments.compliance.api.request.InitiateComplianceCheckReq
 import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse;
 import com.stablecoin.payments.compliance.api.response.CustomerRiskProfileResponse;
 import com.stablecoin.payments.compliance.application.mapper.ComplianceCheckResponseMapper;
-import com.stablecoin.payments.compliance.domain.event.ComplianceCheckFailed;
-import com.stablecoin.payments.compliance.domain.event.ComplianceCheckPassed;
-import com.stablecoin.payments.compliance.domain.event.SanctionsHitEvent;
-import com.stablecoin.payments.compliance.domain.exception.CheckNotFoundException;
-import com.stablecoin.payments.compliance.domain.exception.CustomerNotFoundException;
-import com.stablecoin.payments.compliance.domain.exception.DuplicatePaymentException;
-import com.stablecoin.payments.compliance.domain.model.ComplianceCheck;
 import com.stablecoin.payments.compliance.domain.model.Money;
-import com.stablecoin.payments.compliance.domain.model.RiskScoringContext;
-import com.stablecoin.payments.compliance.domain.model.TransmissionStatus;
-import com.stablecoin.payments.compliance.domain.model.TravelRulePackage;
-import com.stablecoin.payments.compliance.domain.model.TravelRuleProtocol;
-import com.stablecoin.payments.compliance.domain.model.VaspInfo;
-import com.stablecoin.payments.compliance.domain.port.AmlProvider;
-import com.stablecoin.payments.compliance.domain.port.ComplianceCheckRepository;
-import com.stablecoin.payments.compliance.domain.port.CustomerRiskProfileRepository;
-import com.stablecoin.payments.compliance.domain.port.EventPublisher;
-import com.stablecoin.payments.compliance.domain.port.KycProvider;
-import com.stablecoin.payments.compliance.domain.port.SanctionsProvider;
-import com.stablecoin.payments.compliance.domain.port.TravelRuleProvider;
-import com.stablecoin.payments.compliance.domain.service.ComplianceCheckService;
-import com.stablecoin.payments.compliance.domain.service.RiskScoringService;
+import com.stablecoin.payments.compliance.domain.service.ComplianceCheckCommandHandler;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.util.UUID;
 
-@Slf4j
+/**
+ * Thin application service that maps API DTOs to domain objects and delegates
+ * all business logic to the {@link ComplianceCheckCommandHandler}.
+ */
 @Service
 @RequiredArgsConstructor
 public class ComplianceCheckApplicationService {
 
-    private final ComplianceCheckRepository checkRepository;
-    private final CustomerRiskProfileRepository profileRepository;
-    private final KycProvider kycProvider;
-    private final SanctionsProvider sanctionsProvider;
-    private final AmlProvider amlProvider;
-    private final TravelRuleProvider travelRuleProvider;
-    private final ComplianceCheckService complianceCheckService;
-    private final RiskScoringService riskScoringService;
-    private final EventPublisher<Object> eventPublisher;
+    private final ComplianceCheckCommandHandler commandHandler;
     private final ComplianceCheckResponseMapper responseMapper;
 
     @Transactional
     public ComplianceCheckResponse initiateCheck(InitiateComplianceCheckRequest request) {
-        log.info("Initiating compliance check for payment={}", request.paymentId());
-
-        checkRepository.findByPaymentId(request.paymentId())
-                .ifPresent(existing -> {
-                    throw new DuplicatePaymentException(request.paymentId());
-                });
-
-        var check = complianceCheckService.initiate(
-                request.paymentId(),
-                request.senderId(),
-                request.recipientId(),
+        var check = commandHandler.initiateCheck(
+                request.paymentId(), request.senderId(), request.recipientId(),
                 new Money(request.amount(), request.currency()),
-                request.sourceCountry(),
-                request.targetCountry(),
-                request.targetCurrency());
-
-        check = runPipeline(check);
-
-        var saved = checkRepository.save(check);
-        publishEvents(saved);
-
-        log.info("Compliance check completed for payment={}, status={}, result={}",
-                saved.paymentId(), saved.status(), saved.overallResult());
-
-        return responseMapper.toResponse(saved);
-    }
-
-    @Transactional(readOnly = true)
-    public ComplianceCheckResponse getCheck(UUID checkId) {
-        var check = checkRepository.findById(checkId)
-                .orElseThrow(() -> new CheckNotFoundException(checkId));
+                request.sourceCountry(), request.targetCountry(), request.targetCurrency());
         return responseMapper.toResponse(check);
     }
 
     @Transactional(readOnly = true)
+    public ComplianceCheckResponse getCheck(UUID checkId) {
+        return responseMapper.toResponse(commandHandler.getCheck(checkId));
+    }
+
+    @Transactional(readOnly = true)
     public CustomerRiskProfileResponse getCustomerRiskProfile(UUID customerId) {
-        var profile = profileRepository.findByCustomerId(customerId)
-                .orElseThrow(() -> new CustomerNotFoundException(customerId));
-        return responseMapper.toResponse(profile);
-    }
-
-    private ComplianceCheck runPipeline(ComplianceCheck check) {
-        // Step 1: KYC verification
-        var kycResult = kycProvider.verify(check.senderId(), check.recipientId());
-        check = complianceCheckService.recordKycResult(check, kycResult);
-        if (check.isTerminal()) {
-            return check;
-        }
-
-        // Step 2: Sanctions screening
-        var sanctionsResult = sanctionsProvider.screen(check.senderId(), check.recipientId());
-        check = complianceCheckService.recordSanctionsResult(check, sanctionsResult);
-        if (check.isTerminal()) {
-            return check;
-        }
-
-        // Step 3: AML analysis
-        var amlResult = amlProvider.analyze(check.senderId(), check.recipientId());
-        check = complianceCheckService.recordAmlResult(check, amlResult);
-        if (check.isTerminal()) {
-            return check;
-        }
-
-        // Step 4: Risk scoring
-        var profile = profileRepository.findByCustomerId(check.senderId()).orElse(null);
-        var context = RiskScoringContext.builder()
-                .check(check)
-                .customerProfile(profile)
-                .recentTransactionCount(0)
-                .build();
-        var riskScore = riskScoringService.calculateScore(context);
-        check = complianceCheckService.recordRiskScore(check, riskScore);
-        if (check.isTerminal()) {
-            return check;
-        }
-
-        // Step 5: Travel rule packaging
-        if (complianceCheckService.requiresTravelRule(check)) {
-            check = handleTravelRule(check);
-        } else {
-            check = complianceCheckService.skipTravelRule(check);
-        }
-
-        return check;
-    }
-
-    private ComplianceCheck handleTravelRule(ComplianceCheck check) {
-        var travelRulePackage = TravelRulePackage.builder()
-                .packageId(UUID.randomUUID())
-                .checkId(check.checkId())
-                .originatorVasp(new VaspInfo("vasp-originator", "StableBridge", check.sourceCountry(), null))
-                .beneficiaryVasp(new VaspInfo("vasp-beneficiary", "StableBridge", check.targetCountry(), null))
-                .originatorData("{}")
-                .beneficiaryData("{}")
-                .protocol(TravelRuleProtocol.IVMS101)
-                .transmissionStatus(TransmissionStatus.PENDING)
-                .build();
-
-        try {
-            var protocolRef = travelRuleProvider.transmit(travelRulePackage);
-            travelRulePackage = travelRulePackage.toBuilder()
-                    .transmissionStatus(TransmissionStatus.TRANSMITTED)
-                    .transmittedAt(Instant.now())
-                    .protocolRef(protocolRef)
-                    .build();
-            return complianceCheckService.recordTravelRuleResult(check, travelRulePackage);
-        } catch (Exception e) {
-            log.error("Travel rule transmission failed for check={}: {}", check.checkId(), e.getMessage());
-            return check.failTravelRule("Travel rule transmission failed: " + e.getMessage());
-        }
-    }
-
-    private void publishEvents(ComplianceCheck check) {
-        if (check.overallResult() == null) {
-            return;
-        }
-
-        switch (check.overallResult()) {
-            case PASSED -> eventPublisher.publish(new ComplianceCheckPassed(
-                    check.checkId(),
-                    check.paymentId(),
-                    check.correlationId(),
-                    check.riskScore() != null ? check.riskScore().score() : 0,
-                    check.riskScore() != null ? check.riskScore().band().name() : null,
-                    check.travelRulePackage() != null ? check.travelRulePackage().protocolRef() : null,
-                    check.completedAt()));
-
-            case FAILED -> eventPublisher.publish(new ComplianceCheckFailed(
-                    check.checkId(),
-                    check.paymentId(),
-                    check.correlationId(),
-                    check.errorMessage(),
-                    check.errorCode(),
-                    check.completedAt()));
-
-            case SANCTIONS_HIT -> {
-                eventPublisher.publish(new ComplianceCheckFailed(
-                        check.checkId(),
-                        check.paymentId(),
-                        check.correlationId(),
-                        check.errorMessage(),
-                        check.errorCode(),
-                        check.completedAt()));
-                publishSanctionsHitEvent(check);
-            }
-
-            case MANUAL_REVIEW -> eventPublisher.publish(new ComplianceCheckFailed(
-                    check.checkId(),
-                    check.paymentId(),
-                    check.correlationId(),
-                    check.errorMessage(),
-                    check.errorCode(),
-                    check.completedAt()));
-        }
-    }
-
-    private void publishSanctionsHitEvent(ComplianceCheck check) {
-        var sanctions = check.sanctionsResult();
-        if (sanctions == null) {
-            return;
-        }
-
-        String hitParty;
-        if (sanctions.senderHit() && sanctions.recipientHit()) {
-            hitParty = "BOTH";
-        } else if (sanctions.senderHit()) {
-            hitParty = "SENDER";
-        } else {
-            hitParty = "RECIPIENT";
-        }
-
-        var listsChecked = sanctions.listsChecked();
-        eventPublisher.publish(new SanctionsHitEvent(
-                check.checkId(),
-                check.paymentId(),
-                check.correlationId(),
-                hitParty,
-                listsChecked != null && !listsChecked.isEmpty() ? listsChecked.getFirst() : "UNKNOWN",
-                sanctions.hitDetails(),
-                check.completedAt()));
+        return responseMapper.toResponse(commandHandler.getCustomerRiskProfile(customerId));
     }
 }

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/domain/service/ComplianceCheckCommandHandler.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/domain/service/ComplianceCheckCommandHandler.java
@@ -1,0 +1,247 @@
+package com.stablecoin.payments.compliance.domain.service;
+
+import com.stablecoin.payments.compliance.domain.event.ComplianceCheckFailed;
+import com.stablecoin.payments.compliance.domain.event.ComplianceCheckPassed;
+import com.stablecoin.payments.compliance.domain.event.SanctionsHitEvent;
+import com.stablecoin.payments.compliance.domain.exception.CheckNotFoundException;
+import com.stablecoin.payments.compliance.domain.exception.CustomerNotFoundException;
+import com.stablecoin.payments.compliance.domain.exception.DuplicatePaymentException;
+import com.stablecoin.payments.compliance.domain.model.ComplianceCheck;
+import com.stablecoin.payments.compliance.domain.model.CustomerRiskProfile;
+import com.stablecoin.payments.compliance.domain.model.Money;
+import com.stablecoin.payments.compliance.domain.model.RiskScoringContext;
+import com.stablecoin.payments.compliance.domain.model.TransmissionStatus;
+import com.stablecoin.payments.compliance.domain.model.TravelRulePackage;
+import com.stablecoin.payments.compliance.domain.model.TravelRuleProtocol;
+import com.stablecoin.payments.compliance.domain.model.VaspInfo;
+import com.stablecoin.payments.compliance.domain.port.AmlProvider;
+import com.stablecoin.payments.compliance.domain.port.ComplianceCheckRepository;
+import com.stablecoin.payments.compliance.domain.port.CustomerRiskProfileRepository;
+import com.stablecoin.payments.compliance.domain.port.EventPublisher;
+import com.stablecoin.payments.compliance.domain.port.KycProvider;
+import com.stablecoin.payments.compliance.domain.port.SanctionsProvider;
+import com.stablecoin.payments.compliance.domain.port.TravelRuleProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Domain command handler that orchestrates the compliance check pipeline.
+ * <p>
+ * Coordinates KYC, sanctions, AML, risk scoring, and travel rule sub-checks
+ * through provider ports, persists the aggregate via the repository port,
+ * and publishes domain events via the event publisher port.
+ */
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ComplianceCheckCommandHandler {
+
+    private final ComplianceCheckRepository checkRepository;
+    private final CustomerRiskProfileRepository profileRepository;
+    private final KycProvider kycProvider;
+    private final SanctionsProvider sanctionsProvider;
+    private final AmlProvider amlProvider;
+    private final TravelRuleProvider travelRuleProvider;
+    private final ComplianceCheckService complianceCheckService;
+    private final RiskScoringService riskScoringService;
+    private final EventPublisher<Object> eventPublisher;
+
+    /**
+     * Initiates a new compliance check for a payment.
+     *
+     * @throws DuplicatePaymentException if a check already exists for the payment
+     */
+    public ComplianceCheck initiateCheck(UUID paymentId, UUID senderId, UUID recipientId,
+                                         Money sourceAmount, String sourceCountry,
+                                         String targetCountry, String targetCurrency) {
+        log.info("Initiating compliance check for payment={}", paymentId);
+
+        checkRepository.findByPaymentId(paymentId)
+                .ifPresent(existing -> {
+                    throw new DuplicatePaymentException(paymentId);
+                });
+
+        var check = complianceCheckService.initiate(
+                paymentId, senderId, recipientId,
+                sourceAmount, sourceCountry, targetCountry, targetCurrency);
+
+        check = runPipeline(check);
+
+        var saved = checkRepository.save(check);
+        publishEvents(saved);
+
+        log.info("Compliance check completed for payment={}, status={}, result={}",
+                saved.paymentId(), saved.status(), saved.overallResult());
+
+        return saved;
+    }
+
+    /**
+     * Retrieves a compliance check by its ID.
+     *
+     * @throws CheckNotFoundException if no check exists with the given ID
+     */
+    @Transactional(readOnly = true)
+    public ComplianceCheck getCheck(UUID checkId) {
+        return checkRepository.findById(checkId)
+                .orElseThrow(() -> new CheckNotFoundException(checkId));
+    }
+
+    /**
+     * Retrieves a customer risk profile by customer ID.
+     *
+     * @throws CustomerNotFoundException if no profile exists for the customer
+     */
+    @Transactional(readOnly = true)
+    public CustomerRiskProfile getCustomerRiskProfile(UUID customerId) {
+        return profileRepository.findByCustomerId(customerId)
+                .orElseThrow(() -> new CustomerNotFoundException(customerId));
+    }
+
+    private ComplianceCheck runPipeline(ComplianceCheck check) {
+        // Step 1: KYC verification
+        var kycResult = kycProvider.verify(check.senderId(), check.recipientId());
+        check = complianceCheckService.recordKycResult(check, kycResult);
+        if (check.isTerminal()) {
+            return check;
+        }
+
+        // Step 2: Sanctions screening
+        var sanctionsResult = sanctionsProvider.screen(check.senderId(), check.recipientId());
+        check = complianceCheckService.recordSanctionsResult(check, sanctionsResult);
+        if (check.isTerminal()) {
+            return check;
+        }
+
+        // Step 3: AML analysis
+        var amlResult = amlProvider.analyze(check.senderId(), check.recipientId());
+        check = complianceCheckService.recordAmlResult(check, amlResult);
+        if (check.isTerminal()) {
+            return check;
+        }
+
+        // Step 4: Risk scoring
+        var profile = profileRepository.findByCustomerId(check.senderId()).orElse(null);
+        var context = RiskScoringContext.builder()
+                .check(check)
+                .customerProfile(profile)
+                .recentTransactionCount(0)
+                .build();
+        var riskScore = riskScoringService.calculateScore(context);
+        check = complianceCheckService.recordRiskScore(check, riskScore);
+        if (check.isTerminal()) {
+            return check;
+        }
+
+        // Step 5: Travel rule packaging
+        if (complianceCheckService.requiresTravelRule(check)) {
+            check = handleTravelRule(check);
+        } else {
+            check = complianceCheckService.skipTravelRule(check);
+        }
+
+        return check;
+    }
+
+    private ComplianceCheck handleTravelRule(ComplianceCheck check) {
+        var travelRulePackage = TravelRulePackage.builder()
+                .packageId(UUID.randomUUID())
+                .checkId(check.checkId())
+                .originatorVasp(new VaspInfo("vasp-originator", "StableBridge", check.sourceCountry(), null))
+                .beneficiaryVasp(new VaspInfo("vasp-beneficiary", "StableBridge", check.targetCountry(), null))
+                .originatorData("{}")
+                .beneficiaryData("{}")
+                .protocol(TravelRuleProtocol.IVMS101)
+                .transmissionStatus(TransmissionStatus.PENDING)
+                .build();
+
+        try {
+            var protocolRef = travelRuleProvider.transmit(travelRulePackage);
+            travelRulePackage = travelRulePackage.toBuilder()
+                    .transmissionStatus(TransmissionStatus.TRANSMITTED)
+                    .transmittedAt(Instant.now())
+                    .protocolRef(protocolRef)
+                    .build();
+            return complianceCheckService.recordTravelRuleResult(check, travelRulePackage);
+        } catch (Exception e) {
+            log.error("Travel rule transmission failed for check={}: {}", check.checkId(), e.getMessage());
+            return check.failTravelRule("Travel rule transmission failed: " + e.getMessage());
+        }
+    }
+
+    private void publishEvents(ComplianceCheck check) {
+        if (check.overallResult() == null) {
+            return;
+        }
+
+        switch (check.overallResult()) {
+            case PASSED -> eventPublisher.publish(new ComplianceCheckPassed(
+                    check.checkId(),
+                    check.paymentId(),
+                    check.correlationId(),
+                    check.riskScore() != null ? check.riskScore().score() : 0,
+                    check.riskScore() != null ? check.riskScore().band().name() : null,
+                    check.travelRulePackage() != null ? check.travelRulePackage().protocolRef() : null,
+                    check.completedAt()));
+
+            case FAILED -> eventPublisher.publish(new ComplianceCheckFailed(
+                    check.checkId(),
+                    check.paymentId(),
+                    check.correlationId(),
+                    check.errorMessage(),
+                    check.errorCode(),
+                    check.completedAt()));
+
+            case SANCTIONS_HIT -> {
+                eventPublisher.publish(new ComplianceCheckFailed(
+                        check.checkId(),
+                        check.paymentId(),
+                        check.correlationId(),
+                        check.errorMessage(),
+                        check.errorCode(),
+                        check.completedAt()));
+                publishSanctionsHitEvent(check);
+            }
+
+            case MANUAL_REVIEW -> eventPublisher.publish(new ComplianceCheckFailed(
+                    check.checkId(),
+                    check.paymentId(),
+                    check.correlationId(),
+                    check.errorMessage(),
+                    check.errorCode(),
+                    check.completedAt()));
+        }
+    }
+
+    private void publishSanctionsHitEvent(ComplianceCheck check) {
+        var sanctions = check.sanctionsResult();
+        if (sanctions == null) {
+            return;
+        }
+
+        String hitParty;
+        if (sanctions.senderHit() && sanctions.recipientHit()) {
+            hitParty = "BOTH";
+        } else if (sanctions.senderHit()) {
+            hitParty = "SENDER";
+        } else {
+            hitParty = "RECIPIENT";
+        }
+
+        var listsChecked = sanctions.listsChecked();
+        eventPublisher.publish(new SanctionsHitEvent(
+                check.checkId(),
+                check.paymentId(),
+                check.correlationId(),
+                hitParty,
+                listsChecked != null && !listsChecked.isEmpty() ? listsChecked.getFirst() : "UNKNOWN",
+                sanctions.hitDetails(),
+                check.completedAt()));
+    }
+}

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/domain/service/package-info.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/domain/service/package-info.java
@@ -1,8 +1,12 @@
 /**
  * Domain services for compliance orchestration.
  * <p>
- * {@link com.stablecoin.payments.compliance.domain.service.ComplianceCheckService} orchestrates the
- * sub-check pipeline (KYC, sanctions, AML, risk scoring, travel rule).
+ * {@link com.stablecoin.payments.compliance.domain.service.ComplianceCheckCommandHandler} orchestrates
+ * the full compliance pipeline (KYC, sanctions, AML, risk scoring, travel rule), coordinates
+ * persistence and event publishing through domain ports.
+ * <p>
+ * {@link com.stablecoin.payments.compliance.domain.service.ComplianceCheckService} provides
+ * state-transition helper methods for individual sub-checks.
  * <p>
  * {@link com.stablecoin.payments.compliance.domain.service.RiskScoringService} calculates risk scores
  * from multiple factors.

--- a/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/application/service/ComplianceCheckApplicationServiceTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/application/service/ComplianceCheckApplicationServiceTest.java
@@ -2,459 +2,101 @@ package com.stablecoin.payments.compliance.application.service;
 
 import com.stablecoin.payments.compliance.api.request.InitiateComplianceCheckRequest;
 import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse;
-import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse.KycResultResponse;
-import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse.SanctionsResultResponse;
-import com.stablecoin.payments.compliance.api.response.ComplianceCheckResponse.TravelRuleResponse;
 import com.stablecoin.payments.compliance.api.response.CustomerRiskProfileResponse;
 import com.stablecoin.payments.compliance.application.mapper.ComplianceCheckResponseMapper;
-import com.stablecoin.payments.compliance.domain.event.ComplianceCheckFailed;
-import com.stablecoin.payments.compliance.domain.event.ComplianceCheckPassed;
-import com.stablecoin.payments.compliance.domain.event.SanctionsHitEvent;
-import com.stablecoin.payments.compliance.domain.exception.CheckNotFoundException;
-import com.stablecoin.payments.compliance.domain.exception.CustomerNotFoundException;
-import com.stablecoin.payments.compliance.domain.exception.DuplicatePaymentException;
-import com.stablecoin.payments.compliance.domain.model.ComplianceCheck;
-import com.stablecoin.payments.compliance.domain.model.RiskScoringWeights;
-import com.stablecoin.payments.compliance.domain.port.AmlProvider;
-import com.stablecoin.payments.compliance.domain.port.ComplianceCheckRepository;
-import com.stablecoin.payments.compliance.domain.port.CustomerRiskProfileRepository;
-import com.stablecoin.payments.compliance.domain.port.EventPublisher;
-import com.stablecoin.payments.compliance.domain.port.KycProvider;
-import com.stablecoin.payments.compliance.domain.port.SanctionsProvider;
-import com.stablecoin.payments.compliance.domain.port.TravelRuleProvider;
-import com.stablecoin.payments.compliance.domain.service.ComplianceCheckService;
-import com.stablecoin.payments.compliance.domain.service.RiskScoringService;
-import org.junit.jupiter.api.BeforeEach;
+import com.stablecoin.payments.compliance.domain.model.Money;
+import com.stablecoin.payments.compliance.domain.service.ComplianceCheckCommandHandler;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
-import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aKycRejectedResult;
-import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aKycResult;
-import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aSanctionsClearResult;
-import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aSanctionsHitResult;
-import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.anAmlClearResult;
-import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.anAmlFlaggedResult;
+import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aPendingCheck;
 import static com.stablecoin.payments.compliance.fixtures.CustomerRiskProfileFixtures.aRiskProfile;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class ComplianceCheckApplicationServiceTest {
 
-    @Mock private ComplianceCheckRepository checkRepository;
-    @Mock private CustomerRiskProfileRepository profileRepository;
-    @Mock private KycProvider kycProvider;
-    @Mock private SanctionsProvider sanctionsProvider;
-    @Mock private AmlProvider amlProvider;
-    @Mock private TravelRuleProvider travelRuleProvider;
-    @Mock private EventPublisher<Object> eventPublisher;
+    @Mock private ComplianceCheckCommandHandler commandHandler;
+    @Mock private ComplianceCheckResponseMapper responseMapper;
 
-    private ComplianceCheckService complianceCheckService;
-    private RiskScoringService riskScoringService;
-    private ComplianceCheckResponseMapper responseMapper;
+    @InjectMocks
     private ComplianceCheckApplicationService service;
 
-    @BeforeEach
-    void setUp() {
-        complianceCheckService = new ComplianceCheckService();
-        riskScoringService = new RiskScoringService(RiskScoringWeights.defaults());
-        responseMapper = new ComplianceCheckResponseMapper();
-        service = new ComplianceCheckApplicationService(
-                checkRepository, profileRepository,
-                kycProvider, sanctionsProvider, amlProvider, travelRuleProvider,
-                complianceCheckService, riskScoringService,
-                eventPublisher, responseMapper);
-    }
-
-    private static InitiateComplianceCheckRequest aValidRequest() {
-        return new InitiateComplianceCheckRequest(
+    @Test
+    @DisplayName("initiateCheck should delegate to commandHandler and map response")
+    void initiateCheckShouldDelegateAndMap() {
+        var request = new InitiateComplianceCheckRequest(
                 UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
                 new BigDecimal("1000.00"), "USD", "US", "DE", "EUR");
+        var domainCheck = aPendingCheck();
+        var expectedResponse = new ComplianceCheckResponse(
+                domainCheck.checkId(), domainCheck.paymentId(), "PENDING",
+                null, null, null, null, null, null, null,
+                domainCheck.createdAt(), null);
+
+        given(commandHandler.initiateCheck(
+                request.paymentId(), request.senderId(), request.recipientId(),
+                new Money(request.amount(), request.currency()),
+                request.sourceCountry(), request.targetCountry(), request.targetCurrency()))
+                .willReturn(domainCheck);
+        given(responseMapper.toResponse(domainCheck)).willReturn(expectedResponse);
+
+        var result = service.initiateCheck(request);
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponse);
     }
 
-    private static InitiateComplianceCheckRequest aBelowThresholdRequest() {
-        return new InitiateComplianceCheckRequest(
-                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
-                new BigDecimal("500.00"), "USD", "US", "DE", "EUR");
+    @Test
+    @DisplayName("getCheck should delegate to commandHandler and map response")
+    void getCheckShouldDelegateAndMap() {
+        var checkId = UUID.randomUUID();
+        var domainCheck = aPendingCheck();
+        var expectedResponse = new ComplianceCheckResponse(
+                domainCheck.checkId(), domainCheck.paymentId(), "PENDING",
+                null, null, null, null, null, null, null,
+                domainCheck.createdAt(), null);
+
+        given(commandHandler.getCheck(checkId)).willReturn(domainCheck);
+        given(responseMapper.toResponse(domainCheck)).willReturn(expectedResponse);
+
+        var result = service.getCheck(checkId);
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponse);
+        then(commandHandler).should().getCheck(checkId);
     }
 
-    @Nested
-    @DisplayName("Happy path — full pipeline")
-    class HappyPath {
+    @Test
+    @DisplayName("getCustomerRiskProfile should delegate to commandHandler and map response")
+    void getCustomerRiskProfileShouldDelegateAndMap() {
+        var customerId = UUID.randomUUID();
+        var profile = aRiskProfile().toBuilder().customerId(customerId).build();
+        var expectedResponse = new CustomerRiskProfileResponse(
+                customerId, "KYC_TIER_2", profile.kycVerifiedAt(),
+                "LOW", 20,
+                profile.perTxnLimitUsd(), profile.dailyLimitUsd(),
+                profile.monthlyLimitUsd(), profile.lastScoredAt());
 
-        @Test
-        @DisplayName("should complete full pipeline and return PASSED")
-        void shouldCompleteFullPipeline() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(request.senderId(), request.recipientId()))
-                    .willReturn(aKycResult(null));
-            given(sanctionsProvider.screen(request.senderId(), request.recipientId()))
-                    .willReturn(aSanctionsClearResult(null));
-            given(amlProvider.analyze(request.senderId(), request.recipientId()))
-                    .willReturn(anAmlClearResult(null));
-            given(profileRepository.findByCustomerId(request.senderId()))
-                    .willReturn(Optional.of(aRiskProfile()));
-            given(travelRuleProvider.transmit(any())).willReturn("tr-ref-123");
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
+        given(commandHandler.getCustomerRiskProfile(customerId)).willReturn(profile);
+        given(responseMapper.toResponse(profile)).willReturn(expectedResponse);
 
-            var response = service.initiateCheck(request);
+        var result = service.getCustomerRiskProfile(customerId);
 
-            var expected = new ComplianceCheckResponse(
-                    null, request.paymentId(), "PASSED", "PASSED",
-                    null,
-                    new KycResultResponse("VERIFIED", "VERIFIED", "KYC_TIER_2"),
-                    new SanctionsResultResponse(false, false, List.of("OFAC", "EU", "UN")),
-                    new TravelRuleResponse("IVMS101", "TRANSMITTED"),
-                    null, null, null, null);
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "createdAt", "completedAt", "riskScore",
-                            "errorCode", "errorMessage")
-                    .isEqualTo(expected);
-        }
-
-        @Test
-        @DisplayName("should publish ComplianceCheckPassed event")
-        void shouldPublishPassedEvent() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
-            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
-            given(amlProvider.analyze(any(), any())).willReturn(anAmlClearResult(null));
-            given(profileRepository.findByCustomerId(any())).willReturn(Optional.of(aRiskProfile()));
-            given(travelRuleProvider.transmit(any())).willReturn("tr-ref-123");
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            service.initiateCheck(request);
-
-            var captor = ArgumentCaptor.forClass(Object.class);
-            then(eventPublisher).should().publish(captor.capture());
-
-            var expected = new ComplianceCheckPassed(
-                    null, request.paymentId(), null, 0, null, null, null);
-
-            assertThat(captor.getValue())
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "correlationId", "riskScore", "riskBand",
-                            "travelRuleRef", "passedAt")
-                    .isEqualTo(expected);
-        }
-
-        @Test
-        @DisplayName("should skip travel rule for below-threshold amounts")
-        void shouldSkipTravelRuleBelowThreshold() {
-            var request = aBelowThresholdRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
-            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
-            given(amlProvider.analyze(any(), any())).willReturn(anAmlClearResult(null));
-            given(profileRepository.findByCustomerId(any())).willReturn(Optional.of(aRiskProfile()));
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            var response = service.initiateCheck(request);
-
-            var expected = new ComplianceCheckResponse(
-                    null, request.paymentId(), "PASSED", "PASSED",
-                    null, null, null, null, null, null, null, null);
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "createdAt", "completedAt", "riskScore",
-                            "kycResult", "sanctionsResult", "errorCode", "errorMessage")
-                    .isEqualTo(expected);
-            then(travelRuleProvider).should(never()).transmit(any());
-        }
-    }
-
-    @Nested
-    @DisplayName("KYC failure")
-    class KycFailure {
-
-        @Test
-        @DisplayName("should stop pipeline on KYC rejection")
-        void shouldStopOnKycRejection() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycRejectedResult(null));
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            var response = service.initiateCheck(request);
-
-            var expected = new ComplianceCheckResponse(
-                    null, request.paymentId(), "FAILED", "FAILED",
-                    null, null, null, null, null, null, null, null);
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "createdAt", "completedAt", "kycResult",
-                            "errorCode", "errorMessage")
-                    .isEqualTo(expected);
-            then(sanctionsProvider).should(never()).screen(any(), any());
-            then(amlProvider).should(never()).analyze(any(), any());
-        }
-
-        @Test
-        @DisplayName("should publish ComplianceCheckFailed event on KYC rejection")
-        void shouldPublishFailedEventOnKycRejection() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycRejectedResult(null));
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            service.initiateCheck(request);
-
-            var captor = ArgumentCaptor.forClass(Object.class);
-            then(eventPublisher).should().publish(captor.capture());
-
-            var expected = new ComplianceCheckFailed(
-                    null, request.paymentId(), null, null, null, null);
-            assertThat(captor.getValue())
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "correlationId", "reason", "errorCode", "failedAt")
-                    .isEqualTo(expected);
-        }
-    }
-
-    @Nested
-    @DisplayName("Sanctions hit")
-    class SanctionsHitPath {
-
-        @Test
-        @DisplayName("should stop pipeline on sanctions hit")
-        void shouldStopOnSanctionsHit() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
-            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsHitResult(null));
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            var response = service.initiateCheck(request);
-
-            var expected = new ComplianceCheckResponse(
-                    null, request.paymentId(), "SANCTIONS_HIT", "SANCTIONS_HIT",
-                    null, null, null, null, null, null, null, null);
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "createdAt", "completedAt", "kycResult",
-                            "sanctionsResult", "errorCode", "errorMessage")
-                    .isEqualTo(expected);
-            then(amlProvider).should(never()).analyze(any(), any());
-        }
-
-        @Test
-        @DisplayName("should publish both ComplianceCheckFailed and SanctionsHitEvent")
-        void shouldPublishSanctionsHitEvents() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
-            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsHitResult(null));
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            service.initiateCheck(request);
-
-            var captor = ArgumentCaptor.forClass(Object.class);
-            then(eventPublisher).should(times(2)).publish(captor.capture());
-            var events = captor.getAllValues();
-
-            var expectedFailed = new ComplianceCheckFailed(
-                    null, request.paymentId(), null, null, null, null);
-            assertThat(events.get(0))
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "correlationId", "reason", "errorCode", "failedAt")
-                    .isEqualTo(expectedFailed);
-
-            var expectedHit = new SanctionsHitEvent(
-                    null, request.paymentId(), null, "SENDER", "OFAC", null, null);
-            assertThat(events.get(1))
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "correlationId", "hitDetails", "detectedAt")
-                    .isEqualTo(expectedHit);
-        }
-    }
-
-    @Nested
-    @DisplayName("AML flagged")
-    class AmlFlaggedPath {
-
-        @Test
-        @DisplayName("should stop pipeline on AML flag and route to MANUAL_REVIEW")
-        void shouldStopOnAmlFlag() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
-            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
-            given(amlProvider.analyze(any(), any())).willReturn(anAmlFlaggedResult(null));
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            var response = service.initiateCheck(request);
-
-            var expected = new ComplianceCheckResponse(
-                    null, request.paymentId(), "MANUAL_REVIEW", "MANUAL_REVIEW",
-                    null, null, null, null, null, null, null, null);
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "createdAt", "completedAt", "riskScore",
-                            "kycResult", "sanctionsResult", "errorCode", "errorMessage")
-                    .isEqualTo(expected);
-            then(travelRuleProvider).should(never()).transmit(any());
-        }
-    }
-
-    @Nested
-    @DisplayName("Travel rule failure")
-    class TravelRuleFailure {
-
-        @Test
-        @DisplayName("should handle travel rule transmission failure gracefully")
-        void shouldHandleTravelRuleFailure() {
-            var request = aValidRequest();
-            given(checkRepository.findByPaymentId(request.paymentId())).willReturn(Optional.empty());
-            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
-            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
-            given(amlProvider.analyze(any(), any())).willReturn(anAmlClearResult(null));
-            given(profileRepository.findByCustomerId(any())).willReturn(Optional.of(aRiskProfile()));
-            given(travelRuleProvider.transmit(any())).willThrow(new RuntimeException("Network error"));
-            given(checkRepository.save(any(ComplianceCheck.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            var response = service.initiateCheck(request);
-
-            var expected = new ComplianceCheckResponse(
-                    null, request.paymentId(), "FAILED", "FAILED",
-                    null, null, null, null, null,
-                    "Travel rule transmission failed: Network error",
-                    null, null);
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .ignoringFields("checkId", "createdAt", "completedAt", "riskScore",
-                            "kycResult", "sanctionsResult", "travelRule", "errorCode")
-                    .isEqualTo(expected);
-        }
-    }
-
-    @Nested
-    @DisplayName("Duplicate payment")
-    class DuplicatePayment {
-
-        @Test
-        @DisplayName("should throw DuplicatePaymentException when check already exists")
-        void shouldThrowOnDuplicate() {
-            var request = aValidRequest();
-            var existingCheck = ComplianceCheck.initiate(
-                    request.paymentId(), request.senderId(), request.recipientId(),
-                    new com.stablecoin.payments.compliance.domain.model.Money(request.amount(), request.currency()),
-                    request.sourceCountry(), request.targetCountry(), request.targetCurrency());
-            given(checkRepository.findByPaymentId(request.paymentId()))
-                    .willReturn(Optional.of(existingCheck));
-
-            assertThatThrownBy(() -> service.initiateCheck(request))
-                    .isInstanceOf(DuplicatePaymentException.class)
-                    .hasMessageContaining(request.paymentId().toString());
-
-            then(kycProvider).should(never()).verify(any(), any());
-        }
-    }
-
-    @Nested
-    @DisplayName("Get check")
-    class GetCheck {
-
-        @Test
-        @DisplayName("should return check response for existing check")
-        void shouldReturnCheckResponse() {
-            var checkId = UUID.randomUUID();
-            var check = ComplianceCheck.initiate(
-                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
-                    new com.stablecoin.payments.compliance.domain.model.Money(new BigDecimal("1000.00"), "USD"),
-                    "US", "DE", "EUR");
-            given(checkRepository.findById(checkId)).willReturn(Optional.of(check));
-
-            var response = service.getCheck(checkId);
-
-            var expected = new ComplianceCheckResponse(
-                    check.checkId(), check.paymentId(), "PENDING",
-                    null, null, null, null, null, null, null,
-                    check.createdAt(), null);
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .isEqualTo(expected);
-        }
-
-        @Test
-        @DisplayName("should throw CheckNotFoundException for missing check")
-        void shouldThrowOnMissingCheck() {
-            var checkId = UUID.randomUUID();
-            given(checkRepository.findById(checkId)).willReturn(Optional.empty());
-
-            assertThatThrownBy(() -> service.getCheck(checkId))
-                    .isInstanceOf(CheckNotFoundException.class)
-                    .hasMessageContaining(checkId.toString());
-        }
-    }
-
-    @Nested
-    @DisplayName("Get customer risk profile")
-    class GetCustomerProfile {
-
-        @Test
-        @DisplayName("should return customer risk profile response")
-        void shouldReturnProfileResponse() {
-            var customerId = UUID.randomUUID();
-            var profile = aRiskProfile().toBuilder().customerId(customerId).build();
-            given(profileRepository.findByCustomerId(customerId)).willReturn(Optional.of(profile));
-
-            var response = service.getCustomerRiskProfile(customerId);
-
-            var expected = new CustomerRiskProfileResponse(
-                    customerId, "KYC_TIER_2", profile.kycVerifiedAt(),
-                    "LOW", 20,
-                    profile.perTxnLimitUsd(), profile.dailyLimitUsd(),
-                    profile.monthlyLimitUsd(), profile.lastScoredAt());
-
-            assertThat(response)
-                    .usingRecursiveComparison()
-                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-                    .isEqualTo(expected);
-        }
-
-        @Test
-        @DisplayName("should throw CustomerNotFoundException for missing profile")
-        void shouldThrowOnMissingProfile() {
-            var customerId = UUID.randomUUID();
-            given(profileRepository.findByCustomerId(customerId)).willReturn(Optional.empty());
-
-            assertThatThrownBy(() -> service.getCustomerRiskProfile(customerId))
-                    .isInstanceOf(CustomerNotFoundException.class)
-                    .hasMessageContaining(customerId.toString());
-        }
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponse);
+        then(commandHandler).should().getCustomerRiskProfile(customerId);
     }
 }

--- a/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/domain/service/ComplianceCheckCommandHandlerTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/test/java/com/stablecoin/payments/compliance/domain/service/ComplianceCheckCommandHandlerTest.java
@@ -1,0 +1,461 @@
+package com.stablecoin.payments.compliance.domain.service;
+
+import com.stablecoin.payments.compliance.domain.event.ComplianceCheckFailed;
+import com.stablecoin.payments.compliance.domain.event.ComplianceCheckPassed;
+import com.stablecoin.payments.compliance.domain.event.SanctionsHitEvent;
+import com.stablecoin.payments.compliance.domain.exception.CheckNotFoundException;
+import com.stablecoin.payments.compliance.domain.exception.CustomerNotFoundException;
+import com.stablecoin.payments.compliance.domain.exception.DuplicatePaymentException;
+import com.stablecoin.payments.compliance.domain.model.ComplianceCheck;
+import com.stablecoin.payments.compliance.domain.model.ComplianceCheckStatus;
+import com.stablecoin.payments.compliance.domain.model.Money;
+import com.stablecoin.payments.compliance.domain.model.OverallResult;
+import com.stablecoin.payments.compliance.domain.model.RiskScoringWeights;
+import com.stablecoin.payments.compliance.domain.port.AmlProvider;
+import com.stablecoin.payments.compliance.domain.port.ComplianceCheckRepository;
+import com.stablecoin.payments.compliance.domain.port.CustomerRiskProfileRepository;
+import com.stablecoin.payments.compliance.domain.port.EventPublisher;
+import com.stablecoin.payments.compliance.domain.port.KycProvider;
+import com.stablecoin.payments.compliance.domain.port.SanctionsProvider;
+import com.stablecoin.payments.compliance.domain.port.TravelRuleProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aKycRejectedResult;
+import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aKycResult;
+import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aSanctionsClearResult;
+import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.aSanctionsHitResult;
+import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.anAmlClearResult;
+import static com.stablecoin.payments.compliance.fixtures.ComplianceCheckFixtures.anAmlFlaggedResult;
+import static com.stablecoin.payments.compliance.fixtures.CustomerRiskProfileFixtures.aRiskProfile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class ComplianceCheckCommandHandlerTest {
+
+    @Mock private ComplianceCheckRepository checkRepository;
+    @Mock private CustomerRiskProfileRepository profileRepository;
+    @Mock private KycProvider kycProvider;
+    @Mock private SanctionsProvider sanctionsProvider;
+    @Mock private AmlProvider amlProvider;
+    @Mock private TravelRuleProvider travelRuleProvider;
+    @Mock private EventPublisher<Object> eventPublisher;
+
+    private ComplianceCheckService complianceCheckService;
+    private RiskScoringService riskScoringService;
+    private ComplianceCheckCommandHandler handler;
+
+    private static final Money ABOVE_THRESHOLD = new Money(new BigDecimal("1000.00"), "USD");
+    private static final Money BELOW_THRESHOLD = new Money(new BigDecimal("500.00"), "USD");
+
+    /**
+     * Simple record used as comparison target for recursive comparison
+     * when the domain object's builder is package-private.
+     */
+    private record ExpectedCheckState(
+            UUID paymentId,
+            ComplianceCheckStatus status,
+            OverallResult overallResult,
+            String errorMessage
+    ) {}
+
+    @BeforeEach
+    void setUp() {
+        complianceCheckService = new ComplianceCheckService();
+        riskScoringService = new RiskScoringService(RiskScoringWeights.defaults());
+        handler = new ComplianceCheckCommandHandler(
+                checkRepository, profileRepository,
+                kycProvider, sanctionsProvider, amlProvider, travelRuleProvider,
+                complianceCheckService, riskScoringService, eventPublisher);
+    }
+
+    @Nested
+    @DisplayName("Happy path -- full pipeline")
+    class HappyPath {
+
+        @Test
+        @DisplayName("should complete full pipeline and return PASSED domain object")
+        void shouldCompleteFullPipeline() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(senderId, recipientId)).willReturn(aKycResult(null));
+            given(sanctionsProvider.screen(senderId, recipientId))
+                    .willReturn(aSanctionsClearResult(null));
+            given(amlProvider.analyze(senderId, recipientId)).willReturn(anAmlClearResult(null));
+            given(profileRepository.findByCustomerId(senderId))
+                    .willReturn(Optional.of(aRiskProfile()));
+            given(travelRuleProvider.transmit(any())).willReturn("tr-ref-123");
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            var result = handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var expected = new ExpectedCheckState(
+                    paymentId, ComplianceCheckStatus.PASSED, OverallResult.PASSED, null);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("paymentId", "status", "overallResult")
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should publish ComplianceCheckPassed event")
+        void shouldPublishPassedEvent() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
+            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
+            given(amlProvider.analyze(any(), any())).willReturn(anAmlClearResult(null));
+            given(profileRepository.findByCustomerId(any()))
+                    .willReturn(Optional.of(aRiskProfile()));
+            given(travelRuleProvider.transmit(any())).willReturn("tr-ref-123");
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var captor = ArgumentCaptor.forClass(Object.class);
+            then(eventPublisher).should().publish(captor.capture());
+
+            var expected = new ComplianceCheckPassed(
+                    null, paymentId, null, 0, null, null, null);
+
+            assertThat(captor.getValue())
+                    .usingRecursiveComparison()
+                    .ignoringFields("checkId", "correlationId", "riskScore", "riskBand",
+                            "travelRuleRef", "passedAt")
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should skip travel rule for below-threshold amounts")
+        void shouldSkipTravelRuleBelowThreshold() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
+            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
+            given(amlProvider.analyze(any(), any())).willReturn(anAmlClearResult(null));
+            given(profileRepository.findByCustomerId(any()))
+                    .willReturn(Optional.of(aRiskProfile()));
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            var result = handler.initiateCheck(
+                    paymentId, senderId, recipientId, BELOW_THRESHOLD, "US", "DE", "EUR");
+
+            var expected = new ExpectedCheckState(
+                    paymentId, ComplianceCheckStatus.PASSED, OverallResult.PASSED, null);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("paymentId", "status", "overallResult")
+                    .isEqualTo(expected);
+            then(travelRuleProvider).should(never()).transmit(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("KYC failure")
+    class KycFailure {
+
+        @Test
+        @DisplayName("should stop pipeline on KYC rejection")
+        void shouldStopOnKycRejection() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycRejectedResult(null));
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            var result = handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var expected = new ExpectedCheckState(
+                    paymentId, ComplianceCheckStatus.FAILED, OverallResult.FAILED, null);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("paymentId", "status", "overallResult")
+                    .isEqualTo(expected);
+            then(sanctionsProvider).should(never()).screen(any(), any());
+            then(amlProvider).should(never()).analyze(any(), any());
+        }
+
+        @Test
+        @DisplayName("should publish ComplianceCheckFailed event on KYC rejection")
+        void shouldPublishFailedEventOnKycRejection() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycRejectedResult(null));
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var captor = ArgumentCaptor.forClass(Object.class);
+            then(eventPublisher).should().publish(captor.capture());
+
+            var expected = new ComplianceCheckFailed(
+                    null, paymentId, null, null, null, null);
+
+            assertThat(captor.getValue())
+                    .usingRecursiveComparison()
+                    .ignoringFields("checkId", "correlationId", "reason", "errorCode", "failedAt")
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("Sanctions hit")
+    class SanctionsHitPath {
+
+        @Test
+        @DisplayName("should stop pipeline on sanctions hit")
+        void shouldStopOnSanctionsHit() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
+            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsHitResult(null));
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            var result = handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var expected = new ExpectedCheckState(
+                    paymentId, ComplianceCheckStatus.SANCTIONS_HIT,
+                    OverallResult.SANCTIONS_HIT, null);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("paymentId", "status", "overallResult")
+                    .isEqualTo(expected);
+            then(amlProvider).should(never()).analyze(any(), any());
+        }
+
+        @Test
+        @DisplayName("should publish both ComplianceCheckFailed and SanctionsHitEvent")
+        void shouldPublishSanctionsHitEvents() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
+            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsHitResult(null));
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var captor = ArgumentCaptor.forClass(Object.class);
+            then(eventPublisher).should(times(2)).publish(captor.capture());
+            var events = captor.getAllValues();
+
+            var expectedFailed = new ComplianceCheckFailed(
+                    null, paymentId, null, null, null, null);
+
+            assertThat(events.get(0))
+                    .usingRecursiveComparison()
+                    .ignoringFields("checkId", "correlationId", "reason", "errorCode",
+                            "failedAt")
+                    .isEqualTo(expectedFailed);
+
+            var expectedHit = new SanctionsHitEvent(
+                    null, paymentId, null, "SENDER", "OFAC", null, null);
+
+            assertThat(events.get(1))
+                    .usingRecursiveComparison()
+                    .ignoringFields("checkId", "correlationId", "hitDetails", "detectedAt")
+                    .isEqualTo(expectedHit);
+        }
+    }
+
+    @Nested
+    @DisplayName("AML flagged")
+    class AmlFlaggedPath {
+
+        @Test
+        @DisplayName("should stop pipeline on AML flag and route to MANUAL_REVIEW")
+        void shouldStopOnAmlFlag() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
+            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
+            given(amlProvider.analyze(any(), any())).willReturn(anAmlFlaggedResult(null));
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            var result = handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var expected = new ExpectedCheckState(
+                    paymentId, ComplianceCheckStatus.MANUAL_REVIEW,
+                    OverallResult.MANUAL_REVIEW, null);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("paymentId", "status", "overallResult")
+                    .isEqualTo(expected);
+            then(travelRuleProvider).should(never()).transmit(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Travel rule failure")
+    class TravelRuleFailure {
+
+        @Test
+        @DisplayName("should handle travel rule transmission failure gracefully")
+        void shouldHandleTravelRuleFailure() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            given(checkRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+            given(kycProvider.verify(any(), any())).willReturn(aKycResult(null));
+            given(sanctionsProvider.screen(any(), any())).willReturn(aSanctionsClearResult(null));
+            given(amlProvider.analyze(any(), any())).willReturn(anAmlClearResult(null));
+            given(profileRepository.findByCustomerId(any()))
+                    .willReturn(Optional.of(aRiskProfile()));
+            given(travelRuleProvider.transmit(any()))
+                    .willThrow(new RuntimeException("Network error"));
+            given(checkRepository.save(any(ComplianceCheck.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            var result = handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+
+            var expected = new ExpectedCheckState(
+                    paymentId, ComplianceCheckStatus.FAILED, OverallResult.FAILED,
+                    "Travel rule transmission failed: Network error");
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("paymentId", "status", "overallResult",
+                            "errorMessage")
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("Duplicate payment")
+    class DuplicatePayment {
+
+        @Test
+        @DisplayName("should throw DuplicatePaymentException when check already exists")
+        void shouldThrowOnDuplicate() {
+            var paymentId = UUID.randomUUID();
+            var senderId = UUID.randomUUID();
+            var recipientId = UUID.randomUUID();
+            var existingCheck = ComplianceCheck.initiate(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR");
+            given(checkRepository.findByPaymentId(paymentId))
+                    .willReturn(Optional.of(existingCheck));
+
+            assertThatThrownBy(() -> handler.initiateCheck(
+                    paymentId, senderId, recipientId, ABOVE_THRESHOLD, "US", "DE", "EUR"))
+                    .isInstanceOf(DuplicatePaymentException.class)
+                    .hasMessageContaining(paymentId.toString());
+
+            then(kycProvider).should(never()).verify(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Get check")
+    class GetCheck {
+
+        @Test
+        @DisplayName("should return domain check for existing check")
+        void shouldReturnCheck() {
+            var checkId = UUID.randomUUID();
+            var check = ComplianceCheck.initiate(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                    ABOVE_THRESHOLD, "US", "DE", "EUR");
+            given(checkRepository.findById(checkId)).willReturn(Optional.of(check));
+
+            var result = handler.getCheck(checkId);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(check);
+        }
+
+        @Test
+        @DisplayName("should throw CheckNotFoundException for missing check")
+        void shouldThrowOnMissingCheck() {
+            var checkId = UUID.randomUUID();
+            given(checkRepository.findById(checkId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> handler.getCheck(checkId))
+                    .isInstanceOf(CheckNotFoundException.class)
+                    .hasMessageContaining(checkId.toString());
+        }
+    }
+
+    @Nested
+    @DisplayName("Get customer risk profile")
+    class GetCustomerProfile {
+
+        @Test
+        @DisplayName("should return customer risk profile domain object")
+        void shouldReturnProfile() {
+            var customerId = UUID.randomUUID();
+            var profile = aRiskProfile().toBuilder().customerId(customerId).build();
+            given(profileRepository.findByCustomerId(customerId))
+                    .willReturn(Optional.of(profile));
+
+            var result = handler.getCustomerRiskProfile(customerId);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(profile);
+        }
+
+        @Test
+        @DisplayName("should throw CustomerNotFoundException for missing profile")
+        void shouldThrowOnMissingProfile() {
+            var customerId = UUID.randomUUID();
+            given(profileRepository.findByCustomerId(customerId))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> handler.getCustomerRiskProfile(customerId))
+                    .isInstanceOf(CustomerNotFoundException.class)
+                    .hasMessageContaining(customerId.toString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Created `ComplianceCheckCommandHandler`** in `domain/service/` (247 lines) — pipeline orchestration (`runPipeline`, `handleTravelRule`, `publishEvents`) now lives in the domain layer following the S10 `MerchantCommandHandler` pattern
- **Thinned `ComplianceCheckApplicationService`** from 236 → 44 lines — pure DTO mapping + delegation (matches S10 `MerchantApplicationService`)
- **13 CommandHandler tests** + 3 thin delegation tests for app service

### Before → After
| Layer | Before | After |
|-------|--------|-------|
| Application service | 236 lines (pipeline, events, travel rule) | 44 lines (DTO mapping only) |
| Domain command handler | N/A | 247 lines (all business orchestration) |

## Test plan
- [x] All unit tests pass (CommandHandler 13 + AppService 3 + existing)
- [x] All integration tests pass (26 ITs)
- [x] Full build green
- [x] Controller behavior unchanged — same API contract

Closes STA-89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized compliance orchestration and simplified internal wiring while keeping public APIs unchanged.

* **Tests**
  * Expanded and reorganized test coverage for end-to-end compliance scenarios (KYC, sanctions, AML, risk scoring, travel rule) including edge cases and error handling.

* **Documentation**
  * Updated package-level documentation to reflect the new orchestration and state-transition responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->