### PR TITLE
chore(ci): add payment-orchestrator path filter + CI status gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
               - 'settings.gradle.kts'
               - 'gradle/**'
               - 'gradle.properties'
+            payment-orchestrator:payment-orchestrator:
+              - 'payment-orchestrator/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
 
   test:
     needs: [spotless, changes]
@@ -100,6 +106,20 @@ jobs:
             :${{ matrix.service }}:integrationTest \
             :${{ matrix.service }}:businessTest \
             --build-cache --parallel
+
+  ci-status:
+    name: CI Status
+    runs-on: ubuntu-latest
+    needs: [spotless, test]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.spotless.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
+            echo "CI failed"
+            exit 1
+          fi
+          echo "CI passed"
 
   sonar:
     needs: test


### PR DESCRIPTION
## Summary
- Add `payment-orchestrator:payment-orchestrator` to CI path filters so S1 tests actually run on PRs
- Add `ci-status` aggregate job that always runs and gates on spotless + test results — replaces per-service matrix jobs as the single required check

## Why
PR #99 (STA-105) revealed that S1 was missing from path filters, and per-service required checks stay "Expected" forever when path-filtered out, blocking merge.

## Action needed
After merging, update **branch protection rules** to replace the 5 individual `test (...)` required checks with a single `CI Status` required check.

## Test plan
- [ ] CI runs on this PR and `CI Status` job reports success
- [ ] After merge, update branch protection to require `CI Status` instead of per-service test jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)