### PR TITLE
feat(s3,s4): project scaffolds — S3 Fiat On-Ramp + S4 Blockchain & Custody (STA-119, STA-131)

### DIFF
--- a/blockchain-custody/blockchain-custody-api/build.gradle.kts
+++ b/blockchain-custody/blockchain-custody-api/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api("jakarta.validation:jakarta.validation-api")
+    api("com.fasterxml.jackson.core:jackson-annotations")
+
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.assertj:assertj-core")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/ApiError.java
+++ b/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/ApiError.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.custody.api;
+
+import java.util.List;
+import java.util.Map;
+
+public record ApiError(
+        String code,
+        String status,
+        String message,
+        Map<String, List<String>> errors
+) {
+    public static ApiError of(String code, String status, String message) {
+        return new ApiError(code, status, message, Map.of());
+    }
+
+    public static ApiError withErrors(String code, String status, String message,
+                                      Map<String, List<String>> errors) {
+        return new ApiError(code, status, message, errors);
+    }
+}

--- a/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/TransferResponse.java
+++ b/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/TransferResponse.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.custody.api;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TransferResponse(
+        UUID transferId,
+        UUID paymentId,
+        String status,
+        String chainId,
+        String stablecoin,
+        String amount,
+        String fromAddress,
+        String toAddress,
+        String txHash,
+        String blockNumber,
+        Integer confirmations,
+        String gasUsed,
+        String gasPriceGwei,
+        Integer estimatedConfirmationS,
+        Instant confirmedAt,
+        Instant createdAt
+) {}

--- a/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/WalletBalanceResponse.java
+++ b/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/WalletBalanceResponse.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.custody.api;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record WalletBalanceResponse(
+        UUID walletId,
+        String address,
+        String chainId,
+        List<BalanceEntry> balances,
+        Instant updatedAt
+) {
+    public record BalanceEntry(
+            String stablecoin,
+            String availableBalance,
+            String reservedBalance,
+            String blockchainBalance,
+            String lastIndexedBlock
+    ) {}
+}

--- a/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainReturnConfirmed.java
+++ b/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainReturnConfirmed.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.custody.api.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ChainReturnConfirmed(
+        String schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID transferId,
+        UUID parentTransferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String txHash,
+        Instant confirmedAt
+) {
+    public static final String EVENT_TYPE = "chain.return.confirmed";
+    public static final String SCHEMA_VERSION = "1.0";
+}

--- a/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainTransferConfirmed.java
+++ b/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainTransferConfirmed.java
@@ -1,0 +1,22 @@
+package com.stablecoin.payments.custody.api.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ChainTransferConfirmed(
+        String schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID transferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String txHash,
+        String blockNumber,
+        Integer confirmations,
+        String gasUsed,
+        Instant confirmedAt
+) {
+    public static final String EVENT_TYPE = "chain.transfer.confirmed";
+    public static final String SCHEMA_VERSION = "1.0";
+}

--- a/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainTransferFailed.java
+++ b/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainTransferFailed.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.custody.api.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ChainTransferFailed(
+        String schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID transferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String reason,
+        String errorCode,
+        Instant failedAt
+) {
+    public static final String EVENT_TYPE = "chain.transfer.failed";
+    public static final String SCHEMA_VERSION = "1.0";
+}

--- a/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainTransferSubmitted.java
+++ b/blockchain-custody/blockchain-custody-api/src/main/java/com/stablecoin/payments/custody/api/events/ChainTransferSubmitted.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.custody.api.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ChainTransferSubmitted(
+        String schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID transferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String stablecoin,
+        String amount,
+        String txHash,
+        String fromAddress,
+        String toAddress,
+        Instant submittedAt
+) {
+    public static final String EVENT_TYPE = "chain.transfer.submitted";
+    public static final String SCHEMA_VERSION = "1.0";
+}

--- a/blockchain-custody/blockchain-custody-client/build.gradle.kts
+++ b/blockchain-custody/blockchain-custody-client/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":blockchain-custody:blockchain-custody-api"))
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.assertj:assertj-core")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/blockchain-custody/blockchain-custody-client/src/main/java/com/stablecoin/payments/custody/client/BlockchainCustodyClient.java
+++ b/blockchain-custody/blockchain-custody-client/src/main/java/com/stablecoin/payments/custody/client/BlockchainCustodyClient.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.client;
+
+import com.stablecoin.payments.custody.api.TransferResponse;
+import com.stablecoin.payments.custody.api.WalletBalanceResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "blockchain-custody-service", url = "${app.services.blockchain-custody.url}")
+public interface BlockchainCustodyClient {
+
+    @GetMapping(value = "/v1/transfers/{transferId}", produces = "application/json")
+    TransferResponse getTransfer(@PathVariable("transferId") UUID transferId);
+
+    @GetMapping(value = "/v1/wallets/{walletId}/balance", produces = "application/json")
+    WalletBalanceResponse getWalletBalance(@PathVariable("walletId") UUID walletId);
+}

--- a/blockchain-custody/blockchain-custody/build.gradle.kts
+++ b/blockchain-custody/blockchain-custody/build.gradle.kts
@@ -1,0 +1,205 @@
+plugins {
+    id("org.springframework.boot")
+    id("com.google.cloud.tools.jib")
+    java
+    `java-test-fixtures`
+    jacoco
+}
+
+jib {
+    from {
+        image = "eclipse-temurin:25-jre-alpine"
+    }
+    to {
+        image = "stablebridge/blockchain-custody"
+        tags = setOf("latest")
+    }
+    container {
+        creationTime.set("USE_CURRENT_TIMESTAMP")
+    }
+}
+
+val integrationTestSourceSet: SourceSet = sourceSets.create("integrationTest") {
+    java.srcDir("src/integration-test/java")
+    resources.srcDir("src/integration-test/resources")
+    compileClasspath += sourceSets.main.get().output + sourceSets.test.get().output
+    runtimeClasspath += sourceSets.main.get().output + sourceSets.test.get().output
+}
+
+configurations {
+    named("integrationTestImplementation") { extendsFrom(configurations.testImplementation.get()) }
+    named("integrationTestRuntimeOnly") { extendsFrom(configurations.testRuntimeOnly.get()) }
+}
+
+tasks.register<Test>("integrationTest") {
+    testClassesDirs = integrationTestSourceSet.output.classesDirs
+    classpath = integrationTestSourceSet.runtimeClasspath
+    shouldRunAfter(tasks.test)
+    configure<JacocoTaskExtension> { isEnabled = false }
+    failOnNoDiscoveredTests = false
+    exclude("**/Abstract*", "**/config/**")
+}
+
+val businessTestSourceSet: SourceSet = sourceSets.create("businessTest") {
+    java.srcDir("src/business-test/java")
+    resources.srcDir("src/business-test/resources")
+    compileClasspath += sourceSets.main.get().output + sourceSets.test.get().output + integrationTestSourceSet.output
+    runtimeClasspath += sourceSets.main.get().output + sourceSets.test.get().output + integrationTestSourceSet.output
+}
+
+configurations {
+    named("businessTestImplementation") { extendsFrom(configurations.named("integrationTestImplementation").get()) }
+    named("businessTestRuntimeOnly") { extendsFrom(configurations.named("integrationTestRuntimeOnly").get()) }
+}
+
+tasks.register<Test>("businessTest") {
+    testClassesDirs = businessTestSourceSet.output.classesDirs
+    classpath = businessTestSourceSet.runtimeClasspath
+    shouldRunAfter(tasks.named("integrationTest"))
+    failOnNoDiscoveredTests = false
+    configure<JacocoTaskExtension> { isEnabled = false }
+}
+
+val lombokVersion: String by project
+val mapstructVersion: String by project
+val lombokMapstructBindingVersion: String by project
+val resilience4jVersion: String by project
+val flywayVersion: String by project
+val archunitVersion: String by project
+val testcontainersVersion: String by project
+val wiremockVersion: String by project
+val springdocVersion: String by project
+
+dependencies {
+    implementation(project(":blockchain-custody:blockchain-custody-api"))
+
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // OpenAPI / Swagger UI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    implementation("io.micrometer:micrometer-tracing-bridge-otel")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // Redis — nonce locks, balance cache
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+    // Kafka via Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
+    // Feign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    // Resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:$resilience4jVersion")
+    implementation("io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion")
+
+    // MapStruct (compiler args set below in JavaCompile task)
+    implementation("org.mapstruct:mapstruct:$mapstructVersion")
+    annotationProcessor("org.mapstruct:mapstruct-processor:$mapstructVersion")
+    annotationProcessor("org.projectlombok:lombok-mapstruct-binding:$lombokMapstructBindingVersion")
+
+    // Outbox (namastack)
+    implementation("io.namastack:namastack-outbox-starter-jdbc:1.0.0")
+
+    // Database
+    runtimeOnly("org.postgresql:postgresql")
+    implementation("org.springframework.boot:spring-boot-starter-flyway")
+    implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
+
+    // Test Fixtures
+    testFixturesImplementation("org.assertj:assertj-core")
+    testFixturesImplementation("org.mockito:mockito-core")
+
+    // Test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-security-test")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation("com.tngtech.archunit:archunit-junit5:$archunitVersion")
+    testImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
+    "integrationTestImplementation"(testFixtures(project))
+    "integrationTestImplementation"("org.testcontainers:postgresql:$testcontainersVersion")
+    "integrationTestImplementation"("org.testcontainers:kafka:$testcontainersVersion")
+    "integrationTestImplementation"("org.testcontainers:junit-jupiter:$testcontainersVersion")
+    "integrationTestImplementation"("org.wiremock:wiremock-standalone:$wiremockVersion")
+    "integrationTestImplementation"("org.springframework.boot:spring-boot-starter-webmvc-test")
+    "integrationTestImplementation"("org.springframework.boot:spring-boot-starter-security-test")
+}
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(listOf(
+        "-Amapstruct.defaultComponentModel=spring",
+        "-Amapstruct.unmappedTargetPolicy=IGNORE"
+    ))
+}
+
+tasks.withType<Test> {
+    jvmArgs("-Dnet.bytebuddy.experimental=true")
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.14"
+}
+
+tasks.test {
+    configure<JacocoTaskExtension> {
+        excludes = listOf("sun.*", "jdk.*", "com.sun.*", "java.*", "javax.*")
+    }
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+val jacocoExclusions = listOf(
+    "**/entity/**",
+    "**/mapper/**",
+    "**/config/**",
+    "**/*Application*",
+    "**/generated/**",
+    "**/*MapperImpl*"
+)
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+    classDirectories.setFrom(files(classDirectories.files.map {
+        fileTree(it) { exclude(jacocoExclusions) }
+    }))
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.50".toBigDecimal()
+            }
+        }
+    }
+    classDirectories.setFrom(files(classDirectories.files.map {
+        fileTree(it) { exclude(jacocoExclusions) }
+    }))
+}
+
+tasks.named("check") {
+    dependsOn(
+        tasks.named("integrationTest"),
+        tasks.named("businessTest"),
+        tasks.jacocoTestCoverageVerification
+    )
+}

--- a/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/AbstractIntegrationTest.java
+++ b/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/AbstractIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.stablecoin.payments.custody;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SuppressWarnings("resource")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration-test")
+@AutoConfigureMockMvc
+public abstract class AbstractIntegrationTest {
+
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("s4_blockchain_custody")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    protected static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
+
+    static {
+        POSTGRES.start();
+        KAFKA.start();
+    }
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE
+                    chain_selection_log,
+                    transfer_lifecycle_events,
+                    transfer_participants,
+                    wallet_nonces,
+                    wallet_status_audit_log,
+                    chain_transfers,
+                    wallet_balances,
+                    wallets,
+                    custody_outbox_record
+                CASCADE
+                """);
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/config/TestKafkaConfig.java
+++ b/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/config/TestKafkaConfig.java
@@ -1,0 +1,35 @@
+package com.stablecoin.payments.custody.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+@Configuration
+public class TestKafkaConfig {
+
+    @Bean
+    @Primary
+    public ProducerFactory<String, Object> producerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        return new DefaultKafkaProducerFactory<>(Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class));
+    }
+
+    @Bean
+    @Primary
+    public KafkaTemplate<String, Object> kafkaTemplate(
+            ProducerFactory<String, Object> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/integration-test/resources/application-integration-test.yml
+++ b/blockchain-custody/blockchain-custody/src/integration-test/resources/application-integration-test.yml
@@ -1,0 +1,37 @@
+spring:
+  main:
+    allow-bean-definition-overriding: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+outbox:
+  relay:
+    fixed-delay-ms: 50
+
+server:
+  port: 0
+
+app:
+  security:
+    enabled: false
+
+logging:
+  level:
+    com.stablecoin.payments: DEBUG
+    org.springframework.test: INFO
+    org.testcontainers: INFO

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/BlockchainCustodyApplication.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/BlockchainCustodyApplication.java
@@ -1,0 +1,18 @@
+package com.stablecoin.payments.custody;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+@EnableFeignClients
+@EnableScheduling
+public class BlockchainCustodyApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BlockchainCustodyApplication.class, args);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
@@ -1,0 +1,18 @@
+package com.stablecoin.payments.custody.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides fallback (dev/test) implementations for external provider ports.
+ * Each bean uses {@code @ConditionalOnMissingBean} so that production adapters
+ * (activated via {@code @ConditionalOnProperty}) take precedence.
+ *
+ * <p>Domain ports (CustodyEngine, ChainRpcProvider) will be added here
+ * once the domain model is scaffolded.</p>
+ */
+@Slf4j
+@Configuration
+public class FallbackAdaptersConfig {
+    // Fallback beans will be added when domain ports are defined
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/SecurityConfig.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.stablecoin.payments.custody.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "app.security.enabled", havingValue = "true", matchIfMissing = true)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "app.security.enabled", havingValue = "false")
+    public SecurityFilterChain localSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .build();
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/resources/application.yml
+++ b/blockchain-custody/blockchain-custody/src/main/resources/application.yml
@@ -1,0 +1,134 @@
+spring:
+  application:
+    name: blockchain-custody
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/s4_blockchain_custody}
+    username: ${DB_USER:dev}
+    password: ${DB_PASS:dev}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false
+        default_schema: public
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: false
+    locations: classpath:db/migration
+    schemas: public
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BROKERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+namastack:
+  outbox:
+    poll-interval: 2000
+    batch-size: 20
+    jdbc:
+      table-prefix: "custody_"
+      schema-initialization:
+        enabled: false
+    retry:
+      policy: exponential
+      max-retries: 5
+      exponential:
+        initial-delay: 1000
+        max-delay: 60000
+        multiplier: 2.0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: when-authorized
+      group:
+        readiness:
+          include: db
+        liveness:
+          include: livenessState
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      service: blockchain-custody
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+
+server:
+  port: ${SERVER_PORT:8086}
+  servlet:
+    context-path: /custody
+  shutdown: graceful
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+  info:
+    title: S4 Blockchain & Custody API
+    description: On-chain stablecoin transfers, wallet management, and MPC custody
+    version: 1.0.0
+
+app:
+  security:
+    enabled: false
+  custody:
+    provider: dev
+  chains:
+    base:
+      min-confirmations: 1
+      avg-finality-s: 12
+      rpc-url: ${BASE_RPC_URL:https://base-sepolia.g.alchemy.com/v2/demo}
+    ethereum:
+      min-confirmations: 32
+      avg-finality-s: 300
+      rpc-url: ${ETH_RPC_URL:https://eth-sepolia.g.alchemy.com/v2/demo}
+    solana:
+      min-confirmations: 1
+      avg-finality-s: 5
+      rpc-url: ${SOL_RPC_URL:https://api.devnet.solana.com}
+  chain-selection:
+    cost-weight: 0.4
+    speed-weight: 0.35
+    reliability-weight: 0.25
+  transfer:
+    resubmit-timeout-s: 120
+    max-attempts: 3
+  balance:
+    low-alert-threshold-usd: 50000
+
+logging:
+  level:
+    com.stablecoin.payments: INFO
+    org.springframework.security: WARN

--- a/blockchain-custody/blockchain-custody/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/blockchain-custody/blockchain-custody/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,224 @@
+-- ============================================================
+-- S4 Blockchain & Custody — Initial Schema
+-- ============================================================
+
+-- Guard role operations for TestContainers compatibility
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'sp_user') THEN
+        CREATE ROLE sp_user WITH LOGIN PASSWORD 'sp_pass';
+    END IF;
+END
+$$;
+
+-- ============================================================
+-- wallets
+-- ============================================================
+CREATE TABLE wallets (
+    wallet_id           UUID            NOT NULL DEFAULT gen_random_uuid(),
+    chain_id            VARCHAR(20)     NOT NULL,
+    address             VARCHAR(128)    NOT NULL,
+    address_checksum    VARCHAR(128)    NOT NULL,
+    tier                VARCHAR(10)     NOT NULL DEFAULT 'HOT',
+    purpose             VARCHAR(20)     NOT NULL,
+    custodian           VARCHAR(50)     NOT NULL,
+    vault_account_id    VARCHAR(200)    NOT NULL,
+    stablecoin          VARCHAR(20)     NOT NULL,
+    is_active           BOOLEAN         NOT NULL DEFAULT TRUE,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    deactivated_at      TIMESTAMPTZ     NULL,
+    CONSTRAINT wallets_pkey PRIMARY KEY (wallet_id),
+    CONSTRAINT wallets_address_chain_unique UNIQUE (address, chain_id),
+    CONSTRAINT wallets_tier_check CHECK (tier IN ('HOT','WARM','COLD')),
+    CONSTRAINT wallets_purpose_check CHECK (purpose IN ('ON_RAMP','OFF_RAMP','SWEEP','RESERVE'))
+);
+
+CREATE INDEX wallets_chain_purpose_idx
+    ON wallets (chain_id, purpose)
+    WHERE is_active = TRUE;
+
+-- ============================================================
+-- wallet_balances
+-- ============================================================
+CREATE TABLE wallet_balances (
+    balance_id              UUID            NOT NULL DEFAULT gen_random_uuid(),
+    wallet_id               UUID            NOT NULL REFERENCES wallets(wallet_id),
+    chain_id                VARCHAR(20)     NOT NULL,
+    stablecoin              VARCHAR(20)     NOT NULL,
+    available_balance       NUMERIC(30, 8)  NOT NULL DEFAULT 0 CHECK (available_balance >= 0),
+    reserved_balance        NUMERIC(30, 8)  NOT NULL DEFAULT 0 CHECK (reserved_balance >= 0),
+    blockchain_balance      NUMERIC(30, 8)  NOT NULL DEFAULT 0 CHECK (blockchain_balance >= 0),
+    last_indexed_block      NUMERIC(20, 0)  NOT NULL DEFAULT 0,
+    version                 BIGINT          NOT NULL DEFAULT 0,
+    updated_at              TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT wallet_balances_pkey PRIMARY KEY (balance_id),
+    CONSTRAINT wallet_balances_wallet_stablecoin_unique UNIQUE (wallet_id, stablecoin)
+);
+
+CREATE INDEX wallet_balances_wallet_id_idx ON wallet_balances (wallet_id);
+
+-- ============================================================
+-- chain_transfers
+-- ============================================================
+CREATE TABLE chain_transfers (
+    transfer_id         UUID            NOT NULL DEFAULT gen_random_uuid(),
+    payment_id          UUID            NOT NULL,
+    correlation_id      UUID            NOT NULL,
+    transfer_type       VARCHAR(10)     NOT NULL DEFAULT 'FORWARD',
+    parent_transfer_id  UUID            NULL,
+    chain_id            VARCHAR(20)     NOT NULL,
+    stablecoin          VARCHAR(20)     NOT NULL,
+    amount              NUMERIC(30, 8)  NOT NULL CHECK (amount > 0),
+    from_wallet_id      UUID            NOT NULL REFERENCES wallets(wallet_id),
+    from_address        VARCHAR(128)    NOT NULL,
+    to_address          VARCHAR(128)    NOT NULL,
+    nonce               NUMERIC(20, 0)  NULL,
+    tx_hash             VARCHAR(128)    NULL,
+    status              VARCHAR(20)     NOT NULL DEFAULT 'PENDING',
+    block_number        NUMERIC(20, 0)  NULL,
+    confirmations       INT             NULL,
+    block_confirmed_at  TIMESTAMPTZ     NULL,
+    gas_used            NUMERIC(20, 0)  NULL,
+    gas_price_gwei      NUMERIC(20, 9)  NULL,
+    attempt_count       INT             NOT NULL DEFAULT 0,
+    failure_reason      TEXT            NULL,
+    error_code          VARCHAR(100)    NULL,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT chain_transfers_pkey PRIMARY KEY (transfer_id),
+    CONSTRAINT chain_transfers_payment_id_unique UNIQUE (payment_id, transfer_type),
+    CONSTRAINT chain_transfers_status_check CHECK (status IN (
+        'PENDING','CHAIN_SELECTED','SIGNING','SUBMITTED','RESUBMITTING',
+        'CONFIRMING','CONFIRMED','FAILED'
+    )),
+    CONSTRAINT chain_transfers_type_check CHECK (transfer_type IN ('FORWARD','RETURN'))
+);
+
+CREATE INDEX chain_transfers_payment_id_idx
+    ON chain_transfers (payment_id);
+
+CREATE INDEX chain_transfers_tx_hash_idx
+    ON chain_transfers (chain_id, tx_hash)
+    WHERE tx_hash IS NOT NULL;
+
+CREATE INDEX chain_transfers_status_idx
+    ON chain_transfers (status, created_at)
+    WHERE status IN ('SUBMITTED','CONFIRMING','RESUBMITTING');
+
+-- ============================================================
+-- transfer_participants (INPUT/OUTPUT/FEE per transfer)
+-- ============================================================
+CREATE TABLE transfer_participants (
+    participant_id      UUID            NOT NULL DEFAULT gen_random_uuid(),
+    transfer_id         UUID            NOT NULL REFERENCES chain_transfers(transfer_id),
+    participant_type    VARCHAR(10)     NOT NULL,
+    address             VARCHAR(128)    NOT NULL,
+    wallet_id           UUID            NULL REFERENCES wallets(wallet_id),
+    amount              NUMERIC(30, 8)  NOT NULL,
+    asset_code          VARCHAR(20)     NOT NULL,
+    CONSTRAINT transfer_participants_pkey PRIMARY KEY (participant_id),
+    CONSTRAINT transfer_participants_type_check CHECK (participant_type IN ('INPUT','OUTPUT','FEE'))
+);
+
+CREATE INDEX transfer_participants_transfer_id_idx ON transfer_participants (transfer_id);
+
+-- ============================================================
+-- transfer_lifecycle_events (fine-grained audit trail per transfer stage)
+-- ============================================================
+CREATE TABLE transfer_lifecycle_events (
+    event_id            UUID            NOT NULL DEFAULT gen_random_uuid(),
+    transfer_id         UUID            NOT NULL REFERENCES chain_transfers(transfer_id),
+    state               VARCHAR(50)     NOT NULL,
+    participant_type    VARCHAR(10)     NULL,
+    address             VARCHAR(128)    NULL,
+    occurred_at         TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT transfer_lifecycle_events_pkey PRIMARY KEY (event_id)
+);
+
+CREATE INDEX transfer_lifecycle_events_transfer_id_idx ON transfer_lifecycle_events (transfer_id);
+
+-- ============================================================
+-- wallet_nonces (serialized nonce management per wallet)
+-- ============================================================
+CREATE TABLE wallet_nonces (
+    wallet_id       UUID            NOT NULL REFERENCES wallets(wallet_id),
+    chain_id        VARCHAR(20)     NOT NULL,
+    current_nonce   NUMERIC(20, 0)  NOT NULL DEFAULT 0,
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT wallet_nonces_pkey PRIMARY KEY (wallet_id, chain_id)
+);
+
+-- ============================================================
+-- chain_selection_log
+-- ============================================================
+CREATE TABLE chain_selection_log (
+    selection_id    UUID            NOT NULL DEFAULT gen_random_uuid(),
+    transfer_id     UUID            NOT NULL REFERENCES chain_transfers(transfer_id),
+    evaluated_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    candidates      JSONB           NOT NULL,
+    selected_chain  VARCHAR(20)     NOT NULL,
+    CONSTRAINT chain_selection_log_pkey PRIMARY KEY (selection_id)
+);
+
+-- ============================================================
+-- wallet_status_audit_log (compliance trail for wallet lifecycle)
+-- ============================================================
+CREATE TABLE wallet_status_audit_log (
+    audit_id        UUID            NOT NULL DEFAULT gen_random_uuid(),
+    wallet_id       UUID            NOT NULL REFERENCES wallets(wallet_id),
+    previous_status VARCHAR(20)     NULL,
+    new_status      VARCHAR(20)     NOT NULL,
+    changed_by      VARCHAR(100)    NOT NULL,
+    reason          TEXT            NULL,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT wallet_status_audit_log_pkey PRIMARY KEY (audit_id),
+    CONSTRAINT wallet_status_audit_log_status_check CHECK (new_status IN ('ACTIVE','DEACTIVATED','SUSPENDED'))
+);
+
+CREATE INDEX wallet_status_audit_log_wallet_idx
+    ON wallet_status_audit_log (wallet_id, created_at);
+
+-- ============================================================
+-- Namastack outbox tables (3 tables with custody_ prefix)
+-- ============================================================
+CREATE TABLE custody_outbox_record (
+    id              VARCHAR(255)    NOT NULL,
+    status          VARCHAR(20)     NOT NULL DEFAULT 'PENDING',
+    record_key      VARCHAR(255),
+    record_type     VARCHAR(255)    NOT NULL,
+    payload         TEXT            NOT NULL,
+    context         TEXT,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    completed_at    TIMESTAMPTZ,
+    next_retry_at   TIMESTAMPTZ,
+    failure_count   INTEGER         NOT NULL DEFAULT 0,
+    failure_reason  TEXT,
+    partition_no    INTEGER,
+    handler_id      VARCHAR(255),
+    CONSTRAINT custody_outbox_record_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_custody_outbox_record_status
+    ON custody_outbox_record (status, next_retry_at);
+
+CREATE TABLE custody_outbox_instance (
+    instance_id     VARCHAR(255)    NOT NULL,
+    hostname        VARCHAR(255),
+    port            INTEGER,
+    status          VARCHAR(20)     NOT NULL DEFAULT 'ACTIVE',
+    started_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    last_heartbeat  TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT custody_outbox_instance_pkey PRIMARY KEY (instance_id)
+);
+
+CREATE TABLE custody_outbox_partition (
+    partition_number INTEGER         NOT NULL,
+    instance_id      VARCHAR(255),
+    version          BIGINT          NOT NULL DEFAULT 0,
+    updated_at       TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT custody_outbox_partition_pkey PRIMARY KEY (partition_number)
+);
+
+COMMENT ON TABLE custody_outbox_record IS 'Namastack outbox — reliable event publishing for blockchain-custody';

--- a/blockchain-custody/blockchain-custody/src/main/resources/db/migration/V2__seed_wallets.sql
+++ b/blockchain-custody/blockchain-custody/src/main/resources/db/migration/V2__seed_wallets.sql
@@ -1,0 +1,16 @@
+-- V2: Seed wallets for local dev (Base Sepolia testnet)
+
+INSERT INTO wallets (wallet_id, chain_id, address, address_checksum, tier, purpose, custodian, vault_account_id, stablecoin, is_active)
+VALUES
+  (gen_random_uuid(), 'base', '0x1111222233334444555566667777888899990000', '0x1111222233334444555566667777888899990000', 'HOT', 'ON_RAMP', 'dev', 'dev-vault-onramp', 'USDC', true),
+  (gen_random_uuid(), 'base', '0xaaaa222233334444555566667777888899990000', '0xaaaa222233334444555566667777888899990000', 'HOT', 'OFF_RAMP', 'dev', 'dev-vault-offramp', 'USDC', true);
+
+-- Seed initial balances
+INSERT INTO wallet_balances (balance_id, wallet_id, chain_id, stablecoin, available_balance, reserved_balance, blockchain_balance, last_indexed_block)
+SELECT gen_random_uuid(), w.wallet_id, w.chain_id, w.stablecoin, 500000.00000000, 0.00000000, 500000.00000000, 0
+FROM wallets w;
+
+-- Seed nonces
+INSERT INTO wallet_nonces (wallet_id, chain_id, current_nonce)
+SELECT w.wallet_id, w.chain_id, 0
+FROM wallets w;

--- a/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/arch/ArchitectureTest.java
+++ b/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/arch/ArchitectureTest.java
@@ -1,0 +1,112 @@
+package com.stablecoin.payments.custody.arch;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideOutsideOfPackage;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@DisplayName("Architecture Rules")
+class ArchitectureTest {
+
+    private static JavaClasses importedClasses;
+
+    @BeforeAll
+    static void setUp() {
+        importedClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.stablecoin.payments.custody");
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on Spring (except stereotype and transaction)")
+    void domainShouldNotDependOnSpring() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat(
+                        resideInAPackage("org.springframework..")
+                                .and(resideOutsideOfPackage("org.springframework.stereotype.."))
+                                .and(resideOutsideOfPackage("org.springframework.transaction.."))
+                                .and(resideOutsideOfPackage("org.springframework.beans.factory.annotation.."))
+                )
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on JPA")
+    void domainShouldNotDependOnJpa() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("jakarta.persistence..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on infrastructure")
+    void domainShouldNotDependOnInfrastructure() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on application layer")
+    void domainShouldNotDependOnApplication() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..application..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Infrastructure should not depend on application controller")
+    void infrastructureShouldNotDependOnApplicationController() {
+        noClasses()
+                .that().resideInAPackage("..infrastructure..")
+                .should().dependOnClassesThat().resideInAPackage("..application.controller..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Ports should be interfaces")
+    void portsShouldBeInterfaces() {
+        classes()
+                .that().resideInAPackage("..domain.port..")
+                .and().areNotRecords()
+                .should().beInterfaces()
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain events should be records")
+    void domainEventsShouldBeRecords() {
+        classes()
+                .that().resideInAPackage("..domain.event..")
+                .should().beRecords()
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Controllers should reside in application.controller package")
+    void controllersShouldResideInApplicationController() {
+        noClasses()
+                .that().haveSimpleNameEndingWith("Controller")
+                .should().resideOutsideOfPackage("..application.controller..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/testFixtures/java/com/stablecoin/payments/custody/fixtures/TestUtils.java
+++ b/blockchain-custody/blockchain-custody/src/testFixtures/java/com/stablecoin/payments/custody/fixtures/TestUtils.java
@@ -1,0 +1,35 @@
+package com.stablecoin.payments.custody.fixtures;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+
+public final class TestUtils {
+
+    private TestUtils() {}
+
+    public static <T> T eqIgnoringTimestamps(T expected) {
+        return eqIgnoring(expected);
+    }
+
+    public static <T> T eqIgnoring(T expected, String... fieldsToIgnore) {
+        return argThat(it -> isEqualIgnoring(it, expected, fieldsToIgnore));
+    }
+
+    private static <T> boolean isEqualIgnoring(T original, T expected, String... fieldsToIgnore) {
+        try {
+            assertThat(original)
+                    .usingRecursiveComparison()
+                    .ignoringFieldsOfTypes(ZonedDateTime.class, LocalDateTime.class, LocalDate.class, Instant.class)
+                    .ignoringFields(fieldsToIgnore)
+                    .isEqualTo(expected);
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp-api/build.gradle.kts
+++ b/fiat-on-ramp/fiat-on-ramp-api/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api("jakarta.validation:jakarta.validation-api")
+    api("com.fasterxml.jackson.core:jackson-annotations")
+
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.assertj:assertj-core")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/ApiError.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/ApiError.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.onramp.api;
+
+import java.util.List;
+import java.util.Map;
+
+public record ApiError(
+        String code,
+        String status,
+        String message,
+        Map<String, List<String>> errors
+) {
+    public static ApiError of(String code, String status, String message) {
+        return new ApiError(code, status, message, Map.of());
+    }
+
+    public static ApiError withErrors(String code, String status, String message,
+                                      Map<String, List<String>> errors) {
+        return new ApiError(code, status, message, errors);
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/CollectionResponse.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/CollectionResponse.java
@@ -1,0 +1,16 @@
+package com.stablecoin.payments.onramp.api;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record CollectionResponse(
+        UUID collectionId,
+        UUID paymentId,
+        String status,
+        String paymentRail,
+        String psp,
+        String pspReference,
+        Instant estimatedSettlementAt,
+        Instant createdAt,
+        Instant expiresAt
+) {}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/RefundResponse.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/RefundResponse.java
@@ -1,0 +1,15 @@
+package com.stablecoin.payments.onramp.api;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RefundResponse(
+        UUID refundId,
+        UUID collectionId,
+        String status,
+        BigDecimal refundAmount,
+        String currency,
+        Instant initiatedAt,
+        Instant estimatedCompletionAt
+) {}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatCollected.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatCollected.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.onramp.api.events;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatCollected(
+        int schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID collectionId,
+        UUID paymentId,
+        UUID merchantId,
+        BigDecimal settledAmount,
+        String currency,
+        String paymentRail,
+        String psp,
+        String pspReference,
+        Instant settledAt
+) {
+    public static final String EVENT_TYPE = "fiat.collected";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatCollectionFailed.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatCollectionFailed.java
@@ -1,0 +1,22 @@
+package com.stablecoin.payments.onramp.api.events;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatCollectionFailed(
+        int schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID collectionId,
+        UUID paymentId,
+        UUID merchantId,
+        BigDecimal amount,
+        String currency,
+        String failureReason,
+        String errorCode,
+        Instant failedAt
+) {
+    public static final String EVENT_TYPE = "fiat.collection.failed";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatCollectionInitiated.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatCollectionInitiated.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.onramp.api.events;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatCollectionInitiated(
+        int schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID collectionId,
+        UUID paymentId,
+        UUID merchantId,
+        BigDecimal amount,
+        String currency,
+        String paymentRail,
+        String psp,
+        String pspReference,
+        Instant initiatedAt
+) {
+    public static final String EVENT_TYPE = "fiat.collection.initiated";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatRefundCompleted.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatRefundCompleted.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.onramp.api.events;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatRefundCompleted(
+        int schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID refundId,
+        UUID collectionId,
+        UUID paymentId,
+        BigDecimal refundAmount,
+        String currency,
+        Instant completedAt
+) {
+    public static final String EVENT_TYPE = "fiat.refund.completed";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatRefundInitiated.java
+++ b/fiat-on-ramp/fiat-on-ramp-api/src/main/java/com/stablecoin/payments/onramp/api/events/FiatRefundInitiated.java
@@ -1,0 +1,21 @@
+package com.stablecoin.payments.onramp.api.events;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatRefundInitiated(
+        int schemaVersion,
+        UUID eventId,
+        String eventType,
+        UUID refundId,
+        UUID collectionId,
+        UUID paymentId,
+        BigDecimal refundAmount,
+        String currency,
+        String reason,
+        Instant initiatedAt
+) {
+    public static final String EVENT_TYPE = "fiat.refund.initiated";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/fiat-on-ramp/fiat-on-ramp-client/build.gradle.kts
+++ b/fiat-on-ramp/fiat-on-ramp-client/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":fiat-on-ramp:fiat-on-ramp-api"))
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.assertj:assertj-core")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/fiat-on-ramp/fiat-on-ramp-client/src/main/java/com/stablecoin/payments/onramp/client/FiatOnRampClient.java
+++ b/fiat-on-ramp/fiat-on-ramp-client/src/main/java/com/stablecoin/payments/onramp/client/FiatOnRampClient.java
@@ -1,0 +1,24 @@
+package com.stablecoin.payments.onramp.client;
+
+import com.stablecoin.payments.onramp.api.CollectionResponse;
+import com.stablecoin.payments.onramp.api.RefundResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@FeignClient(name = "fiat-on-ramp-service", url = "${app.services.fiat-on-ramp.url}")
+public interface FiatOnRampClient {
+
+    @GetMapping(value = "/v1/collections/{collectionId}", produces = "application/json")
+    CollectionResponse getCollection(@PathVariable("collectionId") UUID collectionId);
+
+    @GetMapping(value = "/v1/collections", produces = "application/json")
+    CollectionResponse getCollectionByPaymentId(@RequestParam("paymentId") UUID paymentId);
+
+    @PostMapping(value = "/v1/collections/{collectionId}/refunds", produces = "application/json")
+    RefundResponse initiateRefund(@PathVariable("collectionId") UUID collectionId);
+}

--- a/fiat-on-ramp/fiat-on-ramp/build.gradle.kts
+++ b/fiat-on-ramp/fiat-on-ramp/build.gradle.kts
@@ -1,0 +1,202 @@
+plugins {
+    id("org.springframework.boot")
+    id("com.google.cloud.tools.jib")
+    java
+    `java-test-fixtures`
+    jacoco
+}
+
+jib {
+    from {
+        image = "eclipse-temurin:25-jre-alpine"
+    }
+    to {
+        image = "stablebridge/fiat-on-ramp"
+        tags = setOf("latest")
+    }
+    container {
+        creationTime.set("USE_CURRENT_TIMESTAMP")
+    }
+}
+
+val integrationTestSourceSet: SourceSet = sourceSets.create("integrationTest") {
+    java.srcDir("src/integration-test/java")
+    resources.srcDir("src/integration-test/resources")
+    compileClasspath += sourceSets.main.get().output + sourceSets.test.get().output
+    runtimeClasspath += sourceSets.main.get().output + sourceSets.test.get().output
+}
+
+configurations {
+    named("integrationTestImplementation") { extendsFrom(configurations.testImplementation.get()) }
+    named("integrationTestRuntimeOnly") { extendsFrom(configurations.testRuntimeOnly.get()) }
+}
+
+tasks.register<Test>("integrationTest") {
+    testClassesDirs = integrationTestSourceSet.output.classesDirs
+    classpath = integrationTestSourceSet.runtimeClasspath
+    shouldRunAfter(tasks.test)
+    configure<JacocoTaskExtension> { isEnabled = false }
+    failOnNoDiscoveredTests = false
+    exclude("**/Abstract*", "**/config/**")
+}
+
+val businessTestSourceSet: SourceSet = sourceSets.create("businessTest") {
+    java.srcDir("src/business-test/java")
+    resources.srcDir("src/business-test/resources")
+    compileClasspath += sourceSets.main.get().output + sourceSets.test.get().output + integrationTestSourceSet.output
+    runtimeClasspath += sourceSets.main.get().output + sourceSets.test.get().output + integrationTestSourceSet.output
+}
+
+configurations {
+    named("businessTestImplementation") { extendsFrom(configurations.named("integrationTestImplementation").get()) }
+    named("businessTestRuntimeOnly") { extendsFrom(configurations.named("integrationTestRuntimeOnly").get()) }
+}
+
+tasks.register<Test>("businessTest") {
+    testClassesDirs = businessTestSourceSet.output.classesDirs
+    classpath = businessTestSourceSet.runtimeClasspath
+    shouldRunAfter(tasks.named("integrationTest"))
+    failOnNoDiscoveredTests = false
+    configure<JacocoTaskExtension> { isEnabled = false }
+}
+
+val lombokVersion: String by project
+val mapstructVersion: String by project
+val lombokMapstructBindingVersion: String by project
+val resilience4jVersion: String by project
+val flywayVersion: String by project
+val archunitVersion: String by project
+val testcontainersVersion: String by project
+val wiremockVersion: String by project
+val springdocVersion: String by project
+
+dependencies {
+    implementation(project(":fiat-on-ramp:fiat-on-ramp-api"))
+
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // OpenAPI / Swagger UI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    implementation("io.micrometer:micrometer-tracing-bridge-otel")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // Kafka via Spring Cloud Stream
+    implementation("org.springframework.cloud:spring-cloud-stream")
+    implementation("org.springframework.cloud:spring-cloud-stream-binder-kafka")
+    implementation("org.springframework.kafka:spring-kafka")
+
+    // Feign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    // Resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:$resilience4jVersion")
+    implementation("io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion")
+
+    // MapStruct (compiler args set below in JavaCompile task)
+    implementation("org.mapstruct:mapstruct:$mapstructVersion")
+    annotationProcessor("org.mapstruct:mapstruct-processor:$mapstructVersion")
+    annotationProcessor("org.projectlombok:lombok-mapstruct-binding:$lombokMapstructBindingVersion")
+
+    // Outbox (namastack)
+    implementation("io.namastack:namastack-outbox-starter-jdbc:1.0.0")
+
+    // Database
+    runtimeOnly("org.postgresql:postgresql")
+    implementation("org.springframework.boot:spring-boot-starter-flyway")
+    implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
+
+    // Test Fixtures
+    testFixturesImplementation("org.assertj:assertj-core")
+    testFixturesImplementation("org.mockito:mockito-core")
+
+    // Test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation("com.tngtech.archunit:archunit-junit5:$archunitVersion")
+    testImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
+    "integrationTestImplementation"(testFixtures(project))
+    "integrationTestImplementation"("org.testcontainers:postgresql:$testcontainersVersion")
+    "integrationTestImplementation"("org.testcontainers:kafka:$testcontainersVersion")
+    "integrationTestImplementation"("org.testcontainers:junit-jupiter:$testcontainersVersion")
+    "integrationTestImplementation"("org.wiremock:wiremock-standalone:$wiremockVersion")
+    "integrationTestImplementation"("org.springframework.boot:spring-boot-starter-webmvc-test")
+    "integrationTestImplementation"("org.springframework.boot:spring-boot-starter-security-test")
+}
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(listOf(
+        "-Amapstruct.defaultComponentModel=spring",
+        "-Amapstruct.unmappedTargetPolicy=IGNORE"
+    ))
+}
+
+tasks.withType<Test> {
+    jvmArgs("-Dnet.bytebuddy.experimental=true")
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.14"
+}
+
+tasks.test {
+    configure<JacocoTaskExtension> {
+        excludes = listOf("sun.*", "jdk.*", "com.sun.*", "java.*", "javax.*")
+    }
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+val jacocoExclusions = listOf(
+    "**/entity/**",
+    "**/mapper/**",
+    "**/config/**",
+    "**/*Application*",
+    "**/generated/**",
+    "**/*MapperImpl*"
+)
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+    classDirectories.setFrom(files(classDirectories.files.map {
+        fileTree(it) { exclude(jacocoExclusions) }
+    }))
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.50".toBigDecimal()
+            }
+        }
+    }
+    classDirectories.setFrom(files(classDirectories.files.map {
+        fileTree(it) { exclude(jacocoExclusions) }
+    }))
+}
+
+tasks.named("check") {
+    dependsOn(
+        tasks.named("integrationTest"),
+        tasks.named("businessTest"),
+        tasks.jacocoTestCoverageVerification
+    )
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/integration-test/java/com/stablecoin/payments/onramp/AbstractIntegrationTest.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/integration-test/java/com/stablecoin/payments/onramp/AbstractIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.stablecoin.payments.onramp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SuppressWarnings("resource")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration-test")
+@AutoConfigureMockMvc
+public abstract class AbstractIntegrationTest {
+
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("s3_fiat_on_ramp")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    protected static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
+
+    static {
+        POSTGRES.start();
+        KAFKA.start();
+    }
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE
+                    reconciliation_records,
+                    refunds,
+                    psp_transactions,
+                    collection_orders,
+                    onramp_outbox_record
+                CASCADE
+                """);
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        registry.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/integration-test/resources/application-integration-test.yml
+++ b/fiat-on-ramp/fiat-on-ramp/src/integration-test/resources/application-integration-test.yml
@@ -1,0 +1,37 @@
+spring:
+  main:
+    allow-bean-definition-overriding: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+outbox:
+  relay:
+    fixed-delay-ms: 50
+
+server:
+  port: 0
+
+app:
+  security:
+    enabled: false
+
+logging:
+  level:
+    com.stablecoin.payments: DEBUG
+    org.springframework.test: INFO
+    org.testcontainers: INFO

--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/FiatOnRampApplication.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/FiatOnRampApplication.java
@@ -1,0 +1,18 @@
+package com.stablecoin.payments.onramp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+@EnableFeignClients
+@EnableScheduling
+public class FiatOnRampApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FiatOnRampApplication.class, args);
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/config/FallbackAdaptersConfig.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/config/FallbackAdaptersConfig.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.onramp.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides fallback (dev/test) implementations of outbound ports
+ * via {@code @ConditionalOnMissingBean}. Real adapters are registered
+ * by provider-specific configurations under
+ * {@code infrastructure/provider/<name>/}.
+ *
+ * <p>Adapters will be added here as domain ports are defined.
+ */
+@Slf4j
+@Configuration
+public class FallbackAdaptersConfig {
+
+    // Fallback beans will be added as domain ports are implemented.
+    // Pattern: @Bean @ConditionalOnMissingBean public <Port> fallback<Port>() { ... }
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/config/SecurityConfig.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.stablecoin.payments.onramp.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "app.security.enabled", havingValue = "true", matchIfMissing = true)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "app.security.enabled", havingValue = "false")
+    public SecurityFilterChain localSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .build();
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
@@ -1,0 +1,122 @@
+spring:
+  application:
+    name: fiat-on-ramp
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/s3_fiat_on_ramp}
+    username: ${DB_USER:sp_user}
+    password: ${DB_PASS:sp_pass}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false
+        default_schema: public
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: false
+    locations: classpath:db/migration
+    schemas: public
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BROKERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+  cloud:
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
+      bindings:
+        fiat-collected-out-0:
+          destination: fiat.collected
+        fiat-collection-failed-out-0:
+          destination: fiat.collection.failed
+
+namastack:
+  outbox:
+    poll-interval: 2000
+    batch-size: 20
+    jdbc:
+      table-prefix: "onramp_"
+      schema-initialization:
+        enabled: false
+    retry:
+      policy: exponential
+      max-retries: 5
+      exponential:
+        initial-delay: 1000
+        max-delay: 60000
+        multiplier: 2.0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: when-authorized
+      group:
+        readiness:
+          include: db
+        liveness:
+          include: livenessState
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      service: fiat-on-ramp
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+
+server:
+  port: ${SERVER_PORT:8085}
+  servlet:
+    context-path: /on-ramp
+  shutdown: graceful
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+  info:
+    title: S3 Fiat On-Ramp API
+    description: Fiat collection, PSP integration, and refund management for inbound payments
+    version: 1.0.0
+
+app:
+  security:
+    enabled: false
+
+logging:
+  level:
+    com.stablecoin.payments: INFO
+    org.springframework.security: WARN

--- a/fiat-on-ramp/fiat-on-ramp/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,180 @@
+-- ============================================================
+-- S3 Fiat On-Ramp — Initial Schema
+-- ============================================================
+
+-- Guard role operations for TestContainers compatibility
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'sp_user') THEN
+        CREATE ROLE sp_user WITH LOGIN PASSWORD 'sp_pass';
+    END IF;
+END
+$$;
+
+-- ============================================================
+-- collection_orders (main aggregate)
+-- ============================================================
+CREATE TABLE collection_orders (
+    collection_id       UUID            NOT NULL DEFAULT gen_random_uuid(),
+    payment_id          UUID            NOT NULL,
+    merchant_id         UUID            NOT NULL,
+    amount              NUMERIC(20, 8)  NOT NULL,
+    currency            VARCHAR(3)      NOT NULL,
+    source_country      VARCHAR(2)      NOT NULL,
+    payment_rail        VARCHAR(30)     NOT NULL,
+    psp                 VARCHAR(50)     NOT NULL,
+    psp_reference       VARCHAR(200)    NULL,
+    status              VARCHAR(30)     NOT NULL DEFAULT 'PENDING',
+    failure_reason      TEXT            NULL,
+    error_code          VARCHAR(100)    NULL,
+    settled_amount      NUMERIC(20, 8)  NULL,
+    settled_at          TIMESTAMPTZ     NULL,
+    estimated_settlement_at TIMESTAMPTZ NULL,
+    expires_at          TIMESTAMPTZ     NOT NULL,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    version             BIGINT          NOT NULL DEFAULT 0,
+    CONSTRAINT collection_orders_pkey PRIMARY KEY (collection_id),
+    CONSTRAINT collection_orders_payment_id_unique UNIQUE (payment_id),
+    CONSTRAINT collection_orders_status_check CHECK (status IN (
+        'PENDING', 'PSP_INITIATED', 'PSP_AUTHORIZED', 'SETTLED',
+        'FAILED', 'EXPIRED', 'REFUND_PENDING', 'REFUNDED'
+    ))
+);
+
+CREATE INDEX collection_orders_merchant_id_idx
+    ON collection_orders (merchant_id, created_at DESC);
+
+CREATE INDEX collection_orders_status_idx
+    ON collection_orders (status, created_at)
+    WHERE status NOT IN ('SETTLED', 'FAILED', 'EXPIRED', 'REFUNDED');
+
+CREATE INDEX collection_orders_psp_reference_idx
+    ON collection_orders (psp, psp_reference)
+    WHERE psp_reference IS NOT NULL;
+
+-- ============================================================
+-- psp_transactions (immutable PSP event log)
+-- ============================================================
+CREATE TABLE psp_transactions (
+    psp_transaction_id  UUID            NOT NULL DEFAULT gen_random_uuid(),
+    collection_id       UUID            NOT NULL REFERENCES collection_orders(collection_id),
+    psp                 VARCHAR(50)     NOT NULL,
+    psp_reference       VARCHAR(200)    NOT NULL,
+    event_type          VARCHAR(50)     NOT NULL,
+    status              VARCHAR(30)     NOT NULL,
+    amount              NUMERIC(20, 8)  NULL,
+    currency            VARCHAR(3)      NULL,
+    raw_response        JSONB           NOT NULL DEFAULT '{}',
+    received_at         TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT psp_transactions_pkey PRIMARY KEY (psp_transaction_id)
+);
+
+CREATE INDEX psp_transactions_collection_id_idx
+    ON psp_transactions (collection_id, received_at DESC);
+
+CREATE INDEX psp_transactions_psp_reference_idx
+    ON psp_transactions (psp, psp_reference);
+
+-- ============================================================
+-- refunds
+-- ============================================================
+CREATE TABLE refunds (
+    refund_id           UUID            NOT NULL DEFAULT gen_random_uuid(),
+    collection_id       UUID            NOT NULL REFERENCES collection_orders(collection_id),
+    refund_amount       NUMERIC(20, 8)  NOT NULL,
+    currency            VARCHAR(3)      NOT NULL,
+    reason              TEXT            NULL,
+    status              VARCHAR(30)     NOT NULL DEFAULT 'PENDING',
+    psp_refund_ref      VARCHAR(200)    NULL,
+    failure_reason      TEXT            NULL,
+    initiated_at        TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    completed_at        TIMESTAMPTZ     NULL,
+    estimated_completion_at TIMESTAMPTZ NULL,
+    CONSTRAINT refunds_pkey PRIMARY KEY (refund_id),
+    CONSTRAINT refunds_status_check CHECK (status IN (
+        'PENDING', 'PROCESSING', 'COMPLETED', 'FAILED'
+    ))
+);
+
+CREATE INDEX refunds_collection_id_idx
+    ON refunds (collection_id);
+
+CREATE INDEX refunds_status_idx
+    ON refunds (status, initiated_at)
+    WHERE status NOT IN ('COMPLETED', 'FAILED');
+
+-- ============================================================
+-- reconciliation_records
+-- ============================================================
+CREATE TABLE reconciliation_records (
+    reconciliation_id   UUID            NOT NULL DEFAULT gen_random_uuid(),
+    collection_id       UUID            NOT NULL REFERENCES collection_orders(collection_id),
+    psp                 VARCHAR(50)     NOT NULL,
+    psp_reference       VARCHAR(200)    NOT NULL,
+    expected_amount     NUMERIC(20, 8)  NOT NULL,
+    actual_amount       NUMERIC(20, 8)  NULL,
+    currency            VARCHAR(3)      NOT NULL,
+    status              VARCHAR(30)     NOT NULL DEFAULT 'PENDING',
+    discrepancy_type    VARCHAR(50)     NULL,
+    discrepancy_amount  NUMERIC(20, 8)  NULL,
+    reconciled_at       TIMESTAMPTZ     NULL,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT reconciliation_records_pkey PRIMARY KEY (reconciliation_id),
+    CONSTRAINT reconciliation_records_status_check CHECK (status IN (
+        'PENDING', 'MATCHED', 'DISCREPANCY', 'UNMATCHED'
+    ))
+);
+
+CREATE INDEX reconciliation_records_collection_id_idx
+    ON reconciliation_records (collection_id);
+
+CREATE INDEX reconciliation_records_status_idx
+    ON reconciliation_records (status, created_at)
+    WHERE status NOT IN ('MATCHED');
+
+-- ============================================================
+-- Namastack outbox tables (prefix: onramp_)
+-- ============================================================
+
+-- Namastack outbox record table (event storage + relay)
+CREATE TABLE onramp_outbox_record (
+    id              VARCHAR(255) PRIMARY KEY,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    record_key      VARCHAR(255),
+    record_type     VARCHAR(255) NOT NULL,
+    payload         TEXT NOT NULL,
+    context         TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at    TIMESTAMPTZ,
+    next_retry_at   TIMESTAMPTZ,
+    failure_count   INTEGER NOT NULL DEFAULT 0,
+    failure_reason  TEXT,
+    partition_no    INTEGER,
+    handler_id      VARCHAR(255)
+);
+
+CREATE INDEX idx_onramp_outbox_record_status
+    ON onramp_outbox_record (status, next_retry_at);
+
+-- Namastack outbox instance tracking
+CREATE TABLE onramp_outbox_instance (
+    instance_id     VARCHAR(255) PRIMARY KEY,
+    hostname        VARCHAR(255),
+    port            INTEGER,
+    status          VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_heartbeat  TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Namastack outbox partition assignment
+CREATE TABLE onramp_outbox_partition (
+    partition_number INTEGER PRIMARY KEY,
+    instance_id      VARCHAR(255),
+    version          BIGINT NOT NULL DEFAULT 0,
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE onramp_outbox_record IS 'Namastack outbox — reliable event publishing for fiat-on-ramp';

--- a/fiat-on-ramp/fiat-on-ramp/src/test/java/com/stablecoin/payments/onramp/arch/ArchitectureTest.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/test/java/com/stablecoin/payments/onramp/arch/ArchitectureTest.java
@@ -1,0 +1,112 @@
+package com.stablecoin.payments.onramp.arch;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideOutsideOfPackage;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@DisplayName("Architecture Rules")
+class ArchitectureTest {
+
+    private static JavaClasses importedClasses;
+
+    @BeforeAll
+    static void setUp() {
+        importedClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.stablecoin.payments.onramp");
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on Spring (except stereotype and transaction)")
+    void domainShouldNotDependOnSpring() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat(
+                        resideInAPackage("org.springframework..")
+                                .and(resideOutsideOfPackage("org.springframework.stereotype.."))
+                                .and(resideOutsideOfPackage("org.springframework.transaction.."))
+                                .and(resideOutsideOfPackage("org.springframework.beans.factory.annotation.."))
+                )
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on JPA")
+    void domainShouldNotDependOnJpa() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("jakarta.persistence..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on infrastructure")
+    void domainShouldNotDependOnInfrastructure() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..infrastructure..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain should not depend on application layer")
+    void domainShouldNotDependOnApplication() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..application..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Infrastructure should not depend on application controller")
+    void infrastructureShouldNotDependOnApplicationController() {
+        noClasses()
+                .that().resideInAPackage("..infrastructure..")
+                .should().dependOnClassesThat().resideInAPackage("..application.controller..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Ports should be interfaces")
+    void portsShouldBeInterfaces() {
+        classes()
+                .that().resideInAPackage("..domain.port..")
+                .and().areNotRecords()
+                .should().beInterfaces()
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain events should be records")
+    void domainEventsShouldBeRecords() {
+        classes()
+                .that().resideInAPackage("..domain.event..")
+                .should().beRecords()
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Controllers should reside in application.controller package")
+    void controllersShouldResideInApplicationController() {
+        noClasses()
+                .that().haveSimpleNameEndingWith("Controller")
+                .should().resideOutsideOfPackage("..application.controller..")
+                .allowEmptyShould(true)
+                .check(importedClasses);
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/test/java/com/stablecoin/payments/onramp/config/TestKafkaConfig.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/test/java/com/stablecoin/payments/onramp/config/TestKafkaConfig.java
@@ -1,0 +1,12 @@
+package com.stablecoin.payments.onramp.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+/**
+ * Test configuration for Kafka. Disables real Kafka bindings during unit tests.
+ * Integration tests use TestContainers Kafka via {@code AbstractIntegrationTest}.
+ */
+@TestConfiguration
+public class TestKafkaConfig {
+    // Kafka-specific test beans will be added as consumers/producers are implemented.
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/testFixtures/java/com/stablecoin/payments/onramp/fixtures/TestUtils.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/testFixtures/java/com/stablecoin/payments/onramp/fixtures/TestUtils.java
@@ -1,0 +1,35 @@
+package com.stablecoin.payments.onramp.fixtures;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+
+public final class TestUtils {
+
+    private TestUtils() {}
+
+    public static <T> T eqIgnoringTimestamps(T expected) {
+        return eqIgnoring(expected);
+    }
+
+    public static <T> T eqIgnoring(T expected, String... fieldsToIgnore) {
+        return argThat(it -> isEqualIgnoring(it, expected, fieldsToIgnore));
+    }
+
+    private static <T> boolean isEqualIgnoring(T original, T expected, String... fieldsToIgnore) {
+        try {
+            assertThat(original)
+                    .usingRecursiveComparison()
+                    .ignoringFieldsOfTypes(ZonedDateTime.class, LocalDateTime.class, LocalDate.class, Instant.class)
+                    .ignoringFields(fieldsToIgnore)
+                    .isEqualTo(expected);
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,3 +29,11 @@ include("fx-liquidity-engine:fx-liquidity-engine")
 include("payment-orchestrator:payment-orchestrator-api")
 include("payment-orchestrator:payment-orchestrator-client")
 include("payment-orchestrator:payment-orchestrator")
+
+include("fiat-on-ramp:fiat-on-ramp-api")
+include("fiat-on-ramp:fiat-on-ramp-client")
+include("fiat-on-ramp:fiat-on-ramp")
+
+include("blockchain-custody:blockchain-custody-api")
+include("blockchain-custody:blockchain-custody-client")
+include("blockchain-custody:blockchain-custody")


### PR DESCRIPTION
## Summary

- **S3 Fiat On-Ramp** (`fiat-on-ramp/`): 3 Gradle modules, V1 migration (7 tables: collection_orders, psp_transactions, refunds, reconciliation_records + 3 Namastack outbox), 5 event records, 2 API DTOs, Feign client, 8 ArchUnit tests
- **S4 Blockchain & Custody** (`blockchain-custody/`): 3 Gradle modules, V1 migration (11 tables: wallets, wallet_balances, chain_transfers, transfer_participants, transfer_lifecycle_events, wallet_nonces, chain_selection_log, wallet_status_audit_log + 3 Namastack outbox), V2 seed (dev wallets), 4 event records, 2 API DTOs, Feign client, 8 ArchUnit tests
- Phase 3 Value Movement MVP kickoff — both scaffolds built in parallel

Closes STA-119
Closes STA-131

## Test plan

- [x] S3 `./gradlew :fiat-on-ramp:fiat-on-ramp:test` — 8 ArchUnit tests pass
- [x] S4 `./gradlew :blockchain-custody:blockchain-custody:test` — 8 ArchUnit tests pass
- [x] Both modules compile cleanly together
- [x] Spotless formatting clean
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added blockchain custody service with transfer tracking and wallet balance inquiry endpoints
  * Added fiat on-ramp service with collection and refund operation endpoints
  * Added event publishing for custody and on-ramp transaction state changes

* **Chores**
  * Expanded microservices architecture with two new application modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->