### PR TITLE
feat(s6): REST controllers for FX quote, corridor, and liquidity pool (STA-101)

### DIFF
--- a/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/CorridorControllerIT.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/CorridorControllerIT.java
@@ -1,0 +1,69 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.AbstractIntegrationTest;
+import com.stablecoin.payments.fx.domain.port.LiquidityPoolRepository;
+import com.stablecoin.payments.fx.domain.port.RateCache;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.stablecoin.payments.fx.fixtures.CorridorRateFixtures.aUsdEurRate;
+import static com.stablecoin.payments.fx.fixtures.LiquidityPoolFixtures.aUsdEurPool;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CorridorController IT")
+class CorridorControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private LiquidityPoolRepository poolRepository;
+
+    @Autowired
+    private RateCache rateCache;
+
+    @Test
+    @DisplayName("should return 200 OK with corridors that have cached rates")
+    void shouldReturn200WithCorridorsWithRates() throws Exception {
+        poolRepository.save(aUsdEurPool());
+        rateCache.put("USD", "EUR", aUsdEurRate());
+
+        mockMvc.perform(get("/v1/fx/corridors"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].fromCurrency", is("USD")))
+                .andExpect(jsonPath("$[0].toCurrency", is("EUR")))
+                .andExpect(jsonPath("$[0].indicativeRate", notNullValue()))
+                .andExpect(jsonPath("$[0].provider", is("REFINITIV")));
+    }
+
+    @Test
+    @DisplayName("should return 200 OK with unavailable rate when no cached rate exists")
+    void shouldReturn200WithUnavailableWhenNoCachedRate() throws Exception {
+        poolRepository.save(aUsdEurPool());
+
+        mockMvc.perform(get("/v1/fx/corridors"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].fromCurrency", is("USD")))
+                .andExpect(jsonPath("$[0].toCurrency", is("EUR")))
+                .andExpect(jsonPath("$[0].indicativeRate", nullValue()))
+                .andExpect(jsonPath("$[0].provider", is("unavailable")));
+    }
+
+    @Test
+    @DisplayName("should return 200 OK with empty list when no pools exist")
+    void shouldReturn200WithEmptyList() throws Exception {
+        mockMvc.perform(get("/v1/fx/corridors"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerIT.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerIT.java
@@ -1,0 +1,322 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.AbstractIntegrationTest;
+import com.stablecoin.payments.fx.domain.model.FxQuote;
+import com.stablecoin.payments.fx.domain.model.FxQuoteStatus;
+import com.stablecoin.payments.fx.domain.model.LiquidityPool;
+import com.stablecoin.payments.fx.domain.port.FxQuoteRepository;
+import com.stablecoin.payments.fx.domain.port.LiquidityPoolRepository;
+import com.stablecoin.payments.fx.domain.port.RateCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static com.stablecoin.payments.fx.application.config.IdempotencyKeyFilter.IDEMPOTENCY_KEY_HEADER;
+import static com.stablecoin.payments.fx.fixtures.CorridorRateFixtures.aUsdEurRate;
+import static com.stablecoin.payments.fx.fixtures.FxQuoteFixtures.anActiveQuote;
+import static com.stablecoin.payments.fx.fixtures.LiquidityPoolFixtures.aUsdEurPool;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("FxQuoteController IT")
+class FxQuoteControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private FxQuoteRepository quoteRepository;
+
+    @Autowired
+    private LiquidityPoolRepository poolRepository;
+
+    @Autowired
+    private RateCache rateCache;
+
+    @Nested
+    @DisplayName("GET /v1/fx/quote")
+    class GetQuote {
+
+        @BeforeEach
+        void seedRate() {
+            rateCache.put("USD", "EUR", aUsdEurRate());
+        }
+
+        @Test
+        @DisplayName("should return 200 OK with quote response")
+        void shouldReturn200WithQuoteResponse() throws Exception {
+            mockMvc.perform(get("/v1/fx/quote")
+                            .param("fromCurrency", "USD")
+                            .param("toCurrency", "EUR")
+                            .param("amount", "10000.00"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.quoteId", notNullValue()))
+                    .andExpect(jsonPath("$.fromCurrency", is("USD")))
+                    .andExpect(jsonPath("$.toCurrency", is("EUR")))
+                    .andExpect(jsonPath("$.rate", notNullValue()))
+                    .andExpect(jsonPath("$.provider", is("REFINITIV")));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request for missing fromCurrency")
+        void shouldReturn400ForMissingFromCurrency() throws Exception {
+            mockMvc.perform(get("/v1/fx/quote")
+                            .param("toCurrency", "EUR")
+                            .param("amount", "10000.00"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request for missing amount")
+        void shouldReturn400ForMissingAmount() throws Exception {
+            mockMvc.perform(get("/v1/fx/quote")
+                            .param("fromCurrency", "USD")
+                            .param("toCurrency", "EUR"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("should return 503 Service Unavailable when rate is not available")
+        void shouldReturn503WhenRateUnavailable() throws Exception {
+            mockMvc.perform(get("/v1/fx/quote")
+                            .param("fromCurrency", "JPY")
+                            .param("toCurrency", "BRL")
+                            .param("amount", "10000.00"))
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.code", is("FX-4001")));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/fx/quote/{quoteId}")
+    class GetQuoteById {
+
+        @Test
+        @DisplayName("should return 200 OK for existing quote")
+        void shouldReturn200ForExistingQuote() throws Exception {
+            var quote = anActiveQuote();
+            var saved = quoteRepository.save(quote);
+
+            mockMvc.perform(get("/v1/fx/quote/{quoteId}", saved.quoteId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.quoteId", is(saved.quoteId().toString())))
+                    .andExpect(jsonPath("$.fromCurrency", is("USD")))
+                    .andExpect(jsonPath("$.toCurrency", is("EUR")));
+        }
+
+        @Test
+        @DisplayName("should return 404 Not Found for non-existing quote")
+        void shouldReturn404ForNonExistingQuote() throws Exception {
+            var quoteId = UUID.randomUUID();
+
+            mockMvc.perform(get("/v1/fx/quote/{quoteId}", quoteId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code", is("FX-1001")));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /v1/fx/lock/{quoteId}")
+    class LockRate {
+
+        @Test
+        @DisplayName("should return 201 Created with lock response")
+        void shouldReturn201WithLockResponse() throws Exception {
+            var quote = anActiveQuote();
+            var saved = quoteRepository.save(quote);
+            poolRepository.save(aUsdEurPool());
+
+            var paymentId = UUID.randomUUID();
+            var correlationId = UUID.randomUUID();
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "correlationId": "%s",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE"
+                    }
+                    """.formatted(paymentId, correlationId);
+
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", saved.quoteId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.lockId", notNullValue()))
+                    .andExpect(jsonPath("$.quoteId", is(saved.quoteId().toString())))
+                    .andExpect(jsonPath("$.paymentId", is(paymentId.toString())))
+                    .andExpect(jsonPath("$.fromCurrency", is("USD")))
+                    .andExpect(jsonPath("$.toCurrency", is("EUR")));
+        }
+
+        @Test
+        @DisplayName("should return 404 Not Found for non-existing quote")
+        void shouldReturn404ForNonExistingQuote() throws Exception {
+            var quoteId = UUID.randomUUID();
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "correlationId": "%s",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", quoteId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code", is("FX-1001")));
+        }
+
+        @Test
+        @DisplayName("should return 410 Gone for expired quote")
+        void shouldReturn410ForExpiredQuote() throws Exception {
+            var expiredQuote = new FxQuote(
+                    UUID.randomUUID(), "USD", "EUR",
+                    new BigDecimal("10000.00000000"), new BigDecimal("9200.00000000"),
+                    new BigDecimal("0.9200000000"), new BigDecimal("1.0869565217"),
+                    0, 30, new BigDecimal("30.00000000"), "REFINITIV", "REF-123",
+                    FxQuoteStatus.ACTIVE, Instant.now().minusSeconds(600), Instant.now().minusSeconds(10)
+            );
+            var saved = quoteRepository.save(expiredQuote);
+            poolRepository.save(aUsdEurPool());
+
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "correlationId": "%s",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", saved.quoteId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isGone())
+                    .andExpect(jsonPath("$.code", is("FX-1002")));
+        }
+
+        @Test
+        @DisplayName("should return 409 Conflict for already locked quote")
+        void shouldReturn409ForAlreadyLockedQuote() throws Exception {
+            var lockedQuote = new FxQuote(
+                    UUID.randomUUID(), "USD", "EUR",
+                    new BigDecimal("10000.00000000"), new BigDecimal("9200.00000000"),
+                    new BigDecimal("0.9200000000"), new BigDecimal("1.0869565217"),
+                    0, 30, new BigDecimal("30.00000000"), "REFINITIV", "REF-123",
+                    FxQuoteStatus.LOCKED, Instant.now(), Instant.now().plusSeconds(300)
+            );
+            var saved = quoteRepository.save(lockedQuote);
+
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "correlationId": "%s",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", saved.quoteId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code", is("FX-1003")));
+        }
+
+        @Test
+        @DisplayName("should return 422 Unprocessable Entity for insufficient liquidity")
+        void shouldReturn422ForInsufficientLiquidity() throws Exception {
+            var quote = new FxQuote(
+                    UUID.randomUUID(), "GBP", "EUR",
+                    new BigDecimal("10000000.00000000"), new BigDecimal("11600000.00000000"),
+                    new BigDecimal("1.1600000000"), new BigDecimal("0.8620689655"),
+                    0, 25, new BigDecimal("25000.00000000"), "REFINITIV", "REF-456",
+                    FxQuoteStatus.ACTIVE, Instant.now(), Instant.now().plusSeconds(300)
+            );
+            var saved = quoteRepository.save(quote);
+
+            // Save a pool with very low balance for GBP/EUR
+            var lowPool = new LiquidityPool(
+                    UUID.randomUUID(), "GBP", "EUR",
+                    new BigDecimal("100.00000000"), BigDecimal.ZERO,
+                    new BigDecimal("50000.00000000"), new BigDecimal("2000000.00000000"),
+                    Instant.now()
+            );
+            poolRepository.save(lowPool);
+
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "correlationId": "%s",
+                        "sourceCountry": "GB",
+                        "targetCountry": "DE"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", saved.quoteId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.code", is("FX-3001")));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request for missing required fields")
+        void shouldReturn400ForMissingFields() throws Exception {
+            var quoteId = UUID.randomUUID();
+            var requestBody = """
+                    {
+                        "sourceCountry": "US"
+                    }
+                    """;
+
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", quoteId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code", is("FX-0001")))
+                    .andExpect(jsonPath("$.errors", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request when Idempotency-Key header is missing")
+        void shouldReturn400ForMissingIdempotencyKey() throws Exception {
+            var quoteId = UUID.randomUUID();
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "correlationId": "%s",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE"
+                    }
+                    """.formatted(UUID.randomUUID(), UUID.randomUUID());
+
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", quoteId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code", is("FX-0001")))
+                    .andExpect(jsonPath("$.message", is("Idempotency-Key header is required for mutating requests")));
+        }
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/LiquidityPoolControllerIT.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/LiquidityPoolControllerIT.java
@@ -1,0 +1,85 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.AbstractIntegrationTest;
+import com.stablecoin.payments.fx.domain.port.LiquidityPoolRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static com.stablecoin.payments.fx.fixtures.LiquidityPoolFixtures.aGbpEurPool;
+import static com.stablecoin.payments.fx.fixtures.LiquidityPoolFixtures.aUsdEurPool;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("LiquidityPoolController IT")
+class LiquidityPoolControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private LiquidityPoolRepository poolRepository;
+
+    @Nested
+    @DisplayName("GET /v1/liquidity/pools")
+    class ListPools {
+
+        @Test
+        @DisplayName("should return 200 OK with pool list")
+        void shouldReturn200WithPoolList() throws Exception {
+            poolRepository.save(aUsdEurPool());
+            poolRepository.save(aGbpEurPool());
+
+            mockMvc.perform(get("/v1/liquidity/pools"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(2)))
+                    .andExpect(jsonPath("$[0].poolId", notNullValue()))
+                    .andExpect(jsonPath("$[0].status", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("should return 200 OK with empty list when no pools exist")
+        void shouldReturn200WithEmptyList() throws Exception {
+            mockMvc.perform(get("/v1/liquidity/pools"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(0)));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/liquidity/pools/{poolId}")
+    class GetPool {
+
+        @Test
+        @DisplayName("should return 200 OK with pool response for existing pool")
+        void shouldReturn200ForExistingPool() throws Exception {
+            var pool = aUsdEurPool();
+            var saved = poolRepository.save(pool);
+
+            mockMvc.perform(get("/v1/liquidity/pools/{poolId}", saved.poolId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.poolId", is(saved.poolId().toString())))
+                    .andExpect(jsonPath("$.fromCurrency", is("USD")))
+                    .andExpect(jsonPath("$.toCurrency", is("EUR")))
+                    .andExpect(jsonPath("$.status", is("HEALTHY")));
+        }
+
+        @Test
+        @DisplayName("should return 404 Not Found for non-existing pool")
+        void shouldReturn404ForNonExistingPool() throws Exception {
+            var poolId = UUID.randomUUID();
+
+            mockMvc.perform(get("/v1/liquidity/pools/{poolId}", poolId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code", is("FX-2001")));
+        }
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/CorridorController.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/CorridorController.java
@@ -1,0 +1,26 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.api.response.CorridorResponse;
+import com.stablecoin.payments.fx.application.service.LiquidityPoolApplicationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/fx")
+@RequiredArgsConstructor
+public class CorridorController {
+
+    private final LiquidityPoolApplicationService liquidityPoolApplicationService;
+
+    @GetMapping("/corridors")
+    public List<CorridorResponse> listCorridors() {
+        log.info("GET /v1/fx/corridors");
+        return liquidityPoolApplicationService.listCorridors();
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/FxQuoteController.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/FxQuoteController.java
@@ -1,0 +1,52 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.api.request.FxQuoteRequest;
+import com.stablecoin.payments.fx.api.request.FxRateLockRequest;
+import com.stablecoin.payments.fx.api.response.FxQuoteResponse;
+import com.stablecoin.payments.fx.api.response.FxRateLockResponse;
+import com.stablecoin.payments.fx.application.service.FxQuoteApplicationService;
+import com.stablecoin.payments.fx.application.service.FxRateLockApplicationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/fx")
+@RequiredArgsConstructor
+public class FxQuoteController {
+
+    private final FxQuoteApplicationService quoteApplicationService;
+    private final FxRateLockApplicationService rateLockApplicationService;
+
+    @GetMapping("/quote")
+    public FxQuoteResponse getQuote(@Valid FxQuoteRequest request) {
+        log.info("GET /v1/fx/quote fromCurrency={} toCurrency={} amount={}",
+                request.fromCurrency(), request.toCurrency(), request.amount());
+        return quoteApplicationService.getQuote(request);
+    }
+
+    @GetMapping("/quote/{quoteId}")
+    public FxQuoteResponse getQuoteById(@PathVariable UUID quoteId) {
+        log.info("GET /v1/fx/quote/{}", quoteId);
+        return quoteApplicationService.getQuoteById(quoteId);
+    }
+
+    @PostMapping("/lock/{quoteId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public FxRateLockResponse lockRate(@PathVariable UUID quoteId,
+                                       @Valid @RequestBody FxRateLockRequest request) {
+        log.info("POST /v1/fx/lock/{} paymentId={}", quoteId, request.paymentId());
+        return rateLockApplicationService.lockRate(quoteId, request);
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/LiquidityPoolController.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/LiquidityPoolController.java
@@ -1,0 +1,34 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.api.response.LiquidityPoolResponse;
+import com.stablecoin.payments.fx.application.service.LiquidityPoolApplicationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/liquidity")
+@RequiredArgsConstructor
+public class LiquidityPoolController {
+
+    private final LiquidityPoolApplicationService liquidityPoolApplicationService;
+
+    @GetMapping("/pools")
+    public List<LiquidityPoolResponse> listPools() {
+        log.info("GET /v1/liquidity/pools");
+        return liquidityPoolApplicationService.listPools();
+    }
+
+    @GetMapping("/pools/{poolId}")
+    public LiquidityPoolResponse getPool(@PathVariable UUID poolId) {
+        log.info("GET /v1/liquidity/pools/{}", poolId);
+        return liquidityPoolApplicationService.getPool(poolId);
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/CorridorControllerTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/CorridorControllerTest.java
@@ -1,0 +1,61 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.api.response.CorridorResponse;
+import com.stablecoin.payments.fx.application.service.LiquidityPoolApplicationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CorridorController")
+class CorridorControllerTest {
+
+    @Mock
+    private LiquidityPoolApplicationService liquidityPoolApplicationService;
+
+    @InjectMocks
+    private CorridorController controller;
+
+    @Test
+    @DisplayName("should delegate to application service and return corridor list")
+    void shouldListCorridors() {
+        // given
+        var now = Instant.now();
+        var corridors = List.of(
+                new CorridorResponse("USD", "EUR", new BigDecimal("0.92"), 30, 30, "REFINITIV", now),
+                new CorridorResponse("GBP", "EUR", new BigDecimal("1.16"), 25, 25, "REFINITIV", now)
+        );
+        given(liquidityPoolApplicationService.listCorridors()).willReturn(corridors);
+
+        // when
+        var result = controller.listCorridors();
+
+        // then
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(corridors);
+    }
+
+    @Test
+    @DisplayName("should return empty list when no corridors available")
+    void shouldReturnEmptyList() {
+        // given
+        given(liquidityPoolApplicationService.listCorridors()).willReturn(List.of());
+
+        // when
+        var result = controller.listCorridors();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerTest.java
@@ -1,0 +1,205 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.api.request.FxQuoteRequest;
+import com.stablecoin.payments.fx.api.request.FxRateLockRequest;
+import com.stablecoin.payments.fx.api.response.FxQuoteResponse;
+import com.stablecoin.payments.fx.api.response.FxRateLockResponse;
+import com.stablecoin.payments.fx.application.service.FxQuoteApplicationService;
+import com.stablecoin.payments.fx.application.service.FxRateLockApplicationService;
+import com.stablecoin.payments.fx.domain.exception.QuoteAlreadyLockedException;
+import com.stablecoin.payments.fx.domain.exception.QuoteExpiredException;
+import com.stablecoin.payments.fx.domain.exception.QuoteNotFoundException;
+import com.stablecoin.payments.fx.domain.exception.RateUnavailableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FxQuoteController")
+class FxQuoteControllerTest {
+
+    @Mock
+    private FxQuoteApplicationService quoteApplicationService;
+
+    @Mock
+    private FxRateLockApplicationService rateLockApplicationService;
+
+    @InjectMocks
+    private FxQuoteController controller;
+
+    @Nested
+    @DisplayName("GET /v1/fx/quote")
+    class GetQuote {
+
+        @Test
+        @DisplayName("should delegate to application service and return quote response")
+        void shouldGetQuote() {
+            // given
+            var request = new FxQuoteRequest("USD", "EUR", new BigDecimal("10000.00"));
+            var now = Instant.now();
+            var expectedResponse = new FxQuoteResponse(
+                    UUID.randomUUID(), "USD", "EUR",
+                    new BigDecimal("10000.00"), new BigDecimal("9200.00"),
+                    new BigDecimal("0.92"), new BigDecimal("1.087"),
+                    30, new BigDecimal("30.00"), "REFINITIV",
+                    now, now.plusSeconds(300));
+
+            given(quoteApplicationService.getQuote(request)).willReturn(expectedResponse);
+
+            // when
+            var result = controller.getQuote(request);
+
+            // then
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedResponse);
+        }
+
+        @Test
+        @DisplayName("should propagate RateUnavailableException")
+        void shouldPropagateRateUnavailable() {
+            // given
+            var request = new FxQuoteRequest("JPY", "BRL", new BigDecimal("10000.00"));
+            given(quoteApplicationService.getQuote(request))
+                    .willThrow(RateUnavailableException.forCorridor("JPY", "BRL"));
+
+            // when/then
+            assertThatThrownBy(() -> controller.getQuote(request))
+                    .isInstanceOf(RateUnavailableException.class)
+                    .hasMessageContaining("JPY")
+                    .hasMessageContaining("BRL");
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/fx/quote/{quoteId}")
+    class GetQuoteById {
+
+        @Test
+        @DisplayName("should delegate to application service and return quote response")
+        void shouldGetQuoteById() {
+            // given
+            var quoteId = UUID.randomUUID();
+            var now = Instant.now();
+            var expectedResponse = new FxQuoteResponse(
+                    quoteId, "USD", "EUR",
+                    new BigDecimal("10000.00"), new BigDecimal("9200.00"),
+                    new BigDecimal("0.92"), new BigDecimal("1.087"),
+                    30, new BigDecimal("30.00"), "REFINITIV",
+                    now, now.plusSeconds(300));
+
+            given(quoteApplicationService.getQuoteById(quoteId)).willReturn(expectedResponse);
+
+            // when
+            var result = controller.getQuoteById(quoteId);
+
+            // then
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedResponse);
+        }
+
+        @Test
+        @DisplayName("should propagate QuoteNotFoundException")
+        void shouldPropagateQuoteNotFound() {
+            // given
+            var quoteId = UUID.randomUUID();
+            given(quoteApplicationService.getQuoteById(quoteId))
+                    .willThrow(QuoteNotFoundException.withId(quoteId));
+
+            // when/then
+            assertThatThrownBy(() -> controller.getQuoteById(quoteId))
+                    .isInstanceOf(QuoteNotFoundException.class)
+                    .hasMessageContaining(quoteId.toString());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /v1/fx/lock/{quoteId}")
+    class LockRate {
+
+        @Test
+        @DisplayName("should delegate to application service and return lock response")
+        void shouldLockRate() {
+            // given
+            var quoteId = UUID.randomUUID();
+            var paymentId = UUID.randomUUID();
+            var correlationId = UUID.randomUUID();
+            var request = new FxRateLockRequest(paymentId, correlationId, "US", "DE");
+            var now = Instant.now();
+            var expectedResponse = new FxRateLockResponse(
+                    UUID.randomUUID(), quoteId, paymentId,
+                    "USD", "EUR",
+                    new BigDecimal("10000.00"), new BigDecimal("9200.00"),
+                    new BigDecimal("0.92"), 30, new BigDecimal("30.00"),
+                    now, now.plusSeconds(30));
+
+            given(rateLockApplicationService.lockRate(quoteId, request)).willReturn(expectedResponse);
+
+            // when
+            var result = controller.lockRate(quoteId, request);
+
+            // then
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedResponse);
+        }
+
+        @Test
+        @DisplayName("should propagate QuoteNotFoundException")
+        void shouldPropagateQuoteNotFound() {
+            // given
+            var quoteId = UUID.randomUUID();
+            var request = new FxRateLockRequest(UUID.randomUUID(), UUID.randomUUID(), "US", "DE");
+            given(rateLockApplicationService.lockRate(quoteId, request))
+                    .willThrow(QuoteNotFoundException.withId(quoteId));
+
+            // when/then
+            assertThatThrownBy(() -> controller.lockRate(quoteId, request))
+                    .isInstanceOf(QuoteNotFoundException.class)
+                    .hasMessageContaining(quoteId.toString());
+        }
+
+        @Test
+        @DisplayName("should propagate QuoteExpiredException")
+        void shouldPropagateQuoteExpired() {
+            // given
+            var quoteId = UUID.randomUUID();
+            var request = new FxRateLockRequest(UUID.randomUUID(), UUID.randomUUID(), "US", "DE");
+            given(rateLockApplicationService.lockRate(quoteId, request))
+                    .willThrow(QuoteExpiredException.withId(quoteId));
+
+            // when/then
+            assertThatThrownBy(() -> controller.lockRate(quoteId, request))
+                    .isInstanceOf(QuoteExpiredException.class)
+                    .hasMessageContaining(quoteId.toString());
+        }
+
+        @Test
+        @DisplayName("should propagate QuoteAlreadyLockedException")
+        void shouldPropagateQuoteAlreadyLocked() {
+            // given
+            var quoteId = UUID.randomUUID();
+            var request = new FxRateLockRequest(UUID.randomUUID(), UUID.randomUUID(), "US", "DE");
+            given(rateLockApplicationService.lockRate(quoteId, request))
+                    .willThrow(QuoteAlreadyLockedException.withId(quoteId));
+
+            // when/then
+            assertThatThrownBy(() -> controller.lockRate(quoteId, request))
+                    .isInstanceOf(QuoteAlreadyLockedException.class)
+                    .hasMessageContaining(quoteId.toString());
+        }
+    }
+}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/LiquidityPoolControllerTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/LiquidityPoolControllerTest.java
@@ -1,0 +1,120 @@
+package com.stablecoin.payments.fx.application.controller;
+
+import com.stablecoin.payments.fx.api.response.LiquidityPoolResponse;
+import com.stablecoin.payments.fx.application.service.LiquidityPoolApplicationService;
+import com.stablecoin.payments.fx.domain.exception.PoolNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LiquidityPoolController")
+class LiquidityPoolControllerTest {
+
+    @Mock
+    private LiquidityPoolApplicationService liquidityPoolApplicationService;
+
+    @InjectMocks
+    private LiquidityPoolController controller;
+
+    @Nested
+    @DisplayName("GET /v1/liquidity/pools")
+    class ListPools {
+
+        @Test
+        @DisplayName("should delegate to application service and return pool list")
+        void shouldListPools() {
+            // given
+            var now = Instant.now();
+            var pools = List.of(
+                    new LiquidityPoolResponse(
+                            UUID.randomUUID(), "USD", "EUR",
+                            new BigDecimal("1000000.00"), BigDecimal.ZERO,
+                            new BigDecimal("100000.00"), new BigDecimal("5000000.00"),
+                            BigDecimal.ZERO, "HEALTHY", now),
+                    new LiquidityPoolResponse(
+                            UUID.randomUUID(), "GBP", "EUR",
+                            new BigDecimal("500000.00"), BigDecimal.ZERO,
+                            new BigDecimal("50000.00"), new BigDecimal("2000000.00"),
+                            BigDecimal.ZERO, "HEALTHY", now)
+            );
+            given(liquidityPoolApplicationService.listPools()).willReturn(pools);
+
+            // when
+            var result = controller.listPools();
+
+            // then
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(pools);
+        }
+
+        @Test
+        @DisplayName("should return empty list when no pools exist")
+        void shouldReturnEmptyList() {
+            // given
+            given(liquidityPoolApplicationService.listPools()).willReturn(List.of());
+
+            // when
+            var result = controller.listPools();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/liquidity/pools/{poolId}")
+    class GetPool {
+
+        @Test
+        @DisplayName("should delegate to application service and return pool response")
+        void shouldGetPool() {
+            // given
+            var poolId = UUID.randomUUID();
+            var now = Instant.now();
+            var expectedResponse = new LiquidityPoolResponse(
+                    poolId, "USD", "EUR",
+                    new BigDecimal("1000000.00"), BigDecimal.ZERO,
+                    new BigDecimal("100000.00"), new BigDecimal("5000000.00"),
+                    BigDecimal.ZERO, "HEALTHY", now);
+
+            given(liquidityPoolApplicationService.getPool(poolId)).willReturn(expectedResponse);
+
+            // when
+            var result = controller.getPool(poolId);
+
+            // then
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedResponse);
+        }
+
+        @Test
+        @DisplayName("should propagate PoolNotFoundException")
+        void shouldPropagatePoolNotFound() {
+            // given
+            var poolId = UUID.randomUUID();
+            given(liquidityPoolApplicationService.getPool(poolId))
+                    .willThrow(PoolNotFoundException.withId(poolId));
+
+            // when/then
+            assertThatThrownBy(() -> controller.getPool(poolId))
+                    .isInstanceOf(PoolNotFoundException.class)
+                    .hasMessageContaining(poolId.toString());
+        }
+    }
+}


### PR DESCRIPTION
Closes STA-101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * FX corridors endpoint to retrieve available currency pairs with rates and provider information.
  * FX quote endpoints for obtaining exchange rate quotes and managing rate locks with idempotency support.
  * Liquidity pools management endpoints to list and view pool details and status.

* **Tests**
  * Added comprehensive integration and unit test coverage for new API endpoints and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->