### PR TITLE
feat(s6): lock idempotency + application layer tests (STA-102)

### DIFF
--- a/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerIT.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerIT.java
@@ -318,5 +318,44 @@ class FxQuoteControllerIT extends AbstractIntegrationTest {
                     .andExpect(jsonPath("$.code", is("FX-0001")))
                     .andExpect(jsonPath("$.message", is("Idempotency-Key header is required for mutating requests")));
         }
+
+        @Test
+        @DisplayName("should return 200 OK for idempotent lock with same paymentId")
+        void shouldReturn200ForIdempotentLock() throws Exception {
+            var quote = anActiveQuote();
+            var saved = quoteRepository.save(quote);
+            poolRepository.save(aUsdEurPool());
+
+            var paymentId = UUID.randomUUID();
+            var correlationId = UUID.randomUUID();
+            var requestBody = """
+                    {
+                        "paymentId": "%s",
+                        "correlationId": "%s",
+                        "sourceCountry": "US",
+                        "targetCountry": "DE"
+                    }
+                    """.formatted(paymentId, correlationId);
+
+            // First request: should return 201 Created
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", saved.quoteId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.lockId", notNullValue()))
+                    .andExpect(jsonPath("$.paymentId", is(paymentId.toString())));
+
+            // Second request with same paymentId: should return 200 OK
+            mockMvc.perform(post("/v1/fx/lock/{quoteId}", saved.quoteId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString())
+                            .content(requestBody))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.lockId", notNullValue()))
+                    .andExpect(jsonPath("$.paymentId", is(paymentId.toString())))
+                    .andExpect(jsonPath("$.fromCurrency", is("USD")))
+                    .andExpect(jsonPath("$.toCurrency", is("EUR")));
+        }
     }
 }

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/FxQuoteController.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/controller/FxQuoteController.java
@@ -10,12 +10,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -43,10 +43,11 @@ public class FxQuoteController {
     }
 
     @PostMapping("/lock/{quoteId}")
-    @ResponseStatus(HttpStatus.CREATED)
-    public FxRateLockResponse lockRate(@PathVariable UUID quoteId,
-                                       @Valid @RequestBody FxRateLockRequest request) {
+    public ResponseEntity<FxRateLockResponse> lockRate(@PathVariable UUID quoteId,
+                                                        @Valid @RequestBody FxRateLockRequest request) {
         log.info("POST /v1/fx/lock/{} paymentId={}", quoteId, request.paymentId());
-        return rateLockApplicationService.lockRate(quoteId, request);
+        var result = rateLockApplicationService.lockRate(quoteId, request);
+        var status = result.created() ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(result.response());
     }
 }

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/service/FxRateLockApplicationService.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/application/service/FxRateLockApplicationService.java
@@ -35,9 +35,23 @@ public class FxRateLockApplicationService {
     private final EventPublisher<Object> eventPublisher;
     private final FxResponseMapper responseMapper;
 
+    /**
+     * Result of a lock-rate operation, indicating whether the lock was newly created
+     * or returned from an existing idempotent match.
+     */
+    public record LockRateResult(FxRateLockResponse response, boolean created) {}
+
     @Transactional
-    public FxRateLockResponse lockRate(UUID quoteId, FxRateLockRequest request) {
+    public LockRateResult lockRate(UUID quoteId, FxRateLockRequest request) {
         log.info("Locking rate for quote={} payment={}", quoteId, request.paymentId());
+
+        // Idempotency: check if a lock already exists for this paymentId
+        var existingLock = lockRepository.findByPaymentId(request.paymentId());
+        if (existingLock.isPresent()) {
+            log.info("Idempotent lock return for payment={} lockId={}",
+                    request.paymentId(), existingLock.get().lockId());
+            return new LockRateResult(responseMapper.toResponse(existingLock.get()), false);
+        }
 
         // Load and validate quote
         var quote = quoteRepository.findById(quoteId)
@@ -73,7 +87,7 @@ public class FxRateLockApplicationService {
         log.info("Rate locked: lockId={} rate={} expires={}",
                 savedLock.lockId(), savedLock.lockedRate(), savedLock.expiresAt());
 
-        return responseMapper.toResponse(savedLock);
+        return new LockRateResult(responseMapper.toResponse(savedLock), true);
     }
 
     private void validateQuote(FxQuote quote) {

--- a/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/controller/FxQuoteControllerTest.java
@@ -6,6 +6,7 @@ import com.stablecoin.payments.fx.api.response.FxQuoteResponse;
 import com.stablecoin.payments.fx.api.response.FxRateLockResponse;
 import com.stablecoin.payments.fx.application.service.FxQuoteApplicationService;
 import com.stablecoin.payments.fx.application.service.FxRateLockApplicationService;
+import com.stablecoin.payments.fx.application.service.FxRateLockApplicationService.LockRateResult;
 import com.stablecoin.payments.fx.domain.exception.QuoteAlreadyLockedException;
 import com.stablecoin.payments.fx.domain.exception.QuoteExpiredException;
 import com.stablecoin.payments.fx.domain.exception.QuoteNotFoundException;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -131,30 +133,61 @@ class FxQuoteControllerTest {
     class LockRate {
 
         @Test
-        @DisplayName("should delegate to application service and return lock response")
-        void shouldLockRate() {
+        @DisplayName("should return 201 Created for new lock")
+        void shouldReturn201ForNewLock() {
             // given
             var quoteId = UUID.randomUUID();
             var paymentId = UUID.randomUUID();
             var correlationId = UUID.randomUUID();
             var request = new FxRateLockRequest(paymentId, correlationId, "US", "DE");
             var now = Instant.now();
-            var expectedResponse = new FxRateLockResponse(
+            var lockResponse = new FxRateLockResponse(
                     UUID.randomUUID(), quoteId, paymentId,
                     "USD", "EUR",
                     new BigDecimal("10000.00"), new BigDecimal("9200.00"),
                     new BigDecimal("0.92"), 30, new BigDecimal("30.00"),
                     now, now.plusSeconds(30));
 
-            given(rateLockApplicationService.lockRate(quoteId, request)).willReturn(expectedResponse);
+            given(rateLockApplicationService.lockRate(quoteId, request))
+                    .willReturn(new LockRateResult(lockResponse, true));
 
             // when
             var result = controller.lockRate(quoteId, request);
 
             // then
-            assertThat(result)
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(result.getBody())
                     .usingRecursiveComparison()
-                    .isEqualTo(expectedResponse);
+                    .isEqualTo(lockResponse);
+        }
+
+        @Test
+        @DisplayName("should return 200 OK for idempotent lock")
+        void shouldReturn200ForIdempotentLock() {
+            // given
+            var quoteId = UUID.randomUUID();
+            var paymentId = UUID.randomUUID();
+            var correlationId = UUID.randomUUID();
+            var request = new FxRateLockRequest(paymentId, correlationId, "US", "DE");
+            var now = Instant.now();
+            var lockResponse = new FxRateLockResponse(
+                    UUID.randomUUID(), quoteId, paymentId,
+                    "USD", "EUR",
+                    new BigDecimal("10000.00"), new BigDecimal("9200.00"),
+                    new BigDecimal("0.92"), 30, new BigDecimal("30.00"),
+                    now, now.plusSeconds(30));
+
+            given(rateLockApplicationService.lockRate(quoteId, request))
+                    .willReturn(new LockRateResult(lockResponse, false));
+
+            // when
+            var result = controller.lockRate(quoteId, request);
+
+            // then
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(result.getBody())
+                    .usingRecursiveComparison()
+                    .isEqualTo(lockResponse);
         }
 
         @Test

--- a/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/service/FxRateLockApplicationServiceTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/test/java/com/stablecoin/payments/fx/application/service/FxRateLockApplicationServiceTest.java
@@ -91,6 +91,7 @@ class FxRateLockApplicationServiceTest {
                     lock.sourceAmount(), lock.targetAmount(), lock.lockedRate(),
                     lock.feeBps(), lock.feeAmount(), lock.lockedAt(), lock.expiresAt());
 
+            given(lockRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.empty());
             given(quoteRepository.findById(quoteId)).willReturn(Optional.of(quote));
             given(poolRepository.findByCorridor("USD", "EUR")).willReturn(Optional.of(pool));
             given(lockService.lockRate(quote, PAYMENT_ID, CORRELATION_ID,
@@ -104,11 +105,45 @@ class FxRateLockApplicationServiceTest {
             var result = service.lockRate(quoteId, request);
 
             // then
+            var expected = new FxRateLockApplicationService.LockRateResult(expectedResponse, true);
             assertThat(result)
                     .usingRecursiveComparison()
-                    .isEqualTo(expectedResponse);
+                    .isEqualTo(expected);
 
             then(eventPublisher).should().publish(any(FxRateLocked.class));
+        }
+
+        @Test
+        void shouldReturnExistingLockForSamePaymentId() {
+            // given
+            var quoteId = UUID.randomUUID();
+            var existingLock = anActiveLock(quoteId, PAYMENT_ID);
+            var request = new FxRateLockRequest(PAYMENT_ID, CORRELATION_ID,
+                    SOURCE_COUNTRY, TARGET_COUNTRY);
+
+            var expectedResponse = new FxRateLockResponse(
+                    existingLock.lockId(), existingLock.quoteId(), existingLock.paymentId(),
+                    existingLock.fromCurrency(), existingLock.toCurrency(),
+                    existingLock.sourceAmount(), existingLock.targetAmount(),
+                    existingLock.lockedRate(), existingLock.feeBps(), existingLock.feeAmount(),
+                    existingLock.lockedAt(), existingLock.expiresAt());
+
+            given(lockRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.of(existingLock));
+            given(responseMapper.toResponse(existingLock)).willReturn(expectedResponse);
+
+            // when
+            var result = service.lockRate(quoteId, request);
+
+            // then
+            var expected = new FxRateLockApplicationService.LockRateResult(expectedResponse, false);
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+
+            then(quoteRepository).should(never()).findById(any());
+            then(lockService).should(never()).lockRate(any(), any(), any(), any(), any(), any());
+            then(lockRepository).should(never()).save(any());
+            then(eventPublisher).should(never()).publish(any());
         }
 
         @Test
@@ -117,6 +152,7 @@ class FxRateLockApplicationServiceTest {
             var quoteId = UUID.randomUUID();
             var request = new FxRateLockRequest(PAYMENT_ID, CORRELATION_ID,
                     SOURCE_COUNTRY, TARGET_COUNTRY);
+            given(lockRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.empty());
             given(quoteRepository.findById(quoteId)).willReturn(Optional.empty());
 
             // when/then
@@ -135,6 +171,7 @@ class FxRateLockApplicationServiceTest {
             var quoteId = expiredQuote.quoteId();
             var request = new FxRateLockRequest(PAYMENT_ID, CORRELATION_ID,
                     SOURCE_COUNTRY, TARGET_COUNTRY);
+            given(lockRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.empty());
             given(quoteRepository.findById(quoteId)).willReturn(Optional.of(expiredQuote));
 
             // when/then
@@ -153,6 +190,7 @@ class FxRateLockApplicationServiceTest {
             var quoteId = lockedQuote.quoteId();
             var request = new FxRateLockRequest(PAYMENT_ID, CORRELATION_ID,
                     SOURCE_COUNTRY, TARGET_COUNTRY);
+            given(lockRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.empty());
             given(quoteRepository.findById(quoteId)).willReturn(Optional.of(lockedQuote));
 
             // when/then
@@ -171,6 +209,7 @@ class FxRateLockApplicationServiceTest {
             var quoteId = quote.quoteId();
             var request = new FxRateLockRequest(PAYMENT_ID, CORRELATION_ID,
                     SOURCE_COUNTRY, TARGET_COUNTRY);
+            given(lockRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.empty());
             given(quoteRepository.findById(quoteId)).willReturn(Optional.of(quote));
             given(poolRepository.findByCorridor("USD", "EUR")).willReturn(Optional.empty());
 
@@ -191,6 +230,7 @@ class FxRateLockApplicationServiceTest {
             var lowPool = aPoolWithLowBalance();
             var request = new FxRateLockRequest(PAYMENT_ID, CORRELATION_ID,
                     SOURCE_COUNTRY, TARGET_COUNTRY);
+            given(lockRepository.findByPaymentId(PAYMENT_ID)).willReturn(Optional.empty());
             given(quoteRepository.findById(quoteId)).willReturn(Optional.of(quote));
             given(poolRepository.findByCorridor("USD", "EUR")).willReturn(Optional.of(lowPool));
 


### PR DESCRIPTION
Closes STA-102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotent lock requests: duplicate lock requests with the same payment ID now return the existing lock with HTTP 200 OK instead of failing.
  * Improved HTTP status codes: new locks return 201 Created, idempotent requests return 200 OK.

* **Tests**
  * Added integration test verifying idempotent lock behavior.
  * Updated unit tests to cover both new and idempotent lock scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->