### PR TITLE
feat(s4): domain model — ChainTransfer, Wallet, WalletBalance, value objects, ports (STA-132)

### DIFF
--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/ReturnConfirmedEvent.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/ReturnConfirmedEvent.java
@@ -1,0 +1,16 @@
+package com.stablecoin.payments.custody.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReturnConfirmedEvent(
+        UUID transferId,
+        UUID parentTransferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String txHash,
+        Instant confirmedAt
+) {
+    public static final String TOPIC = "chain.return.confirmed";
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/TransferConfirmedEvent.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/TransferConfirmedEvent.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.domain.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record TransferConfirmedEvent(
+        UUID transferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String txHash,
+        long blockNumber,
+        int confirmations,
+        BigDecimal gasUsed,
+        Instant confirmedAt
+) {
+    public static final String TOPIC = "chain.transfer.confirmed";
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/TransferFailedEvent.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/TransferFailedEvent.java
@@ -1,0 +1,16 @@
+package com.stablecoin.payments.custody.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TransferFailedEvent(
+        UUID transferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String reason,
+        String errorCode,
+        Instant failedAt
+) {
+    public static final String TOPIC = "chain.transfer.failed";
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/TransferSubmittedEvent.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/event/TransferSubmittedEvent.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.custody.domain.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record TransferSubmittedEvent(
+        UUID transferId,
+        UUID paymentId,
+        UUID correlationId,
+        String chainId,
+        String stablecoin,
+        BigDecimal amount,
+        String txHash,
+        String fromAddress,
+        String toAddress,
+        Instant submittedAt
+) {
+    public static final String TOPIC = "chain.transfer.submitted";
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainConfig.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainConfig.java
@@ -1,0 +1,32 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import java.util.List;
+
+public record ChainConfig(
+        ChainId chainId,
+        int minConfirmations,
+        int avgFinalitySeconds,
+        String nativeToken,
+        List<String> rpcEndpoints,
+        String explorerUrl
+) {
+
+    public ChainConfig {
+        if (chainId == null) {
+            throw new IllegalArgumentException("Chain ID is required");
+        }
+        if (minConfirmations < 0) {
+            throw new IllegalArgumentException("Min confirmations must be non-negative");
+        }
+        if (avgFinalitySeconds < 0) {
+            throw new IllegalArgumentException("Avg finality seconds must be non-negative");
+        }
+        if (nativeToken == null || nativeToken.isBlank()) {
+            throw new IllegalArgumentException("Native token is required");
+        }
+        if (rpcEndpoints == null || rpcEndpoints.isEmpty()) {
+            throw new IllegalArgumentException("At least one RPC endpoint is required");
+        }
+        rpcEndpoints = List.copyOf(rpcEndpoints);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainId.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainId.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import java.util.Set;
+
+public record ChainId(String value) {
+
+    private static final Set<String> SUPPORTED_CHAINS =
+            Set.of("ethereum", "solana", "stellar", "tron", "base", "polygon", "avalanche");
+
+    public ChainId {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Chain ID value is required");
+        }
+        if (!SUPPORTED_CHAINS.contains(value)) {
+            throw new IllegalArgumentException(
+                    "Unsupported chain: %s. Must be one of: %s".formatted(value, SUPPORTED_CHAINS));
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainTransfer.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainTransfer.java
@@ -1,0 +1,295 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import com.stablecoin.payments.custody.domain.statemachine.StateMachine;
+import com.stablecoin.payments.custody.domain.statemachine.StateTransition;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.CHAIN_SELECTED;
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.CONFIRMED;
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.CONFIRMING;
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.FAILED;
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.PENDING;
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.RESUBMITTING;
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.SIGNING;
+import static com.stablecoin.payments.custody.domain.model.TransferStatus.SUBMITTED;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.CONFIRM;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.CONFIRM_SUBMISSION;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.FAIL;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.RESUBMIT;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.SELECT_CHAIN;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.START_CONFIRMING;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.START_SIGNING;
+import static com.stablecoin.payments.custody.domain.model.TransferTrigger.SUBMIT;
+
+/**
+ * Aggregate root for a blockchain chain transfer.
+ * <p>
+ * Enforces the transfer lifecycle via an internal state machine:
+ * {@code PENDING -> CHAIN_SELECTED -> SIGNING -> SUBMITTED -> CONFIRMING -> CONFIRMED}.
+ * <p>
+ * Resubmission path handles mempool drops: {@code SUBMITTED -> RESUBMITTING -> SUBMITTED}.
+ * <p>
+ * Failure can occur from multiple states: CHAIN_SELECTED, SIGNING, SUBMITTED, RESUBMITTING, CONFIRMING.
+ * <p>
+ * Immutable record — all state transitions return new instances via {@code toBuilder()}.
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record ChainTransfer(
+        UUID transferId,
+        UUID paymentId,
+        UUID correlationId,
+        TransferType transferType,
+        UUID parentTransferId,
+        ChainId chainId,
+        StablecoinTicker stablecoin,
+        BigDecimal amount,
+        UUID fromWalletId,
+        String toWalletAddress,
+        String fromAddress,
+        Long nonce,
+        String txHash,
+        TransferStatus status,
+        Long blockNumber,
+        Instant blockConfirmedAt,
+        Integer confirmations,
+        BigDecimal gasUsed,
+        BigDecimal gasPriceGwei,
+        int attemptCount,
+        String failureReason,
+        String errorCode,
+        Instant createdAt,
+        Instant updatedAt
+) {
+
+    private static final Set<TransferStatus> TERMINAL_STATES = Set.of(CONFIRMED, FAILED);
+
+    private static final StateMachine<TransferStatus, TransferTrigger> STATE_MACHINE =
+            new StateMachine<>(List.of(
+                    // -- Happy path -------------------------------------------------
+                    new StateTransition<>(PENDING, SELECT_CHAIN, CHAIN_SELECTED),
+                    new StateTransition<>(CHAIN_SELECTED, START_SIGNING, SIGNING),
+                    new StateTransition<>(SIGNING, SUBMIT, SUBMITTED),
+                    new StateTransition<>(SUBMITTED, START_CONFIRMING, CONFIRMING),
+                    new StateTransition<>(CONFIRMING, CONFIRM, CONFIRMED),
+
+                    // -- Resubmission path ------------------------------------------
+                    new StateTransition<>(SUBMITTED, RESUBMIT, RESUBMITTING),
+                    new StateTransition<>(RESUBMITTING, CONFIRM_SUBMISSION, SUBMITTED),
+
+                    // -- Failure from multiple states --------------------------------
+                    new StateTransition<>(CHAIN_SELECTED, FAIL, FAILED),
+                    new StateTransition<>(SIGNING, FAIL, FAILED),
+                    new StateTransition<>(SUBMITTED, FAIL, FAILED),
+                    new StateTransition<>(RESUBMITTING, FAIL, FAILED),
+                    new StateTransition<>(CONFIRMING, FAIL, FAILED)
+            ));
+
+    // -- Factory Method -------------------------------------------------
+
+    /**
+     * Creates a new chain transfer in PENDING state.
+     */
+    public static ChainTransfer initiate(UUID paymentId, UUID correlationId,
+                                         TransferType transferType, UUID parentTransferId,
+                                         StablecoinTicker stablecoin, BigDecimal amount,
+                                         UUID fromWalletId, String toWalletAddress,
+                                         String fromAddress) {
+        if (paymentId == null) {
+            throw new IllegalArgumentException("paymentId is required");
+        }
+        if (correlationId == null) {
+            throw new IllegalArgumentException("correlationId is required");
+        }
+        if (transferType == null) {
+            throw new IllegalArgumentException("transferType is required");
+        }
+        if (stablecoin == null) {
+            throw new IllegalArgumentException("stablecoin is required");
+        }
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        if (fromWalletId == null) {
+            throw new IllegalArgumentException("fromWalletId is required");
+        }
+        if (toWalletAddress == null || toWalletAddress.isBlank()) {
+            throw new IllegalArgumentException("toWalletAddress is required");
+        }
+        if (fromAddress == null || fromAddress.isBlank()) {
+            throw new IllegalArgumentException("fromAddress is required");
+        }
+
+        var now = Instant.now();
+        return ChainTransfer.builder()
+                .transferId(UUID.randomUUID())
+                .paymentId(paymentId)
+                .correlationId(correlationId)
+                .transferType(transferType)
+                .parentTransferId(parentTransferId)
+                .stablecoin(stablecoin)
+                .amount(amount)
+                .fromWalletId(fromWalletId)
+                .toWalletAddress(toWalletAddress)
+                .fromAddress(fromAddress)
+                .status(PENDING)
+                .attemptCount(0)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+
+    // -- State Transition Methods ---------------------------------------
+
+    /**
+     * Selects the blockchain chain. Transitions PENDING -> CHAIN_SELECTED.
+     */
+    public ChainTransfer selectChain(ChainId selectedChainId) {
+        assertNotTerminal();
+        if (selectedChainId == null) {
+            throw new IllegalArgumentException("Chain ID is required");
+        }
+        var nextState = STATE_MACHINE.transition(status, SELECT_CHAIN);
+        return toBuilder()
+                .status(nextState)
+                .chainId(selectedChainId)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Starts the signing process. Transitions CHAIN_SELECTED -> SIGNING.
+     */
+    public ChainTransfer startSigning(Long signingNonce) {
+        assertNotTerminal();
+        var nextState = STATE_MACHINE.transition(status, START_SIGNING);
+        return toBuilder()
+                .status(nextState)
+                .nonce(signingNonce)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Submits the signed transaction to the chain. Transitions SIGNING -> SUBMITTED.
+     */
+    public ChainTransfer submit(String transactionHash) {
+        assertNotTerminal();
+        if (transactionHash == null || transactionHash.isBlank()) {
+            throw new IllegalArgumentException("Transaction hash is required");
+        }
+        var nextState = STATE_MACHINE.transition(status, SUBMIT);
+        return toBuilder()
+                .status(nextState)
+                .txHash(transactionHash)
+                .attemptCount(attemptCount + 1)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Starts the confirmation monitoring. Transitions SUBMITTED -> CONFIRMING.
+     */
+    public ChainTransfer startConfirming() {
+        assertNotTerminal();
+        var nextState = STATE_MACHINE.transition(status, START_CONFIRMING);
+        return toBuilder()
+                .status(nextState)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Confirms the transfer after sufficient block confirmations.
+     * Transitions CONFIRMING -> CONFIRMED.
+     */
+    public ChainTransfer confirm(long confirmedBlockNumber, int confirmedConfirmations,
+                                 BigDecimal confirmedGasUsed, BigDecimal confirmedGasPriceGwei) {
+        assertNotTerminal();
+        var nextState = STATE_MACHINE.transition(status, CONFIRM);
+        return toBuilder()
+                .status(nextState)
+                .blockNumber(confirmedBlockNumber)
+                .confirmations(confirmedConfirmations)
+                .gasUsed(confirmedGasUsed)
+                .gasPriceGwei(confirmedGasPriceGwei)
+                .blockConfirmedAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Marks the transfer for resubmission (mempool drop / timeout).
+     * Transitions SUBMITTED -> RESUBMITTING.
+     */
+    public ChainTransfer markForResubmission() {
+        assertNotTerminal();
+        var nextState = STATE_MACHINE.transition(status, RESUBMIT);
+        return toBuilder()
+                .status(nextState)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Resubmits with a new transaction hash. Transitions RESUBMITTING -> SUBMITTED.
+     */
+    public ChainTransfer resubmit(String newTxHash) {
+        assertNotTerminal();
+        if (newTxHash == null || newTxHash.isBlank()) {
+            throw new IllegalArgumentException("Transaction hash is required for resubmission");
+        }
+        var nextState = STATE_MACHINE.transition(status, CONFIRM_SUBMISSION);
+        return toBuilder()
+                .status(nextState)
+                .txHash(newTxHash)
+                .attemptCount(attemptCount + 1)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Fails the transfer. Can be triggered from multiple non-terminal states.
+     */
+    public ChainTransfer fail(String reason, String code) {
+        var nextState = STATE_MACHINE.transition(status, FAIL);
+        return toBuilder()
+                .status(nextState)
+                .failureReason(reason)
+                .errorCode(code)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    // -- Query Methods --------------------------------------------------
+
+    /**
+     * Returns true if this transfer is in a terminal state (CONFIRMED or FAILED).
+     */
+    public boolean isTerminal() {
+        return TERMINAL_STATES.contains(status);
+    }
+
+    /**
+     * Returns true if a given trigger can be applied from the current status.
+     */
+    public boolean canApply(TransferTrigger trigger) {
+        return STATE_MACHINE.canTransition(status, trigger);
+    }
+
+    // -- Invariant Guards -----------------------------------------------
+
+    private void assertNotTerminal() {
+        if (isTerminal()) {
+            throw new IllegalStateException(
+                    "Transfer %s is in terminal state %s and cannot be modified"
+                            .formatted(transferId, status));
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ParticipantType.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ParticipantType.java
@@ -1,0 +1,7 @@
+package com.stablecoin.payments.custody.domain.model;
+
+public enum ParticipantType {
+    INPUT,
+    OUTPUT,
+    FEE
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/StablecoinTicker.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/StablecoinTicker.java
@@ -1,0 +1,40 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import java.util.Map;
+
+public record StablecoinTicker(String ticker, String issuer, int decimals) {
+
+    private static final Map<String, StablecoinInfo> SUPPORTED = Map.of(
+            "USDC", new StablecoinInfo("circle", 6),
+            "USDT", new StablecoinInfo("tether", 6),
+            "EURC", new StablecoinInfo("circle_euro", 6),
+            "PYUSD", new StablecoinInfo("paypal", 6),
+            "RLUSD", new StablecoinInfo("ripple", 6)
+    );
+
+    private record StablecoinInfo(String issuer, int decimals) {}
+
+    public StablecoinTicker {
+        if (ticker == null || ticker.isBlank()) {
+            throw new IllegalArgumentException("Ticker is required");
+        }
+        var info = SUPPORTED.get(ticker);
+        if (info == null) {
+            throw new IllegalArgumentException(
+                    "Unsupported stablecoin: %s. Must be one of: %s".formatted(ticker, SUPPORTED.keySet()));
+        }
+        if (issuer == null || issuer.isBlank()) {
+            issuer = info.issuer();
+        }
+        if (decimals <= 0) {
+            decimals = info.decimals();
+        }
+    }
+
+    /**
+     * Factory that auto-fills issuer and decimals from the ticker.
+     */
+    public static StablecoinTicker of(String ticker) {
+        return new StablecoinTicker(ticker, null, 0);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferLifecycleEvent.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferLifecycleEvent.java
@@ -1,0 +1,64 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Audit record for a state change in a chain transfer's lifecycle.
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record TransferLifecycleEvent(
+        UUID eventId,
+        UUID transferId,
+        String state,
+        String participantType,
+        String address,
+        Instant occurredAt
+) {
+
+    // -- Factory Methods ------------------------------------------------
+
+    /**
+     * Records a simple state change event.
+     */
+    public static TransferLifecycleEvent record(UUID transferId, String state) {
+        if (transferId == null) {
+            throw new IllegalArgumentException("transferId is required");
+        }
+        if (state == null || state.isBlank()) {
+            throw new IllegalArgumentException("state is required");
+        }
+
+        return TransferLifecycleEvent.builder()
+                .eventId(UUID.randomUUID())
+                .transferId(transferId)
+                .state(state)
+                .occurredAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Records a state change event with participant details.
+     */
+    public static TransferLifecycleEvent record(UUID transferId, String state,
+                                                String participantType, String address) {
+        if (transferId == null) {
+            throw new IllegalArgumentException("transferId is required");
+        }
+        if (state == null || state.isBlank()) {
+            throw new IllegalArgumentException("state is required");
+        }
+
+        return TransferLifecycleEvent.builder()
+                .eventId(UUID.randomUUID())
+                .transferId(transferId)
+                .state(state)
+                .participantType(participantType)
+                .address(address)
+                .occurredAt(Instant.now())
+                .build();
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferParticipant.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferParticipant.java
@@ -1,0 +1,57 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Represents a participant (input, output, or fee) in a chain transfer.
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record TransferParticipant(
+        UUID participantId,
+        UUID transferId,
+        ParticipantType participantType,
+        String address,
+        UUID walletId,
+        BigDecimal amount,
+        String assetCode
+) {
+
+    // -- Factory Method -------------------------------------------------
+
+    /**
+     * Creates a new transfer participant.
+     */
+    public static TransferParticipant create(UUID transferId, ParticipantType participantType,
+                                             String address, UUID walletId,
+                                             BigDecimal amount, String assetCode) {
+        if (transferId == null) {
+            throw new IllegalArgumentException("transferId is required");
+        }
+        if (participantType == null) {
+            throw new IllegalArgumentException("participantType is required");
+        }
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("address is required");
+        }
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        if (assetCode == null || assetCode.isBlank()) {
+            throw new IllegalArgumentException("assetCode is required");
+        }
+
+        return TransferParticipant.builder()
+                .participantId(UUID.randomUUID())
+                .transferId(transferId)
+                .participantType(participantType)
+                .address(address)
+                .walletId(walletId)
+                .amount(amount)
+                .assetCode(assetCode)
+                .build();
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferStatus.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferStatus.java
@@ -1,0 +1,12 @@
+package com.stablecoin.payments.custody.domain.model;
+
+public enum TransferStatus {
+    PENDING,
+    CHAIN_SELECTED,
+    SIGNING,
+    SUBMITTED,
+    RESUBMITTING,
+    CONFIRMING,
+    CONFIRMED,
+    FAILED
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferTrigger.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferTrigger.java
@@ -1,0 +1,12 @@
+package com.stablecoin.payments.custody.domain.model;
+
+public enum TransferTrigger {
+    SELECT_CHAIN,
+    START_SIGNING,
+    SUBMIT,
+    CONFIRM_SUBMISSION,
+    START_CONFIRMING,
+    CONFIRM,
+    RESUBMIT,
+    FAIL
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferType.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/TransferType.java
@@ -1,0 +1,6 @@
+package com.stablecoin.payments.custody.domain.model;
+
+public enum TransferType {
+    FORWARD,
+    RETURN
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/Wallet.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/Wallet.java
@@ -1,0 +1,105 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a custody wallet on a specific blockchain chain.
+ * <p>
+ * Wallets are managed by a custody provider (e.g., Fireblocks) and have a specific
+ * tier (HOT/WARM/COLD) and purpose (ON_RAMP/OFF_RAMP/SWEEP/RESERVE).
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record Wallet(
+        UUID walletId,
+        ChainId chainId,
+        String address,
+        String addressChecksum,
+        WalletTier tier,
+        WalletPurpose purpose,
+        String custodian,
+        String vaultAccountId,
+        StablecoinTicker stablecoin,
+        boolean active,
+        Instant createdAt,
+        Instant deactivatedAt
+) {
+
+    // -- Factory Method -------------------------------------------------
+
+    /**
+     * Creates a new active wallet.
+     */
+    public static Wallet create(ChainId chainId, String address, String addressChecksum,
+                                WalletTier tier, WalletPurpose purpose,
+                                String custodian, String vaultAccountId,
+                                StablecoinTicker stablecoin) {
+        if (chainId == null) {
+            throw new IllegalArgumentException("chainId is required");
+        }
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("address is required");
+        }
+        if (addressChecksum == null || addressChecksum.isBlank()) {
+            throw new IllegalArgumentException("addressChecksum is required");
+        }
+        if (tier == null) {
+            throw new IllegalArgumentException("tier is required");
+        }
+        if (purpose == null) {
+            throw new IllegalArgumentException("purpose is required");
+        }
+        if (custodian == null || custodian.isBlank()) {
+            throw new IllegalArgumentException("custodian is required");
+        }
+        if (vaultAccountId == null || vaultAccountId.isBlank()) {
+            throw new IllegalArgumentException("vaultAccountId is required");
+        }
+        if (stablecoin == null) {
+            throw new IllegalArgumentException("stablecoin is required");
+        }
+
+        var now = Instant.now();
+        return Wallet.builder()
+                .walletId(UUID.randomUUID())
+                .chainId(chainId)
+                .address(address)
+                .addressChecksum(addressChecksum)
+                .tier(tier)
+                .purpose(purpose)
+                .custodian(custodian)
+                .vaultAccountId(vaultAccountId)
+                .stablecoin(stablecoin)
+                .active(true)
+                .createdAt(now)
+                .build();
+    }
+
+    // -- Domain Methods -------------------------------------------------
+
+    /**
+     * Deactivates this wallet. Returns a new instance with active=false.
+     */
+    public Wallet deactivate() {
+        if (!active) {
+            throw new IllegalStateException(
+                    "Wallet %s is already deactivated".formatted(walletId));
+        }
+        return toBuilder()
+                .active(false)
+                .deactivatedAt(Instant.now())
+                .build();
+    }
+
+    // -- Query Methods --------------------------------------------------
+
+    /**
+     * Returns true if this wallet is currently active.
+     */
+    public boolean isActive() {
+        return active;
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/WalletBalance.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/WalletBalance.java
@@ -1,0 +1,173 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Tracks the balance of a specific stablecoin in a wallet.
+ * <p>
+ * Maintains three balance views:
+ * <ul>
+ *   <li>{@code availableBalance} — funds available for new transfers</li>
+ *   <li>{@code reservedBalance} — funds locked for in-flight transfers</li>
+ *   <li>{@code blockchainBalance} — last indexed on-chain balance</li>
+ * </ul>
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record WalletBalance(
+        UUID balanceId,
+        UUID walletId,
+        ChainId chainId,
+        StablecoinTicker stablecoin,
+        BigDecimal availableBalance,
+        BigDecimal reservedBalance,
+        BigDecimal blockchainBalance,
+        long lastIndexedBlock,
+        long version,
+        Instant updatedAt
+) {
+
+    public WalletBalance {
+        if (availableBalance != null && availableBalance.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Available balance must be non-negative");
+        }
+        if (reservedBalance != null && reservedBalance.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Reserved balance must be non-negative");
+        }
+        if (blockchainBalance != null && blockchainBalance.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Blockchain balance must be non-negative");
+        }
+    }
+
+    // -- Factory Method -------------------------------------------------
+
+    /**
+     * Initializes a new wallet balance with zero balances.
+     */
+    public static WalletBalance initialize(UUID walletId, ChainId chainId,
+                                           StablecoinTicker stablecoin) {
+        if (walletId == null) {
+            throw new IllegalArgumentException("walletId is required");
+        }
+        if (chainId == null) {
+            throw new IllegalArgumentException("chainId is required");
+        }
+        if (stablecoin == null) {
+            throw new IllegalArgumentException("stablecoin is required");
+        }
+
+        return WalletBalance.builder()
+                .balanceId(UUID.randomUUID())
+                .walletId(walletId)
+                .chainId(chainId)
+                .stablecoin(stablecoin)
+                .availableBalance(BigDecimal.ZERO)
+                .reservedBalance(BigDecimal.ZERO)
+                .blockchainBalance(BigDecimal.ZERO)
+                .lastIndexedBlock(0L)
+                .version(0L)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    // -- Domain Methods -------------------------------------------------
+
+    /**
+     * Reserves an amount for an in-flight transfer.
+     * Moves funds from available to reserved.
+     */
+    public WalletBalance reserve(BigDecimal amount) {
+        validatePositiveAmount(amount);
+        if (availableBalance.compareTo(amount) < 0) {
+            throw new IllegalStateException(
+                    "Insufficient available balance: available=%s, requested=%s"
+                            .formatted(availableBalance, amount));
+        }
+        return toBuilder()
+                .availableBalance(availableBalance.subtract(amount))
+                .reservedBalance(reservedBalance.add(amount))
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Releases a previously reserved amount back to available.
+     */
+    public WalletBalance release(BigDecimal amount) {
+        validatePositiveAmount(amount);
+        if (reservedBalance.compareTo(amount) < 0) {
+            throw new IllegalStateException(
+                    "Insufficient reserved balance: reserved=%s, requested=%s"
+                            .formatted(reservedBalance, amount));
+        }
+        return toBuilder()
+                .availableBalance(availableBalance.add(amount))
+                .reservedBalance(reservedBalance.subtract(amount))
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Confirms a debit after chain confirmation. Reduces reserved balance.
+     */
+    public WalletBalance confirmDebit(BigDecimal amount) {
+        validatePositiveAmount(amount);
+        if (reservedBalance.compareTo(amount) < 0) {
+            throw new IllegalStateException(
+                    "Insufficient reserved balance for debit: reserved=%s, requested=%s"
+                            .formatted(reservedBalance, amount));
+        }
+        return toBuilder()
+                .reservedBalance(reservedBalance.subtract(amount))
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Syncs the balance from on-chain data. Updates blockchain balance and recalculates available.
+     */
+    public WalletBalance syncFromChain(BigDecimal onChainBalance, long blockNumber) {
+        if (onChainBalance == null || onChainBalance.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("On-chain balance must be non-negative");
+        }
+        if (blockNumber <= lastIndexedBlock) {
+            throw new IllegalArgumentException(
+                    "Block number %d must be greater than last indexed block %d"
+                            .formatted(blockNumber, lastIndexedBlock));
+        }
+        var newAvailable = onChainBalance.subtract(reservedBalance);
+        if (newAvailable.compareTo(BigDecimal.ZERO) < 0) {
+            newAvailable = BigDecimal.ZERO;
+        }
+        return toBuilder()
+                .blockchainBalance(onChainBalance)
+                .availableBalance(newAvailable)
+                .lastIndexedBlock(blockNumber)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    // -- Query Methods --------------------------------------------------
+
+    /**
+     * Returns true if the wallet has sufficient available balance for the given amount.
+     */
+    public boolean hasSufficientBalance(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            return false;
+        }
+        return availableBalance.compareTo(amount) >= 0;
+    }
+
+    // -- Validation Helpers ---------------------------------------------
+
+    private static void validatePositiveAmount(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Amount must be positive");
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/WalletPurpose.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/WalletPurpose.java
@@ -1,0 +1,8 @@
+package com.stablecoin.payments.custody.domain.model;
+
+public enum WalletPurpose {
+    ON_RAMP,
+    OFF_RAMP,
+    SWEEP,
+    RESERVE
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/WalletTier.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/WalletTier.java
@@ -1,0 +1,7 @@
+package com.stablecoin.payments.custody.domain.model;
+
+public enum WalletTier {
+    HOT,
+    WARM,
+    COLD
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainRpcProvider.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainRpcProvider.java
@@ -1,0 +1,14 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+
+import java.math.BigDecimal;
+
+public interface ChainRpcProvider {
+
+    TransactionReceipt getTransactionReceipt(ChainId chainId, String txHash);
+
+    long getLatestBlockNumber(ChainId chainId);
+
+    BigDecimal getTokenBalance(ChainId chainId, String address, String tokenContract);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainTransferRepository.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainTransferRepository.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.ChainTransfer;
+import com.stablecoin.payments.custody.domain.model.TransferStatus;
+import com.stablecoin.payments.custody.domain.model.TransferType;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ChainTransferRepository {
+
+    ChainTransfer save(ChainTransfer transfer);
+
+    Optional<ChainTransfer> findById(UUID transferId);
+
+    Optional<ChainTransfer> findByPaymentIdAndType(UUID paymentId, TransferType type);
+
+    List<ChainTransfer> findByStatus(TransferStatus status);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/CustodyEngine.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/CustodyEngine.java
@@ -1,0 +1,8 @@
+package com.stablecoin.payments.custody.domain.port;
+
+public interface CustodyEngine {
+
+    SignResult signAndSubmit(SignRequest request);
+
+    TransactionStatus getTransactionStatus(String txId);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/SignRequest.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/SignRequest.java
@@ -1,0 +1,18 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record SignRequest(
+        UUID transferId,
+        ChainId chainId,
+        String fromAddress,
+        String toAddress,
+        BigDecimal amount,
+        StablecoinTicker stablecoin,
+        Long nonce,
+        String vaultAccountId
+) {}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/SignResult.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/SignResult.java
@@ -1,0 +1,3 @@
+package com.stablecoin.payments.custody.domain.port;
+
+public record SignResult(String txHash, String custodyTxId) {}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransactionReceipt.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransactionReceipt.java
@@ -1,0 +1,12 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import java.math.BigDecimal;
+
+public record TransactionReceipt(
+        String txHash,
+        long blockNumber,
+        boolean success,
+        BigDecimal gasUsed,
+        BigDecimal effectiveGasPrice,
+        int confirmations
+) {}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransactionStatus.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransactionStatus.java
@@ -1,0 +1,3 @@
+package com.stablecoin.payments.custody.domain.port;
+
+public record TransactionStatus(String status, String txHash, Integer confirmations) {}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransferEventPublisher.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransferEventPublisher.java
@@ -1,0 +1,6 @@
+package com.stablecoin.payments.custody.domain.port;
+
+public interface TransferEventPublisher {
+
+    void publish(Object event);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransferLifecycleEventRepository.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransferLifecycleEventRepository.java
@@ -1,0 +1,13 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.TransferLifecycleEvent;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TransferLifecycleEventRepository {
+
+    TransferLifecycleEvent save(TransferLifecycleEvent event);
+
+    List<TransferLifecycleEvent> findByTransferId(UUID transferId);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransferParticipantRepository.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/TransferParticipantRepository.java
@@ -1,0 +1,13 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.TransferParticipant;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TransferParticipantRepository {
+
+    TransferParticipant save(TransferParticipant participant);
+
+    List<TransferParticipant> findByTransferId(UUID transferId);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/WalletBalanceRepository.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/WalletBalanceRepository.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+import com.stablecoin.payments.custody.domain.model.WalletBalance;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface WalletBalanceRepository {
+
+    WalletBalance save(WalletBalance balance);
+
+    Optional<WalletBalance> findByWalletIdAndStablecoin(UUID walletId, StablecoinTicker stablecoin);
+
+    Optional<WalletBalance> findByWalletIdAndStablecoinForUpdate(UUID walletId, StablecoinTicker stablecoin);
+
+    List<WalletBalance> findByWalletId(UUID walletId);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/WalletRepository.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/WalletRepository.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.Wallet;
+import com.stablecoin.payments.custody.domain.model.WalletPurpose;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface WalletRepository {
+
+    Wallet save(Wallet wallet);
+
+    Optional<Wallet> findById(UUID walletId);
+
+    List<Wallet> findByChainIdAndPurpose(ChainId chainId, WalletPurpose purpose);
+
+    Optional<Wallet> findByAddress(String address);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/statemachine/StateMachine.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/statemachine/StateMachine.java
@@ -1,0 +1,25 @@
+package com.stablecoin.payments.custody.domain.statemachine;
+
+import java.util.List;
+
+public class StateMachine<S, T> {
+
+    private final List<StateTransition<S, T>> transitions;
+
+    public StateMachine(List<StateTransition<S, T>> transitions) {
+        this.transitions = List.copyOf(transitions);
+    }
+
+    public S transition(S currentState, T trigger) {
+        return transitions.stream()
+                .filter(t -> t.from().equals(currentState) && t.trigger().equals(trigger))
+                .map(StateTransition::to)
+                .findFirst()
+                .orElseThrow(() -> StateMachineException.invalidTransition(currentState, trigger));
+    }
+
+    public boolean canTransition(S currentState, T trigger) {
+        return transitions.stream()
+                .anyMatch(t -> t.from().equals(currentState) && t.trigger().equals(trigger));
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/statemachine/StateMachineException.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/statemachine/StateMachineException.java
@@ -1,0 +1,13 @@
+package com.stablecoin.payments.custody.domain.statemachine;
+
+public class StateMachineException extends RuntimeException {
+
+    private StateMachineException(String message) {
+        super(message);
+    }
+
+    public static <S, T> StateMachineException invalidTransition(S state, T trigger) {
+        return new StateMachineException(
+                "Invalid transition: state=%s trigger=%s".formatted(state, trigger));
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/statemachine/StateTransition.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/statemachine/StateTransition.java
@@ -1,0 +1,3 @@
+package com.stablecoin.payments.custody.domain.statemachine;
+
+public record StateTransition<S, T>(S from, T trigger, S to) {}


### PR DESCRIPTION
## Summary
- **ChainTransfer** aggregate root with 12-transition state machine (PENDING → CONFIRMED, with RESUBMITTING path)
- **Wallet** entity with create/deactivate lifecycle
- **WalletBalance** with reserve/release/confirmDebit/syncFromChain operations
- **TransferParticipant** (INPUT/OUTPUT/FEE) and **TransferLifecycleEvent** (audit trail)
- 3 value objects: `ChainId`, `StablecoinTicker` (auto-fill), `ChainConfig`
- 4 domain events, 8 ports (5 repos, CustodyEngine, ChainRpcProvider, publisher) + 4 port DTOs
- Generic state machine reused from S1 pattern
- 6 enums for transfer status, triggers, wallet types

## Test plan
- [x] 8 ArchUnit tests pass (domain purity verified)
- [ ] Domain unit tests (STA-133 — next task)

Closes STA-132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive blockchain transfer lifecycle with resubmission and failure handling
  * New domain events for transfer/return submitted, confirmed, and failed
  * Custody wallet management with activation/deactivation and multi-chain support
  * Wallet balance tracking with reserve/confirm/sync operations and insufficiency checks
  * Stablecoin ticker support with validation and auto-fill
  * Transfer participant tracking and lifecycle audit events
  * Pluggable RPC, custody engine, publishing, and repository interfaces
* **Refactor**
  * Introduced a state machine utility to enforce transfer state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->