### PR TITLE
chore(ci): optimize CI pipeline performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,56 @@ jobs:
       - name: Spotless check
         run: ./gradlew spotlessCheck --build-cache
 
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            merchant-onboarding:merchant-onboarding:
+              - 'merchant-onboarding/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
+            merchant-iam:merchant-iam:
+              - 'merchant-iam/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
+            api-gateway-iam:api-gateway-iam:
+              - 'api-gateway-iam/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
+            compliance-travel-rule:compliance-travel-rule:
+              - 'compliance-travel-rule/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
+            fx-liquidity-engine:fx-liquidity-engine:
+              - 'fx-liquidity-engine/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
+
   test:
-    needs: spotless
+    needs: [spotless, changes]
+    if: needs.changes.outputs.services != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        service:
-          - merchant-onboarding:merchant-onboarding
-          - merchant-iam:merchant-iam
-          - api-gateway-iam:api-gateway-iam
-          - compliance-travel-rule:compliance-travel-rule
-          - fx-liquidity-engine:fx-liquidity-engine
+        service: ${{ fromJson(needs.changes.outputs.services) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -46,30 +84,22 @@ jobs:
           java-version: "25"
           distribution: "temurin"
 
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-home-cache-cleanup: true
 
-      - name: Unit tests
-        run: ./gradlew :${{ matrix.service }}:test :${{ matrix.service }}:jacocoTestReport --build-cache
-
-      - name: Integration tests
-        run: ./gradlew :${{ matrix.service }}:integrationTest --build-cache
-
-      - name: Business tests
-        run: ./gradlew :${{ matrix.service }}:businessTest --build-cache
+      - name: All tests
+        env:
+          TESTCONTAINERS_REUSE_ENABLE: true
+        run: |
+          ./gradlew \
+            :${{ matrix.service }}:test \
+            :${{ matrix.service }}:jacocoTestReport \
+            :${{ matrix.service }}:integrationTest \
+            :${{ matrix.service }}:businessTest \
+            --build-cache --parallel
 
   sonar:
     needs: test
@@ -84,16 +114,6 @@ jobs:
         with:
           java-version: "25"
           distribution: "temurin"
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,7 @@ subprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
         testLogging {
             events(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED)
         }


### PR DESCRIPTION
## Summary
- Add `dorny/paths-filter` to only test services with changed files — skips unchanged services entirely
- Merge 3 separate Gradle test invocations (unit, integration, business) into a single call with `--parallel`
- Remove duplicate `actions/cache` blocks — `gradle/actions/setup-gradle` already handles caching
- Enable TestContainers reuse via `TESTCONTAINERS_REUSE_ENABLE` env var
- Add `maxParallelForks` in `build.gradle.kts` for parallel test class execution

## Test plan
- [ ] Verify CI runs on this PR with path filtering active
- [ ] Confirm all test types (unit, integration, business) still execute in the single Gradle invocation
- [ ] Verify Gradle cache is restored correctly without the manual `actions/cache` block
- [ ] Push a follow-up commit touching only one service and confirm other services are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)