### PR TITLE
feat(s1): event publishing — Temporal activity + Namastack outbox (STA-113)

### DIFF
--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/application/config/TemporalWorkerConfig.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/application/config/TemporalWorkerConfig.java
@@ -2,6 +2,7 @@ package com.stablecoin.payments.orchestrator.application.config;
 
 import com.stablecoin.payments.orchestrator.domain.workflow.PaymentWorkflowImpl;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.ComplianceCheckActivity;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.EventPublishingActivity;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxLockActivity;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
@@ -25,12 +26,14 @@ public class TemporalWorkerConfig {
     @Bean
     public Worker paymentWorker(WorkerFactory workerFactory,
                                 ComplianceCheckActivity complianceCheckActivity,
-                                FxLockActivity fxLockActivity) {
+                                FxLockActivity fxLockActivity,
+                                EventPublishingActivity eventPublishingActivity) {
         var worker = workerFactory.newWorker(TASK_QUEUE);
         worker.registerWorkflowImplementationTypes(PaymentWorkflowImpl.class);
-        worker.registerActivitiesImplementations(complianceCheckActivity, fxLockActivity);
+        worker.registerActivitiesImplementations(
+                complianceCheckActivity, fxLockActivity, eventPublishingActivity);
         log.info("Temporal worker registered on queue={} with PaymentWorkflow, "
-                + "ComplianceCheckActivity, FxLockActivity", TASK_QUEUE);
+                + "ComplianceCheckActivity, FxLockActivity, EventPublishingActivity", TASK_QUEUE);
         workerFactory.start();
         return worker;
     }

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentCompensationStarted.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentCompensationStarted.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public record PaymentCompensationStarted(
         UUID paymentId,
+        UUID correlationId,
         String compensationReason,
         Instant startedAt
 ) {

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentCompleted.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentCompleted.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 public record PaymentCompleted(
         UUID paymentId,
+        UUID correlationId,
         Money sourceAmount,
         Money targetAmount,
         FxRate fxRate,

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentFailed.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentFailed.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public record PaymentFailed(
         UUID paymentId,
+        UUID correlationId,
         PaymentState failedState,
         String reason,
         String errorCode,

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentStateAdvanced.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/event/PaymentStateAdvanced.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public record PaymentStateAdvanced(
         UUID paymentId,
+        UUID correlationId,
         PaymentState fromState,
         PaymentState toState,
         Instant advancedAt,

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/service/PaymentCommandHandler.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/service/PaymentCommandHandler.java
@@ -1,10 +1,12 @@
 package com.stablecoin.payments.orchestrator.domain.service;
 
+import com.stablecoin.payments.orchestrator.domain.event.PaymentInitiated;
 import com.stablecoin.payments.orchestrator.domain.model.Corridor;
 import com.stablecoin.payments.orchestrator.domain.model.Money;
 import com.stablecoin.payments.orchestrator.domain.model.Payment;
 import com.stablecoin.payments.orchestrator.domain.model.PaymentNotCancellableException;
 import com.stablecoin.payments.orchestrator.domain.model.PaymentNotFoundException;
+import com.stablecoin.payments.orchestrator.domain.port.PaymentEventPublisher;
 import com.stablecoin.payments.orchestrator.domain.port.PaymentRepository;
 import com.stablecoin.payments.orchestrator.domain.workflow.PaymentWorkflow;
 import com.stablecoin.payments.orchestrator.domain.workflow.dto.CancelRequest;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -37,6 +40,7 @@ import static com.stablecoin.payments.orchestrator.application.config.TemporalCo
 public class PaymentCommandHandler {
 
     private final PaymentRepository paymentRepository;
+    private final PaymentEventPublisher eventPublisher;
     private final WorkflowClient workflowClient;
 
     /**
@@ -87,6 +91,18 @@ public class PaymentCommandHandler {
                     .orElseThrow(() -> ex);
             return new InitiateResult(concurrent, true);
         }
+
+        eventPublisher.publish(new PaymentInitiated(
+                saved.paymentId(),
+                saved.idempotencyKey(),
+                saved.correlationId(),
+                saved.senderId(),
+                saved.recipientId(),
+                saved.sourceAmount(),
+                saved.targetCurrency(),
+                saved.corridor(),
+                Instant.now()
+        ));
 
         startWorkflow(saved, sourceCountry, targetCountry);
 

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/workflow/PaymentWorkflowImpl.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/workflow/PaymentWorkflowImpl.java
@@ -3,10 +3,12 @@ package com.stablecoin.payments.orchestrator.domain.workflow;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.ComplianceCheckActivity;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.ComplianceRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.ComplianceResult;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.EventPublishingActivity;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxLockActivity;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxLockRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxLockResult;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxReleaseRequest;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.PaymentEventRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.dto.CancelRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.dto.ChainConfirmedSignal;
 import com.stablecoin.payments.orchestrator.domain.workflow.dto.FiatCollectedSignal;
@@ -69,6 +71,18 @@ public class PaymentWorkflowImpl implements PaymentWorkflow {
                             .build())
                     .build());
 
+    private final EventPublishingActivity eventPublishingActivity = Workflow.newActivityStub(
+            EventPublishingActivity.class,
+            ActivityOptions.newBuilder()
+                    .setStartToCloseTimeout(Duration.ofSeconds(10))
+                    .setRetryOptions(RetryOptions.newBuilder()
+                            .setMaximumAttempts(3)
+                            .setInitialInterval(Duration.ofSeconds(1))
+                            .setMaximumInterval(Duration.ofSeconds(5))
+                            .setBackoffCoefficient(2.0)
+                            .build())
+                    .build());
+
     // Workflow state — deterministic, no external I/O
     private String currentState = "INITIATED";
     private boolean cancelRequested;
@@ -104,18 +118,22 @@ public class PaymentWorkflowImpl implements PaymentWorkflow {
             ));
         } catch (Exception e) {
             currentState = "FAILED";
+            var reason = "Compliance check failed: " + e.getMessage();
             log.error("Compliance check failed with exception for paymentId={}",
                     request.paymentId(), e);
-            return PaymentResult.failed(request.paymentId(),
-                    "Compliance check failed: " + e.getMessage());
+            publishEvent(PaymentEventRequest.failed(request.paymentId(),
+                    request.correlationId(), "COMPLIANCE_CHECK", reason, "COMPLIANCE_ERROR"));
+            return PaymentResult.failed(request.paymentId(), reason);
         }
 
         if (complianceResult.status() != ComplianceResult.ComplianceStatus.PASSED) {
             currentState = "FAILED";
+            var reason = "Compliance check failed: " + complianceResult.failureReason();
             log.info("Compliance check rejected for paymentId={}: {}",
                     request.paymentId(), complianceResult.failureReason());
-            return PaymentResult.failed(request.paymentId(),
-                    "Compliance check failed: " + complianceResult.failureReason());
+            publishEvent(PaymentEventRequest.failed(request.paymentId(),
+                    request.correlationId(), "COMPLIANCE_CHECK", reason, "COMPLIANCE_REJECTED"));
+            return PaymentResult.failed(request.paymentId(), reason);
         }
 
         // No compensation needed for compliance — it's a read-only check
@@ -143,18 +161,22 @@ public class PaymentWorkflowImpl implements PaymentWorkflow {
             ));
         } catch (Exception e) {
             currentState = "FAILED";
+            var reason = "FX rate lock failed: " + e.getMessage();
             log.error("FX lock failed with exception for paymentId={}",
                     request.paymentId(), e);
-            return PaymentResult.failed(request.paymentId(),
-                    "FX rate lock failed: " + e.getMessage());
+            publishEvent(PaymentEventRequest.failed(request.paymentId(),
+                    request.correlationId(), "FX_LOCKING", reason, "FX_LOCK_ERROR"));
+            return PaymentResult.failed(request.paymentId(), reason);
         }
 
         if (fxResult.status() != FxLockResult.FxLockStatus.LOCKED) {
             currentState = "FAILED";
+            var reason = "FX rate lock failed: " + fxResult.failureReason();
             log.info("FX lock rejected for paymentId={}: {}",
                     request.paymentId(), fxResult.failureReason());
-            return PaymentResult.failed(request.paymentId(),
-                    "FX rate lock failed: " + fxResult.failureReason());
+            publishEvent(PaymentEventRequest.failed(request.paymentId(),
+                    request.correlationId(), "FX_LOCKING", reason, "FX_LOCK_REJECTED"));
+            return PaymentResult.failed(request.paymentId(), reason);
         }
 
         // FX lock succeeded — push compensation (release lock) onto stack
@@ -219,6 +241,9 @@ public class PaymentWorkflowImpl implements PaymentWorkflow {
         log.info("Cancellation requested for paymentId={}, reason={}, compensationSteps={}",
                 request.paymentId(), reason, compensationStack.size());
 
+        publishEvent(PaymentEventRequest.cancelled(
+                request.paymentId(), request.correlationId(), reason));
+
         // Unwind compensation stack in LIFO order
         while (!compensationStack.isEmpty()) {
             var step = compensationStack.pop();
@@ -242,6 +267,18 @@ public class PaymentWorkflowImpl implements PaymentWorkflow {
         } catch (Exception e) {
             log.error("Compensation step failed: {} for paymentId={}, error={}",
                     step, paymentId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Fire-and-forget event publishing. Failures are logged but do not block the saga.
+     */
+    private void publishEvent(PaymentEventRequest request) {
+        try {
+            eventPublishingActivity.publishPaymentEvent(request);
+        } catch (Exception e) {
+            log.warn("Event publishing failed for paymentId={}, eventType={}: {}",
+                    request.paymentId(), request.eventType(), e.getMessage());
         }
     }
 }

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/workflow/activity/EventPublishingActivity.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/workflow/activity/EventPublishingActivity.java
@@ -1,0 +1,15 @@
+package com.stablecoin.payments.orchestrator.domain.workflow.activity;
+
+import io.temporal.activity.ActivityInterface;
+
+/**
+ * Temporal activity for publishing payment lifecycle events to Kafka via Namastack outbox.
+ * <p>
+ * Events are published fire-and-forget from the workflow — failures do not block
+ * the saga. The outbox guarantees at-least-once delivery to Kafka.
+ */
+@ActivityInterface
+public interface EventPublishingActivity {
+
+    void publishPaymentEvent(PaymentEventRequest request);
+}

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/workflow/activity/PaymentEventRequest.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/domain/workflow/activity/PaymentEventRequest.java
@@ -1,0 +1,42 @@
+package com.stablecoin.payments.orchestrator.domain.workflow.activity;
+
+import com.stablecoin.payments.orchestrator.domain.event.PaymentCompensationStarted;
+import com.stablecoin.payments.orchestrator.domain.event.PaymentFailed;
+
+import java.util.UUID;
+
+/**
+ * Serializable DTO for publishing payment events from the Temporal workflow.
+ * <p>
+ * Uses Strings for enum fields to ensure clean Temporal serialization.
+ * The activity implementation maps this back to the appropriate domain event.
+ *
+ * @param eventType   event type identifier matching the domain event TOPIC constant
+ * @param paymentId   payment aggregate ID (used as Kafka partition key)
+ * @param correlationId trace correlation ID for distributed tracing
+ * @param failedState state at which failure occurred (only for payment.failed)
+ * @param reason      failure or cancellation reason
+ * @param errorCode   error code (only for payment.failed)
+ */
+public record PaymentEventRequest(
+        String eventType,
+        UUID paymentId,
+        UUID correlationId,
+        String failedState,
+        String reason,
+        String errorCode
+) {
+
+    public static PaymentEventRequest failed(UUID paymentId, UUID correlationId,
+                                             String failedState, String reason,
+                                             String errorCode) {
+        return new PaymentEventRequest(PaymentFailed.TOPIC, paymentId, correlationId,
+                failedState, reason, errorCode);
+    }
+
+    public static PaymentEventRequest cancelled(UUID paymentId, UUID correlationId,
+                                                String reason) {
+        return new PaymentEventRequest(PaymentCompensationStarted.TOPIC, paymentId, correlationId,
+                null, reason, null);
+    }
+}

--- a/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/infrastructure/activity/EventPublishingActivityImpl.java
+++ b/payment-orchestrator/payment-orchestrator/src/main/java/com/stablecoin/payments/orchestrator/infrastructure/activity/EventPublishingActivityImpl.java
@@ -1,0 +1,62 @@
+package com.stablecoin.payments.orchestrator.infrastructure.activity;
+
+import com.stablecoin.payments.orchestrator.domain.event.PaymentCompensationStarted;
+import com.stablecoin.payments.orchestrator.domain.event.PaymentFailed;
+import com.stablecoin.payments.orchestrator.domain.model.PaymentState;
+import com.stablecoin.payments.orchestrator.domain.port.PaymentEventPublisher;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.EventPublishingActivity;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.PaymentEventRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * Temporal activity implementation that publishes payment events via Namastack outbox.
+ * <p>
+ * Each invocation runs in its own transaction so the outbox write is atomic.
+ * The {@link PaymentEventPublisher} uses {@code @Transactional(propagation = MANDATORY)},
+ * which joins this activity's transaction.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventPublishingActivityImpl implements EventPublishingActivity {
+
+    private final PaymentEventPublisher eventPublisher;
+
+    @Override
+    @Transactional
+    public void publishPaymentEvent(PaymentEventRequest request) {
+        log.info("Publishing event type={} for paymentId={}", request.eventType(), request.paymentId());
+
+        var event = mapToEvent(request);
+        eventPublisher.publish(event);
+
+        log.info("Event published type={} paymentId={}", request.eventType(), request.paymentId());
+    }
+
+    private Object mapToEvent(PaymentEventRequest request) {
+        if (PaymentFailed.TOPIC.equals(request.eventType())) {
+            return new PaymentFailed(
+                    request.paymentId(),
+                    request.correlationId(),
+                    PaymentState.valueOf(request.failedState()),
+                    request.reason(),
+                    request.errorCode(),
+                    Instant.now()
+            );
+        }
+        if (PaymentCompensationStarted.TOPIC.equals(request.eventType())) {
+            return new PaymentCompensationStarted(
+                    request.paymentId(),
+                    request.correlationId(),
+                    request.reason(),
+                    Instant.now()
+            );
+        }
+        throw new IllegalArgumentException("Unknown event type: " + request.eventType());
+    }
+}

--- a/payment-orchestrator/payment-orchestrator/src/test/java/com/stablecoin/payments/orchestrator/domain/service/PaymentCommandHandlerTest.java
+++ b/payment-orchestrator/payment-orchestrator/src/test/java/com/stablecoin/payments/orchestrator/domain/service/PaymentCommandHandlerTest.java
@@ -1,11 +1,13 @@
 package com.stablecoin.payments.orchestrator.domain.service;
 
+import com.stablecoin.payments.orchestrator.domain.event.PaymentInitiated;
 import com.stablecoin.payments.orchestrator.domain.model.Corridor;
 import com.stablecoin.payments.orchestrator.domain.model.Money;
 import com.stablecoin.payments.orchestrator.domain.model.Payment;
 import com.stablecoin.payments.orchestrator.domain.model.PaymentNotCancellableException;
 import com.stablecoin.payments.orchestrator.domain.model.PaymentNotFoundException;
 import com.stablecoin.payments.orchestrator.domain.model.PaymentState;
+import com.stablecoin.payments.orchestrator.domain.port.PaymentEventPublisher;
 import com.stablecoin.payments.orchestrator.domain.port.PaymentRepository;
 import com.stablecoin.payments.orchestrator.domain.workflow.PaymentWorkflow;
 import com.stablecoin.payments.orchestrator.domain.workflow.dto.CancelRequest;
@@ -54,6 +56,9 @@ class PaymentCommandHandlerTest {
     private PaymentRepository paymentRepository;
 
     @Mock
+    private PaymentEventPublisher eventPublisher;
+
+    @Mock
     private WorkflowClient workflowClient;
 
     @InjectMocks
@@ -99,6 +104,19 @@ class PaymentCommandHandlerTest {
                     .isEqualTo(expectedPayment);
 
             then(paymentRepository).should().save(eqIgnoring(expectedPayment, "paymentId"));
+
+            var eventCaptor = ArgumentCaptor.forClass(Object.class);
+            then(eventPublisher).should().publish(eventCaptor.capture());
+            var publishedEvent = (PaymentInitiated) eventCaptor.getValue();
+            var expectedEvent = new PaymentInitiated(
+                    result.payment().paymentId(), IDEMPOTENCY_KEY, CORRELATION_ID,
+                    SENDER_ID, RECIPIENT_ID, new Money(SOURCE_AMOUNT_VALUE, SOURCE_CURRENCY),
+                    TARGET_CURRENCY, new Corridor(SOURCE_COUNTRY, TARGET_COUNTRY), null);
+            assertThat(publishedEvent)
+                    .usingRecursiveComparison()
+                    .ignoringFields("initiatedAt")
+                    .isEqualTo(expectedEvent);
+
             then(workflowClient).should().newWorkflowStub(eq(PaymentWorkflow.class), any(WorkflowOptions.class));
         }
 
@@ -125,6 +143,7 @@ class PaymentCommandHandlerTest {
                     .isEqualTo(existingPayment);
 
             then(paymentRepository).should(never()).save(any());
+            then(eventPublisher).should(never()).publish(any());
             then(workflowClient).should(never()).newWorkflowStub(eq(PaymentWorkflow.class), any(WorkflowOptions.class));
         }
 
@@ -155,6 +174,7 @@ class PaymentCommandHandlerTest {
                     .usingRecursiveComparison()
                     .isEqualTo(existingPayment);
 
+            then(eventPublisher).should(never()).publish(any());
             then(workflowClient).should(never()).newWorkflowStub(eq(PaymentWorkflow.class), any(WorkflowOptions.class));
         }
     }

--- a/payment-orchestrator/payment-orchestrator/src/test/java/com/stablecoin/payments/orchestrator/domain/workflow/PaymentWorkflowTest.java
+++ b/payment-orchestrator/payment-orchestrator/src/test/java/com/stablecoin/payments/orchestrator/domain/workflow/PaymentWorkflowTest.java
@@ -3,10 +3,12 @@ package com.stablecoin.payments.orchestrator.domain.workflow;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.ComplianceCheckActivity;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.ComplianceRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.ComplianceResult;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.EventPublishingActivity;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxLockActivity;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxLockRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxLockResult;
 import com.stablecoin.payments.orchestrator.domain.workflow.activity.FxReleaseRequest;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.PaymentEventRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.dto.CancelRequest;
 import com.stablecoin.payments.orchestrator.domain.workflow.dto.PaymentResult;
 import io.temporal.client.WorkflowClient;
@@ -44,11 +46,12 @@ class PaymentWorkflowTest {
 
     private final ComplianceCheckActivity complianceActivity = mock(ComplianceCheckActivity.class);
     private final FxLockActivity fxLockActivity = mock(FxLockActivity.class);
+    private final EventPublishingActivity eventPublishingActivity = mock(EventPublishingActivity.class);
 
     @RegisterExtension
     public TestWorkflowExtension testWorkflow = TestWorkflowExtension.newBuilder()
             .setWorkflowTypes(PaymentWorkflowImpl.class)
-            .setActivityImplementations(complianceActivity, fxLockActivity)
+            .setActivityImplementations(complianceActivity, fxLockActivity, eventPublishingActivity)
             .build();
 
     @Nested
@@ -80,6 +83,7 @@ class PaymentWorkflowTest {
 
             then(complianceActivity).should().checkCompliance(any(ComplianceRequest.class));
             then(fxLockActivity).should().lockFxRate(any(FxLockRequest.class));
+            then(eventPublishingActivity).should(never()).publishPaymentEvent(any());
         }
     }
 
@@ -103,6 +107,12 @@ class PaymentWorkflowTest {
                     .isEqualTo(expected);
 
             then(fxLockActivity).should(never()).lockFxRate(any());
+
+            var expectedEvent = PaymentEventRequest.failed(
+                    PAYMENT_ID, aPaymentRequest().correlationId(),
+                    "COMPLIANCE_CHECK", "Compliance check failed: PEP match",
+                    "COMPLIANCE_REJECTED");
+            then(eventPublishingActivity).should().publishPaymentEvent(expectedEvent);
         }
 
         @Test
@@ -123,6 +133,12 @@ class PaymentWorkflowTest {
                     .isEqualTo(expected);
 
             then(fxLockActivity).should(never()).lockFxRate(any());
+
+            var expectedEvent = PaymentEventRequest.failed(
+                    PAYMENT_ID, aPaymentRequest().correlationId(),
+                    "COMPLIANCE_CHECK", "Compliance check failed: OFAC sanctions list match",
+                    "COMPLIANCE_REJECTED");
+            then(eventPublishingActivity).should().publishPaymentEvent(expectedEvent);
         }
     }
 
@@ -149,6 +165,12 @@ class PaymentWorkflowTest {
             assertThat(result)
                     .usingRecursiveComparison()
                     .isEqualTo(expected);
+
+            var expectedEvent = PaymentEventRequest.failed(
+                    PAYMENT_ID, aPaymentRequest().correlationId(),
+                    "FX_LOCKING", "FX rate lock failed: No liquidity for USD/EUR",
+                    "FX_LOCK_REJECTED");
+            then(eventPublishingActivity).should().publishPaymentEvent(expectedEvent);
         }
     }
 
@@ -187,6 +209,11 @@ class PaymentWorkflowTest {
 
             then(fxLockActivity).should().releaseLock(new FxReleaseRequest(
                     LOCK_ID, PAYMENT_ID, "Customer requested cancellation"));
+
+            var expectedEvent = PaymentEventRequest.cancelled(
+                    PAYMENT_ID, aPaymentRequest().correlationId(),
+                    "Customer requested cancellation");
+            then(eventPublishingActivity).should().publishPaymentEvent(expectedEvent);
         }
 
         @Test
@@ -213,6 +240,10 @@ class PaymentWorkflowTest {
 
             then(fxLockActivity).should(never()).lockFxRate(any());
             then(fxLockActivity).should(never()).releaseLock(any());
+
+            var expectedEvent = PaymentEventRequest.cancelled(
+                    PAYMENT_ID, aPaymentRequest().correlationId(), "Changed mind");
+            then(eventPublishingActivity).should().publishPaymentEvent(expectedEvent);
         }
 
         @Test

--- a/payment-orchestrator/payment-orchestrator/src/test/java/com/stablecoin/payments/orchestrator/infrastructure/activity/EventPublishingActivityImplTest.java
+++ b/payment-orchestrator/payment-orchestrator/src/test/java/com/stablecoin/payments/orchestrator/infrastructure/activity/EventPublishingActivityImplTest.java
@@ -1,0 +1,86 @@
+package com.stablecoin.payments.orchestrator.infrastructure.activity;
+
+import com.stablecoin.payments.orchestrator.domain.event.PaymentCompensationStarted;
+import com.stablecoin.payments.orchestrator.domain.event.PaymentFailed;
+import com.stablecoin.payments.orchestrator.domain.model.PaymentState;
+import com.stablecoin.payments.orchestrator.domain.port.PaymentEventPublisher;
+import com.stablecoin.payments.orchestrator.domain.workflow.activity.PaymentEventRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static com.stablecoin.payments.orchestrator.fixtures.TestUtils.eqIgnoringTimestamps;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventPublishingActivityImpl")
+class EventPublishingActivityImplTest {
+
+    @Mock
+    private PaymentEventPublisher eventPublisher;
+
+    @InjectMocks
+    private EventPublishingActivityImpl activity;
+
+    private static final UUID PAYMENT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID CORRELATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000010");
+
+    @Test
+    @DisplayName("should publish PaymentFailed event via outbox")
+    void shouldPublishPaymentFailedEvent() {
+        // given
+        var request = PaymentEventRequest.failed(
+                PAYMENT_ID, CORRELATION_ID, "COMPLIANCE_CHECK",
+                "Sanctions hit", "COMPLIANCE_REJECTED");
+
+        // when
+        activity.publishPaymentEvent(request);
+
+        // then
+        var expected = new PaymentFailed(
+                PAYMENT_ID, CORRELATION_ID,
+                PaymentState.COMPLIANCE_CHECK,
+                "Sanctions hit", "COMPLIANCE_REJECTED",
+                Instant.now());
+        then(eventPublisher).should().publish(eqIgnoringTimestamps(expected));
+    }
+
+    @Test
+    @DisplayName("should publish PaymentCompensationStarted event via outbox")
+    void shouldPublishCompensationStartedEvent() {
+        // given
+        var request = PaymentEventRequest.cancelled(
+                PAYMENT_ID, CORRELATION_ID, "Customer requested cancellation");
+
+        // when
+        activity.publishPaymentEvent(request);
+
+        // then
+        var expected = new PaymentCompensationStarted(
+                PAYMENT_ID, CORRELATION_ID,
+                "Customer requested cancellation",
+                Instant.now());
+        then(eventPublisher).should().publish(eqIgnoringTimestamps(expected));
+    }
+
+    @Test
+    @DisplayName("should throw on unknown event type")
+    void shouldThrowOnUnknownEventType() {
+        // given
+        var request = new PaymentEventRequest(
+                "payment.unknown", PAYMENT_ID, CORRELATION_ID,
+                null, null, null);
+
+        // when/then
+        assertThatThrownBy(() -> activity.publishPaymentEvent(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("payment.unknown");
+    }
+}


### PR DESCRIPTION
## Summary

- **EventPublishingActivity** `@ActivityInterface` with `publishPaymentEvent()` — Temporal activity wrapping Namastack outbox for Kafka event fanout
- **PaymentCommandHandler** publishes `PaymentInitiated` on payment creation (atomic with save via outbox)
- **PaymentWorkflowImpl** fires `PaymentFailed` on compliance/FX failures and `PaymentCompensationStarted` on cancellation — non-blocking (try-catch, doesn't fail the saga)
- All domain events gain `correlationId` field per acceptance criteria
- `PaymentEventRequest` uses domain event `TOPIC` constants as single source of truth
- 3 new unit tests (EventPublishingActivityImplTest), all 198 unit + 20 IT green

## Test plan

- [x] `EventPublishingActivityImplTest` — verifies PaymentFailed and PaymentCompensationStarted mapping + outbox publish
- [x] `PaymentCommandHandlerTest` — verifies PaymentInitiated published on creation, not on replay
- [x] `PaymentWorkflowTest` — verifies event publishing on compliance failure, FX failure, and cancellation; no event on happy path
- [x] Integration tests pass (20 ITs)
- [x] Spotless formatting clean

Closes STA-113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Payment lifecycle events are now published reliably for initiations, completions, failures, and state changes, enabling event-driven system integrations
  * Correlation ID tracking added across all payment events to improve request traceability and facilitate debugging
  * Event publishing uses fire-and-forget semantics ensuring at-least-once delivery

* **Tests**
  * Added comprehensive test coverage for event publishing workflows and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->