### PR TITLE
feat(s3): Stripe PSP adapter + WireMock stubs (STA-124)

### DIFF
--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/config/FallbackAdaptersConfig.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/config/FallbackAdaptersConfig.java
@@ -1,20 +1,44 @@
 package com.stablecoin.payments.onramp.config;
 
+import com.stablecoin.payments.onramp.domain.port.PspGateway;
+import com.stablecoin.payments.onramp.domain.port.PspPaymentResult;
+import com.stablecoin.payments.onramp.domain.port.PspRefundResult;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.UUID;
 
 /**
  * Provides fallback (dev/test) implementations of outbound ports
  * via {@code @ConditionalOnMissingBean}. Real adapters are registered
  * by provider-specific configurations under
  * {@code infrastructure/provider/<name>/}.
- *
- * <p>Adapters will be added here as domain ports are defined.
  */
 @Slf4j
 @Configuration
 public class FallbackAdaptersConfig {
 
-    // Fallback beans will be added as domain ports are implemented.
-    // Pattern: @Bean @ConditionalOnMissingBean public <Port> fallback<Port>() { ... }
+    @Bean
+    @ConditionalOnMissingBean
+    public PspGateway fallbackPspGateway() {
+        return new PspGateway() {
+            @Override
+            public PspPaymentResult initiatePayment(
+                    com.stablecoin.payments.onramp.domain.port.PspPaymentRequest request) {
+                log.warn("[FALLBACK-PSP] Using dev PSP gateway for payment collectionId={}",
+                        request.collectionId());
+                return new PspPaymentResult("dev-pi-" + UUID.randomUUID(), "succeeded");
+            }
+
+            @Override
+            public PspRefundResult initiateRefund(
+                    com.stablecoin.payments.onramp.domain.port.PspRefundRequest request) {
+                log.warn("[FALLBACK-PSP] Using dev PSP gateway for refund collectionId={}",
+                        request.collectionId());
+                return new PspRefundResult("dev-re-" + UUID.randomUUID(), "succeeded");
+            }
+        };
+    }
 }

--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripePaymentIntentResponse.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripePaymentIntentResponse.java
@@ -1,0 +1,10 @@
+package com.stablecoin.payments.onramp.infrastructure.provider.stripe;
+
+record StripePaymentIntentResponse(
+        String id,
+        String status,
+        Long amount,
+        String currency,
+        String clientSecret
+) {
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripeProperties.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripeProperties.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.onramp.infrastructure.provider.stripe;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.psp.stripe")
+public record StripeProperties(String baseUrl, String apiKey, int timeoutSeconds) {
+
+    public StripeProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            baseUrl = "https://api.stripe.com";
+        }
+        if (apiKey == null || apiKey.isBlank()) {
+            apiKey = "sk_test_default";
+        }
+        if (timeoutSeconds <= 0) {
+            timeoutSeconds = 10;
+        }
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripePspAdapter.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripePspAdapter.java
@@ -1,0 +1,120 @@
+package com.stablecoin.payments.onramp.infrastructure.provider.stripe;
+
+import com.stablecoin.payments.onramp.domain.port.PspGateway;
+import com.stablecoin.payments.onramp.domain.port.PspPaymentRequest;
+import com.stablecoin.payments.onramp.domain.port.PspPaymentResult;
+import com.stablecoin.payments.onramp.domain.port.PspRefundRequest;
+import com.stablecoin.payments.onramp.domain.port.PspRefundResult;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.time.Duration;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "app.psp.provider", havingValue = "stripe")
+@EnableConfigurationProperties(StripeProperties.class)
+public class StripePspAdapter implements PspGateway {
+
+    private final RestClient restClient;
+
+    public StripePspAdapter(StripeProperties properties) {
+        var httpClient = HttpClient.newBuilder()
+                .version(Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
+                .build();
+
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.apiKey())
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    @Override
+    @CircuitBreaker(name = "stripe", fallbackMethod = "initiatePaymentFallback")
+    public PspPaymentResult initiatePayment(PspPaymentRequest request) {
+        log.info("[STRIPE] Initiating payment collectionId={} amount={} currency={}",
+                request.collectionId(), request.amount().amount(), request.amount().currency());
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("amount", toMinorUnits(request));
+        formData.add("currency", request.amount().currency().toLowerCase());
+        formData.add("payment_method_types[]", "us_bank_account");
+        formData.add("confirm", "true");
+        formData.add("metadata[collection_id]", request.collectionId().toString());
+
+        var response = restClient.post()
+                .uri("/v1/payment_intents")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(formData)
+                .retrieve()
+                .body(StripePaymentIntentResponse.class);
+
+        log.info("[STRIPE] Payment initiated collectionId={} pspRef={} status={}",
+                request.collectionId(), response.id(), response.status());
+
+        return new PspPaymentResult(response.id(), response.status());
+    }
+
+    @Override
+    @CircuitBreaker(name = "stripe", fallbackMethod = "initiateRefundFallback")
+    public PspRefundResult initiateRefund(PspRefundRequest request) {
+        log.info("[STRIPE] Initiating refund collectionId={} pspRef={} amount={}",
+                request.collectionId(), request.pspReference(), request.refundAmount().amount());
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("payment_intent", request.pspReference());
+        formData.add("amount", toMinorUnitsFromRefund(request));
+        formData.add("reason", "requested_by_customer");
+        formData.add("metadata[collection_id]", request.collectionId().toString());
+
+        var response = restClient.post()
+                .uri("/v1/refunds")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(formData)
+                .retrieve()
+                .body(StripeRefundResponse.class);
+
+        log.info("[STRIPE] Refund initiated collectionId={} refundRef={} status={}",
+                request.collectionId(), response.id(), response.status());
+
+        return new PspRefundResult(response.id(), response.status());
+    }
+
+    @SuppressWarnings("unused")
+    private PspPaymentResult initiatePaymentFallback(PspPaymentRequest request, Exception ex) {
+        log.error("[STRIPE] Circuit breaker open — payment initiation failed collectionId={}",
+                request.collectionId(), ex);
+        throw new IllegalStateException("Stripe payment initiation unavailable", ex);
+    }
+
+    @SuppressWarnings("unused")
+    private PspRefundResult initiateRefundFallback(PspRefundRequest request, Exception ex) {
+        log.error("[STRIPE] Circuit breaker open — refund initiation failed collectionId={}",
+                request.collectionId(), ex);
+        throw new IllegalStateException("Stripe refund initiation unavailable", ex);
+    }
+
+    private String toMinorUnits(PspPaymentRequest request) {
+        return String.valueOf(request.amount().amount().movePointRight(2).longValueExact());
+    }
+
+    private String toMinorUnitsFromRefund(PspRefundRequest request) {
+        return String.valueOf(request.refundAmount().amount().movePointRight(2).longValueExact());
+    }
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripeRefundResponse.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripeRefundResponse.java
@@ -1,0 +1,10 @@
+package com.stablecoin.payments.onramp.infrastructure.provider.stripe;
+
+record StripeRefundResponse(
+        String id,
+        String status,
+        Long amount,
+        String currency,
+        String paymentIntent
+) {
+}

--- a/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
@@ -115,6 +115,12 @@ springdoc:
 app:
   security:
     enabled: false
+  psp:
+    provider: stripe
+    stripe:
+      base-url: https://api.stripe.com
+      api-key: ${STRIPE_API_KEY:sk_test_default}
+      timeout-seconds: 10
 
 logging:
   level:

--- a/fiat-on-ramp/fiat-on-ramp/src/test/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripePspAdapterTest.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/test/java/com/stablecoin/payments/onramp/infrastructure/provider/stripe/StripePspAdapterTest.java
@@ -1,0 +1,250 @@
+package com.stablecoin.payments.onramp.infrastructure.provider.stripe;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.stablecoin.payments.onramp.domain.model.AccountType;
+import com.stablecoin.payments.onramp.domain.model.BankAccount;
+import com.stablecoin.payments.onramp.domain.model.Money;
+import com.stablecoin.payments.onramp.domain.model.PaymentRail;
+import com.stablecoin.payments.onramp.domain.model.PaymentRailType;
+import com.stablecoin.payments.onramp.domain.port.PspPaymentRequest;
+import com.stablecoin.payments.onramp.domain.port.PspPaymentResult;
+import com.stablecoin.payments.onramp.domain.port.PspRefundRequest;
+import com.stablecoin.payments.onramp.domain.port.PspRefundResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StripePspAdapterTest {
+
+    private static WireMockServer wireMock;
+    private StripePspAdapter adapter;
+
+    private static final UUID COLLECTION_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMock.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMock.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        wireMock.resetAll();
+        var properties = new StripeProperties(wireMock.baseUrl(), "sk_test_xxx", 10);
+        adapter = new StripePspAdapter(properties);
+    }
+
+    private PspPaymentRequest aPaymentRequest() {
+        return new PspPaymentRequest(
+                COLLECTION_ID,
+                new Money(new BigDecimal("250.00"), "USD"),
+                new PaymentRail(PaymentRailType.ACH, "US", "USD"),
+                new BankAccount("hash123", "021000021", AccountType.ACH_ROUTING, "US"),
+                "stripe"
+        );
+    }
+
+    private PspRefundRequest aRefundRequest() {
+        return new PspRefundRequest(
+                COLLECTION_ID,
+                "pi_test123",
+                new Money(new BigDecimal("100.00"), "USD"),
+                "stripe",
+                "customer_request"
+        );
+    }
+
+    @Nested
+    @DisplayName("initiatePayment")
+    class InitiatePayment {
+
+        @Test
+        @DisplayName("should return PspPaymentResult on successful payment intent creation")
+        void initiatePayment_success() {
+            wireMock.stubFor(post(urlEqualTo("/v1/payment_intents"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "pi_test123",
+                                      "status": "succeeded",
+                                      "amount": 25000,
+                                      "currency": "usd",
+                                      "client_secret": "pi_test123_secret_xxx"
+                                    }
+                                    """)));
+
+            var result = adapter.initiatePayment(aPaymentRequest());
+
+            var expected = new PspPaymentResult("pi_test123", "succeeded");
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should throw when Stripe returns 402 payment error")
+        void initiatePayment_stripeError() {
+            wireMock.stubFor(post(urlEqualTo("/v1/payment_intents"))
+                    .willReturn(aResponse()
+                            .withStatus(402)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "error": {
+                                        "type": "card_error",
+                                        "message": "Your card was declined."
+                                      }
+                                    }
+                                    """)));
+
+            assertThatThrownBy(() -> adapter.initiatePayment(aPaymentRequest()))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("should throw on connection timeout")
+        void initiatePayment_timeout() {
+            var timeoutProperties = new StripeProperties(wireMock.baseUrl(), "sk_test_xxx", 1);
+            var timeoutAdapter = new StripePspAdapter(timeoutProperties);
+
+            wireMock.stubFor(post(urlEqualTo("/v1/payment_intents"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withFixedDelay(3000)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "pi_test_late",
+                                      "status": "succeeded",
+                                      "amount": 25000,
+                                      "currency": "usd",
+                                      "client_secret": "pi_test_late_secret"
+                                    }
+                                    """)));
+
+            assertThatThrownBy(() -> timeoutAdapter.initiatePayment(aPaymentRequest()))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("should send correct form parameters to Stripe")
+        void initiatePayment_verifiesRequestBody() {
+            wireMock.stubFor(post(urlEqualTo("/v1/payment_intents"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "pi_verify",
+                                      "status": "requires_action",
+                                      "amount": 25000,
+                                      "currency": "usd",
+                                      "client_secret": "pi_verify_secret"
+                                    }
+                                    """)));
+
+            adapter.initiatePayment(aPaymentRequest());
+
+            wireMock.verify(postRequestedFor(urlEqualTo("/v1/payment_intents"))
+                    .withRequestBody(containing("amount=25000"))
+                    .withRequestBody(containing("currency=usd"))
+                    .withRequestBody(containing("payment_method_types%5B%5D=us_bank_account"))
+                    .withRequestBody(containing("confirm=true"))
+                    .withRequestBody(containing("metadata%5Bcollection_id%5D=" + COLLECTION_ID)));
+        }
+    }
+
+    @Nested
+    @DisplayName("initiateRefund")
+    class InitiateRefund {
+
+        @Test
+        @DisplayName("should return PspRefundResult on successful refund")
+        void initiateRefund_success() {
+            wireMock.stubFor(post(urlEqualTo("/v1/refunds"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "re_test456",
+                                      "status": "succeeded",
+                                      "amount": 10000,
+                                      "currency": "usd",
+                                      "payment_intent": "pi_test123"
+                                    }
+                                    """)));
+
+            var result = adapter.initiateRefund(aRefundRequest());
+
+            var expected = new PspRefundResult("re_test456", "succeeded");
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should throw when payment intent not found for refund")
+        void initiateRefund_paymentIntentNotFound() {
+            wireMock.stubFor(post(urlEqualTo("/v1/refunds"))
+                    .willReturn(aResponse()
+                            .withStatus(404)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "error": {
+                                        "type": "invalid_request_error",
+                                        "message": "No such payment_intent: 'pi_test123'"
+                                      }
+                                    }
+                                    """)));
+
+            assertThatThrownBy(() -> adapter.initiateRefund(aRefundRequest()))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("should send correct form parameters for refund")
+        void initiateRefund_verifiesRequestBody() {
+            wireMock.stubFor(post(urlEqualTo("/v1/refunds"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "re_verify",
+                                      "status": "pending",
+                                      "amount": 10000,
+                                      "currency": "usd",
+                                      "payment_intent": "pi_test123"
+                                    }
+                                    """)));
+
+            adapter.initiateRefund(aRefundRequest());
+
+            wireMock.verify(postRequestedFor(urlEqualTo("/v1/refunds"))
+                    .withRequestBody(containing("payment_intent=pi_test123"))
+                    .withRequestBody(containing("amount=10000"))
+                    .withRequestBody(containing("reason=requested_by_customer"))
+                    .withRequestBody(containing("metadata%5Bcollection_id%5D=" + COLLECTION_ID)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `StripePspAdapter` as ACL adapter for `PspGateway` domain port — form-encoded requests to Stripe API (PaymentIntents + Refunds)
- `StripeProperties` with `@ConfigurationProperties(prefix = "app.psp.stripe")` — configurable base URL, API key, timeout
- Package-private ACL DTOs (`StripePaymentIntentResponse`, `StripeRefundResponse`) with `Long` wrapper types (Jackson 3 compat)
- `@CircuitBreaker(name = "stripe")` on both methods with hard-block fallbacks (re-throw)
- `RestClient` with `HttpClient.Version.HTTP_1_1` (avoids WireMock EOF errors)
- Fallback `PspGateway` bean in `FallbackAdaptersConfig` via `@ConditionalOnMissingBean`
- 7 WireMock-based unit tests (success, error, timeout, request body verification for both payment + refund)

## Test plan
- [x] 7 new WireMock unit tests all pass
- [x] All 221 S3 unit tests green (214 existing + 7 new)
- [x] Spotless formatting clean

Closes STA-124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Stripe as a payment service provider with support for payment initiation and refund processing
  * Added fallback payment gateway mechanism to ensure consistent operation

* **Configuration**
  * Added Stripe configuration options with customizable base URL, API authentication, and timeout settings

* **Tests**
  * Added comprehensive test coverage for Stripe operations, including success cases, error scenarios, and timeout handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->