### PR TITLE
feat(s4): chain selection engine — multi-chain scoring (STA-136)

### DIFF
--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/application/config/ChainSelectionConfig.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/application/config/ChainSelectionConfig.java
@@ -1,0 +1,63 @@
+package com.stablecoin.payments.custody.application.config;
+
+import com.stablecoin.payments.custody.domain.model.ChainSelectionWeights;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for the chain selection engine.
+ * Maps {@code app.custody.chain-selection.*} properties to {@link ChainSelectionWeights}.
+ */
+@Configuration
+public class ChainSelectionConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "app.custody.chain-selection")
+    public ChainSelectionProperties chainSelectionProperties() {
+        return new ChainSelectionProperties();
+    }
+
+    @Bean
+    public ChainSelectionWeights chainSelectionWeights(ChainSelectionProperties props) {
+        return ChainSelectionWeights.builder()
+                .costWeight(props.getCostWeight())
+                .speedWeight(props.getSpeedWeight())
+                .reliabilityWeight(props.getReliabilityWeight())
+                .build();
+    }
+
+    /**
+     * Mutable properties bean for Spring Boot's {@code @ConfigurationProperties} binding.
+     * Defaults match {@link ChainSelectionWeights#defaults()}.
+     */
+    public static class ChainSelectionProperties {
+        private double costWeight = ChainSelectionWeights.DEFAULT_COST_WEIGHT;
+        private double speedWeight = ChainSelectionWeights.DEFAULT_SPEED_WEIGHT;
+        private double reliabilityWeight = ChainSelectionWeights.DEFAULT_RELIABILITY_WEIGHT;
+
+        public double getCostWeight() {
+            return costWeight;
+        }
+
+        public void setCostWeight(double costWeight) {
+            this.costWeight = costWeight;
+        }
+
+        public double getSpeedWeight() {
+            return speedWeight;
+        }
+
+        public void setSpeedWeight(double speedWeight) {
+            this.speedWeight = speedWeight;
+        }
+
+        public double getReliabilityWeight() {
+            return reliabilityWeight;
+        }
+
+        public void setReliabilityWeight(double reliabilityWeight) {
+            this.reliabilityWeight = reliabilityWeight;
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
@@ -1,18 +1,50 @@
 package com.stablecoin.payments.custody.config;
 
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+import com.stablecoin.payments.custody.domain.port.ChainFeeProvider;
+import com.stablecoin.payments.custody.domain.port.ChainHealthProvider;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
 
 /**
  * Provides fallback (dev/test) implementations for external provider ports.
  * Each bean uses {@code @ConditionalOnMissingBean} so that production adapters
  * (activated via {@code @ConditionalOnProperty}) take precedence.
- *
- * <p>Domain ports (CustodyEngine, ChainRpcProvider) will be added here
- * once the domain model is scaffolded.</p>
  */
 @Slf4j
 @Configuration
 public class FallbackAdaptersConfig {
-    // Fallback beans will be added when domain ports are defined
+
+    private static final Map<String, Double> DEFAULT_FEES = Map.of(
+            "base", 0.01,
+            "ethereum", 2.50,
+            "solana", 0.005
+    );
+
+    /**
+     * Fallback health provider that returns 1.0 (healthy) for all chains.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public ChainHealthProvider fallbackChainHealthProvider() {
+        log.info("Using fallback ChainHealthProvider (all chains healthy)");
+        return (ChainId chainId) -> 1.0;
+    }
+
+    /**
+     * Fallback fee provider with realistic defaults:
+     * Base=0.01, Ethereum=2.50, Solana=0.005 USD.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public ChainFeeProvider fallbackChainFeeProvider() {
+        log.info("Using fallback ChainFeeProvider (static fee estimates)");
+        return (ChainId chainId, StablecoinTicker stablecoin) ->
+                DEFAULT_FEES.getOrDefault(chainId.value(), 1.0);
+    }
 }

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/exception/ChainUnavailableException.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/exception/ChainUnavailableException.java
@@ -1,0 +1,11 @@
+package com.stablecoin.payments.custody.domain.exception;
+
+/**
+ * Thrown when no healthy blockchain chain is available for a transfer.
+ */
+public class ChainUnavailableException extends RuntimeException {
+
+    public ChainUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainCandidate.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainCandidate.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import lombok.Builder;
+
+/**
+ * A candidate chain evaluation result used during chain selection.
+ * <p>
+ * Each candidate records the fee estimate, finality time, health score,
+ * the composite weighted score, and whether this candidate was ultimately selected.
+ */
+@Builder(toBuilder = true)
+public record ChainCandidate(
+        ChainId chainId,
+        double feeUsd,
+        int finalitySeconds,
+        double healthScore,
+        double score,
+        boolean selected
+) {}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainSelectionResult.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainSelectionResult.java
@@ -1,0 +1,31 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The result of a chain selection evaluation, containing the selected chain,
+ * all evaluated candidates with their scores, and the transfer ID.
+ */
+@Builder(toBuilder = true)
+public record ChainSelectionResult(
+        ChainId selectedChain,
+        List<ChainCandidate> candidates,
+        UUID transferId
+) {
+
+    public ChainSelectionResult {
+        if (selectedChain == null) {
+            throw new IllegalArgumentException("selectedChain is required");
+        }
+        if (candidates == null || candidates.isEmpty()) {
+            throw new IllegalArgumentException("candidates must not be empty");
+        }
+        if (transferId == null) {
+            throw new IllegalArgumentException("transferId is required");
+        }
+        candidates = List.copyOf(candidates);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainSelectionWeights.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/model/ChainSelectionWeights.java
@@ -1,0 +1,46 @@
+package com.stablecoin.payments.custody.domain.model;
+
+import lombok.Builder;
+
+/**
+ * Immutable weights for the multi-criteria chain selection scoring model.
+ * <p>
+ * All weights must be non-negative and sum to approximately 1.0 (±0.001 tolerance).
+ */
+@Builder(toBuilder = true)
+public record ChainSelectionWeights(
+        double costWeight,
+        double speedWeight,
+        double reliabilityWeight
+) {
+
+    public static final double DEFAULT_COST_WEIGHT = 0.4;
+    public static final double DEFAULT_SPEED_WEIGHT = 0.35;
+    public static final double DEFAULT_RELIABILITY_WEIGHT = 0.25;
+
+    private static final double SUM_TOLERANCE = 0.001;
+
+    public ChainSelectionWeights {
+        if (costWeight < 0) {
+            throw new IllegalArgumentException("costWeight must be non-negative");
+        }
+        if (speedWeight < 0) {
+            throw new IllegalArgumentException("speedWeight must be non-negative");
+        }
+        if (reliabilityWeight < 0) {
+            throw new IllegalArgumentException("reliabilityWeight must be non-negative");
+        }
+        double sum = costWeight + speedWeight + reliabilityWeight;
+        if (Math.abs(sum - 1.0) > SUM_TOLERANCE) {
+            throw new IllegalArgumentException(
+                    "Weights must sum to ~1.0, but got %s".formatted(sum));
+        }
+    }
+
+    /**
+     * Returns the default weights (cost=0.4, speed=0.35, reliability=0.25).
+     */
+    public static ChainSelectionWeights defaults() {
+        return new ChainSelectionWeights(DEFAULT_COST_WEIGHT, DEFAULT_SPEED_WEIGHT, DEFAULT_RELIABILITY_WEIGHT);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainFeeProvider.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainFeeProvider.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+
+/**
+ * Port for estimating transaction fees on a given blockchain chain.
+ */
+public interface ChainFeeProvider {
+
+    /**
+     * Estimates the fee in USD for transferring a stablecoin on the given chain.
+     *
+     * @param chainId    the target chain
+     * @param stablecoin the stablecoin to transfer
+     * @return estimated fee in USD
+     */
+    double estimateFeeUsd(ChainId chainId, StablecoinTicker stablecoin);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainHealthProvider.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainHealthProvider.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+
+/**
+ * Port for retrieving the current health score of a blockchain chain.
+ * <p>
+ * Returns 0.0 for unhealthy/down chains and 1.0 for healthy chains.
+ */
+public interface ChainHealthProvider {
+
+    /**
+     * Returns the health score for the given chain.
+     *
+     * @param chainId the chain to evaluate
+     * @return 0.0 (unhealthy) or 1.0 (healthy)
+     */
+    double getHealthScore(ChainId chainId);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainSelectionLogRepository.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/port/ChainSelectionLogRepository.java
@@ -1,0 +1,19 @@
+package com.stablecoin.payments.custody.domain.port;
+
+import com.stablecoin.payments.custody.domain.model.ChainSelectionResult;
+
+import java.util.UUID;
+
+/**
+ * Port for persisting chain selection evaluation results.
+ */
+public interface ChainSelectionLogRepository {
+
+    /**
+     * Saves the chain selection result for the given transfer.
+     *
+     * @param transferId the transfer for which chain was selected
+     * @param result     the selection result including all scored candidates
+     */
+    void save(UUID transferId, ChainSelectionResult result);
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/service/ChainSelectionEngine.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/domain/service/ChainSelectionEngine.java
@@ -1,0 +1,191 @@
+package com.stablecoin.payments.custody.domain.service;
+
+import com.stablecoin.payments.custody.domain.exception.ChainUnavailableException;
+import com.stablecoin.payments.custody.domain.model.ChainCandidate;
+import com.stablecoin.payments.custody.domain.model.ChainConfig;
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.ChainSelectionResult;
+import com.stablecoin.payments.custody.domain.model.ChainSelectionWeights;
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+import com.stablecoin.payments.custody.domain.model.WalletPurpose;
+import com.stablecoin.payments.custody.domain.port.ChainFeeProvider;
+import com.stablecoin.payments.custody.domain.port.ChainHealthProvider;
+import com.stablecoin.payments.custody.domain.port.ChainSelectionLogRepository;
+import com.stablecoin.payments.custody.domain.port.WalletBalanceRepository;
+import com.stablecoin.payments.custody.domain.port.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Domain service that evaluates candidate blockchain chains using a weighted scoring model
+ * and selects the optimal chain for a given transfer.
+ *
+ * <p>Algorithm:
+ * <ol>
+ *   <li>Get MVP candidate chains (Base, Ethereum, Solana)</li>
+ *   <li>Filter by wallet liquidity — chain must have an ON_RAMP wallet with sufficient balance</li>
+ *   <li>Filter by health — chain must have health score &gt; 0</li>
+ *   <li>Score each candidate: score = costWeight * (1/feeUsd) + speedWeight * (1/finalitySeconds) + reliabilityWeight * healthScore</li>
+ *   <li>If preferredChain is set and healthy, select it regardless of score</li>
+ *   <li>Otherwise select the candidate with the highest score</li>
+ * </ol>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChainSelectionEngine {
+
+    private final ChainSelectionWeights weights;
+    private final ChainHealthProvider chainHealthProvider;
+    private final ChainFeeProvider chainFeeProvider;
+    private final WalletRepository walletRepository;
+    private final WalletBalanceRepository walletBalanceRepository;
+    private final ChainSelectionLogRepository chainSelectionLogRepository;
+
+    /**
+     * Request record for chain selection.
+     */
+    public record ChainSelectionRequest(
+            UUID transferId,
+            StablecoinTicker stablecoin,
+            BigDecimal amount,
+            String preferredChain
+    ) {
+
+        public ChainSelectionRequest {
+            if (transferId == null) {
+                throw new IllegalArgumentException("transferId is required");
+            }
+            if (stablecoin == null) {
+                throw new IllegalArgumentException("stablecoin is required");
+            }
+            if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new IllegalArgumentException("amount must be positive");
+            }
+        }
+    }
+
+    /**
+     * MVP candidate chain configurations.
+     */
+    private static final Map<String, ChainConfig> MVP_CHAINS = Map.of(
+            "base", new ChainConfig(
+                    new ChainId("base"), 1, 12, "ETH",
+                    List.of("https://base-rpc.example.com"), "https://basescan.org"),
+            "ethereum", new ChainConfig(
+                    new ChainId("ethereum"), 32, 300, "ETH",
+                    List.of("https://eth-rpc.example.com"), "https://etherscan.io"),
+            "solana", new ChainConfig(
+                    new ChainId("solana"), 1, 5, "SOL",
+                    List.of("https://sol-rpc.example.com"), "https://explorer.solana.com")
+    );
+
+    /**
+     * Selects the optimal chain for a transfer based on cost, speed, reliability,
+     * wallet liquidity, and chain health.
+     *
+     * @param request the selection request containing transfer details
+     * @return the selection result with the chosen chain and all scored candidates
+     * @throws ChainUnavailableException if no healthy, funded chain is available
+     */
+    public ChainSelectionResult selectChain(ChainSelectionRequest request) {
+        log.info("Selecting chain for transfer={}, stablecoin={}, amount={}",
+                request.transferId(), request.stablecoin().ticker(), request.amount());
+
+        var candidateConfigs = new ArrayList<>(MVP_CHAINS.values());
+
+        // Filter and score candidates
+        var scoredCandidates = candidateConfigs.stream()
+                .filter(config -> hasWalletWithSufficientBalance(config.chainId(), request.stablecoin(), request.amount()))
+                .filter(config -> chainHealthProvider.getHealthScore(config.chainId()) > 0)
+                .map(config -> scoreCandidate(config, request.stablecoin()))
+                .toList();
+
+        if (scoredCandidates.isEmpty()) {
+            throw new ChainUnavailableException(
+                    "No healthy chain with sufficient balance available for transfer %s"
+                            .formatted(request.transferId()));
+        }
+
+        // Determine selected chain
+        ChainCandidate selectedCandidate = resolveSelectedCandidate(scoredCandidates, request.preferredChain());
+
+        // Build final candidates list with selected flag
+        var finalCandidates = scoredCandidates.stream()
+                .map(candidate -> candidate.toBuilder()
+                        .selected(candidate.chainId().equals(selectedCandidate.chainId()))
+                        .build())
+                .toList();
+
+        var result = ChainSelectionResult.builder()
+                .selectedChain(selectedCandidate.chainId())
+                .candidates(finalCandidates)
+                .transferId(request.transferId())
+                .build();
+
+        chainSelectionLogRepository.save(request.transferId(), result);
+
+        log.info("Selected chain={} for transfer={} (candidates={})",
+                result.selectedChain().value(), request.transferId(), finalCandidates.size());
+
+        return result;
+    }
+
+    private boolean hasWalletWithSufficientBalance(ChainId chainId, StablecoinTicker stablecoin, BigDecimal amount) {
+        var wallets = walletRepository.findByChainIdAndPurpose(chainId, WalletPurpose.ON_RAMP);
+        if (wallets.isEmpty()) {
+            log.debug("No ON_RAMP wallet found for chain={}", chainId.value());
+            return false;
+        }
+
+        return wallets.stream().anyMatch(wallet -> {
+            var balance = walletBalanceRepository.findByWalletIdAndStablecoin(wallet.walletId(), stablecoin);
+            return balance.map(b -> b.hasSufficientBalance(amount)).orElse(false);
+        });
+    }
+
+    private ChainCandidate scoreCandidate(ChainConfig config, StablecoinTicker stablecoin) {
+        double feeUsd = chainFeeProvider.estimateFeeUsd(config.chainId(), stablecoin);
+        double healthScore = chainHealthProvider.getHealthScore(config.chainId());
+
+        double costScore = feeUsd > 0 ? 1.0 / feeUsd : 0.0;
+        double speedScore = config.avgFinalitySeconds() > 0 ? 1.0 / config.avgFinalitySeconds() : 0.0;
+
+        double score = weights.costWeight() * costScore
+                + weights.speedWeight() * speedScore
+                + weights.reliabilityWeight() * healthScore;
+
+        return ChainCandidate.builder()
+                .chainId(config.chainId())
+                .feeUsd(feeUsd)
+                .finalitySeconds(config.avgFinalitySeconds())
+                .healthScore(healthScore)
+                .score(score)
+                .selected(false)
+                .build();
+    }
+
+    private ChainCandidate resolveSelectedCandidate(List<ChainCandidate> candidates, String preferredChain) {
+        if (preferredChain != null && !preferredChain.isBlank()) {
+            var preferredChainId = new ChainId(preferredChain);
+            var preferred = candidates.stream()
+                    .filter(c -> c.chainId().equals(preferredChainId))
+                    .findFirst();
+            if (preferred.isPresent()) {
+                return preferred.get();
+            }
+            log.warn("Preferred chain {} is not available, falling back to scoring", preferredChain);
+        }
+        return candidates.stream()
+                .max(Comparator.comparingDouble(ChainCandidate::score))
+                .orElseThrow(() -> new ChainUnavailableException("No candidates to select from"));
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/persistence/ChainSelectionLogPersistenceAdapter.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/persistence/ChainSelectionLogPersistenceAdapter.java
@@ -1,0 +1,76 @@
+package com.stablecoin.payments.custody.infrastructure.persistence;
+
+import com.stablecoin.payments.custody.domain.model.ChainCandidate;
+import com.stablecoin.payments.custody.domain.model.ChainSelectionResult;
+import com.stablecoin.payments.custody.domain.port.ChainSelectionLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * JdbcTemplate-based persistence adapter for the chain_selection_log table.
+ * Uses Jackson 3 for JSONB serialization of candidate evaluations.
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ChainSelectionLogPersistenceAdapter implements ChainSelectionLogRepository {
+
+    private static final String INSERT_SQL = """
+            INSERT INTO chain_selection_log (selection_id, transfer_id, evaluated_at, candidates, selected_chain)
+            VALUES (?, ?, ?, ?::jsonb, ?)
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final JsonMapper jsonMapper = JsonMapper.builder().build();
+
+    @Override
+    public void save(UUID transferId, ChainSelectionResult result) {
+        var selectionId = UUID.randomUUID();
+        var evaluatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        var candidatesJson = serializeCandidates(result.candidates());
+
+        jdbcTemplate.update(INSERT_SQL,
+                selectionId,
+                transferId,
+                evaluatedAt,
+                candidatesJson,
+                result.selectedChain().value());
+
+        log.debug("Saved chain selection log: selectionId={}, transferId={}, selectedChain={}",
+                selectionId, transferId, result.selectedChain().value());
+    }
+
+    private String serializeCandidates(List<ChainCandidate> candidates) {
+        try {
+            var dtos = candidates.stream()
+                    .map(c -> new CandidateDto(
+                            c.chainId().value(),
+                            c.feeUsd(),
+                            c.finalitySeconds(),
+                            c.healthScore(),
+                            c.score(),
+                            c.selected()))
+                    .toList();
+            return jsonMapper.writeValueAsString(dtos);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize chain candidates to JSON", e);
+        }
+    }
+
+    private record CandidateDto(
+            String chainId,
+            double feeUsd,
+            int finalitySeconds,
+            double healthScore,
+            double score,
+            boolean selected
+    ) {}
+}

--- a/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/domain/service/ChainSelectionEngineTest.java
+++ b/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/domain/service/ChainSelectionEngineTest.java
@@ -1,0 +1,452 @@
+package com.stablecoin.payments.custody.domain.service;
+
+import com.stablecoin.payments.custody.domain.exception.ChainUnavailableException;
+import com.stablecoin.payments.custody.domain.model.ChainCandidate;
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.ChainSelectionResult;
+import com.stablecoin.payments.custody.domain.model.ChainSelectionWeights;
+import com.stablecoin.payments.custody.domain.model.Wallet;
+import com.stablecoin.payments.custody.domain.model.WalletPurpose;
+import com.stablecoin.payments.custody.domain.model.WalletTier;
+import com.stablecoin.payments.custody.domain.port.ChainFeeProvider;
+import com.stablecoin.payments.custody.domain.port.ChainHealthProvider;
+import com.stablecoin.payments.custody.domain.port.ChainSelectionLogRepository;
+import com.stablecoin.payments.custody.domain.port.WalletBalanceRepository;
+import com.stablecoin.payments.custody.domain.port.WalletRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.AMOUNT;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.CHAIN_BASE;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.CHAIN_ETHEREUM;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.CHAIN_SOLANA;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.TRANSFER_ID;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.USDC;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.aSelectionRequest;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.aSelectionRequestWithAmount;
+import static com.stablecoin.payments.custody.fixtures.ChainSelectionFixtures.aSelectionRequestWithPreferredChain;
+import static com.stablecoin.payments.custody.fixtures.WalletBalanceFixtures.aBalanceWith;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class ChainSelectionEngineTest {
+
+    @Mock
+    private ChainHealthProvider chainHealthProvider;
+
+    @Mock
+    private ChainFeeProvider chainFeeProvider;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private WalletBalanceRepository walletBalanceRepository;
+
+    @Mock
+    private ChainSelectionLogRepository chainSelectionLogRepository;
+
+    @InjectMocks
+    private ChainSelectionEngine engine;
+
+    // -- Helper: create default weights and inject via constructor --
+
+    private ChainSelectionEngine engineWith(ChainSelectionWeights weights) {
+        return new ChainSelectionEngine(
+                weights, chainHealthProvider, chainFeeProvider,
+                walletRepository, walletBalanceRepository, chainSelectionLogRepository);
+    }
+
+    private void stubAllChainsHealthy() {
+        given(chainHealthProvider.getHealthScore(CHAIN_BASE)).willReturn(1.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(1.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_SOLANA)).willReturn(1.0);
+    }
+
+    private void stubAllChainsFees() {
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_BASE, USDC)).willReturn(0.01);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_SOLANA, USDC)).willReturn(0.005);
+    }
+
+    private void stubAllChainsWithSufficientBalance() {
+        stubChainWithBalance(CHAIN_BASE, AMOUNT, true);
+        stubChainWithBalance(CHAIN_ETHEREUM, AMOUNT, true);
+        stubChainWithBalance(CHAIN_SOLANA, AMOUNT, true);
+    }
+
+    private Wallet createWallet(ChainId chainId) {
+        return Wallet.create(
+                chainId,
+                "0x" + chainId.value() + "Address1234567890abcdef",
+                "0x" + chainId.value() + "Address1234567890AbCdEf",
+                WalletTier.HOT, WalletPurpose.ON_RAMP,
+                "fireblocks", "vault-" + chainId.value(),
+                USDC);
+    }
+
+    private void stubChainWithBalance(ChainId chainId, BigDecimal amount, boolean sufficient) {
+        var wallet = createWallet(chainId);
+        given(walletRepository.findByChainIdAndPurpose(chainId, WalletPurpose.ON_RAMP))
+                .willReturn(List.of(wallet));
+        var balance = sufficient
+                ? aBalanceWith(amount.add(BigDecimal.TEN), BigDecimal.ZERO)
+                : aBalanceWith(BigDecimal.ONE, BigDecimal.ZERO);
+        given(walletBalanceRepository.findByWalletIdAndStablecoin(wallet.walletId(), USDC))
+                .willReturn(Optional.of(balance));
+    }
+
+    // ----------------------------------------------------------------
+    // Tests
+    // ----------------------------------------------------------------
+
+    @Test
+    void selectChain_baseWinsOnLowCost() {
+        // Base: fee=0.01 (cheapest for its finality); Solana fee=0.005 but speed dominates less with default weights
+        // Default weights: cost=0.4, speed=0.35, reliability=0.25
+        // Base: 0.4*(1/0.01) + 0.35*(1/12) + 0.25*1.0 = 40.0 + 0.0292 + 0.25 = 40.279
+        // Ethereum: 0.4*(1/2.50) + 0.35*(1/300) + 0.25*1.0 = 0.16 + 0.00117 + 0.25 = 0.411
+        // Solana: 0.4*(1/0.005) + 0.35*(1/5) + 0.25*1.0 = 80.0 + 0.07 + 0.25 = 80.32
+        // Actually Solana wins! Let me adjust fees to make Base win:
+        // Make Solana more expensive and Base cheapest with speed factoring in
+        var weights = ChainSelectionWeights.builder()
+                .costWeight(0.5)
+                .speedWeight(0.25)
+                .reliabilityWeight(0.25)
+                .build();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        stubAllChainsHealthy();
+        // Set fees so Base wins: Base cheap with decent speed
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_BASE, USDC)).willReturn(0.01);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_SOLANA, USDC)).willReturn(0.02);
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        var expected = ChainSelectionResult.builder()
+                .selectedChain(CHAIN_BASE)
+                .transferId(TRANSFER_ID)
+                .candidates(result.candidates())
+                .build();
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFields("candidates")
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void selectChain_solanaWinsOnSpeed() {
+        // Speed weight dominates
+        var weights = ChainSelectionWeights.builder()
+                .costWeight(0.05)
+                .speedWeight(0.9)
+                .reliabilityWeight(0.05)
+                .build();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        stubAllChainsHealthy();
+        stubAllChainsFees();
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        // Solana has 5s finality (fastest) → highest speed score
+        var expected = ChainSelectionResult.builder()
+                .selectedChain(CHAIN_SOLANA)
+                .transferId(TRANSFER_ID)
+                .candidates(result.candidates())
+                .build();
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFields("candidates")
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void selectChain_ethereumWinsForHighValue() {
+        // Only Ethereum has sufficient balance for a large transfer
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+        var highAmount = new BigDecimal("500000.00");
+
+        // Only Ethereum has sufficient balance
+        stubChainWithBalance(CHAIN_ETHEREUM, highAmount, true);
+        stubChainWithBalance(CHAIN_BASE, highAmount, false);
+        stubChainWithBalance(CHAIN_SOLANA, highAmount, false);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(1.0);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+
+        var result = sut.selectChain(aSelectionRequestWithAmount(highAmount));
+
+        var expected = ChainSelectionResult.builder()
+                .selectedChain(CHAIN_ETHEREUM)
+                .transferId(TRANSFER_ID)
+                .candidates(result.candidates())
+                .build();
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFields("candidates")
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void selectChain_unhealthyChainExcluded() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        // Base is unhealthy
+        given(chainHealthProvider.getHealthScore(CHAIN_BASE)).willReturn(0.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(1.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_SOLANA)).willReturn(1.0);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_SOLANA, USDC)).willReturn(0.005);
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        // Base should not be in candidates at all
+        assertThat(result.candidates().stream().map(c -> c.chainId().value()).toList())
+                .doesNotContain("base");
+    }
+
+    @Test
+    void selectChain_allChainsUnhealthy_throwsException() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        given(chainHealthProvider.getHealthScore(CHAIN_BASE)).willReturn(0.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(0.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_SOLANA)).willReturn(0.0);
+
+        assertThatThrownBy(() -> sut.selectChain(aSelectionRequest()))
+                .isInstanceOf(ChainUnavailableException.class)
+                .hasMessageContaining("No healthy chain");
+    }
+
+    @Test
+    void selectChain_preferredChainSelected() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        stubAllChainsHealthy();
+        stubAllChainsFees();
+
+        var result = sut.selectChain(aSelectionRequestWithPreferredChain("base"));
+
+        var expected = ChainSelectionResult.builder()
+                .selectedChain(CHAIN_BASE)
+                .transferId(TRANSFER_ID)
+                .candidates(result.candidates())
+                .build();
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFields("candidates")
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void selectChain_preferredChainUnhealthy_fallsBackToScoring() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        // Base is unhealthy but is preferred
+        given(chainHealthProvider.getHealthScore(CHAIN_BASE)).willReturn(0.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(1.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_SOLANA)).willReturn(1.0);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_SOLANA, USDC)).willReturn(0.005);
+
+        var result = sut.selectChain(aSelectionRequestWithPreferredChain("base"));
+
+        // Base is unhealthy, so it falls back to scoring. Solana should win.
+        assertThat(result.selectedChain()).isNotEqualTo(CHAIN_BASE);
+    }
+
+    @Test
+    void selectChain_insufficientBalance_chainExcluded() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        // Base has insufficient balance
+        stubChainWithBalance(CHAIN_BASE, AMOUNT, false);
+        stubChainWithBalance(CHAIN_ETHEREUM, AMOUNT, true);
+        stubChainWithBalance(CHAIN_SOLANA, AMOUNT, true);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(1.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_SOLANA)).willReturn(1.0);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_SOLANA, USDC)).willReturn(0.005);
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        assertThat(result.candidates().stream().map(c -> c.chainId().value()).toList())
+                .doesNotContain("base");
+    }
+
+    @Test
+    void selectChain_logsSelectionResult() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        stubAllChainsHealthy();
+        stubAllChainsFees();
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        then(chainSelectionLogRepository).should().save(TRANSFER_ID, result);
+    }
+
+    @Test
+    void selectChain_allCandidatesScored() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        stubAllChainsHealthy();
+        stubAllChainsFees();
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        // All 3 MVP chains should appear as candidates
+        assertThat(result.candidates()).hasSize(3);
+    }
+
+    @Test
+    void selectChain_singleHealthyChain_selectedByDefault() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        // Only Ethereum is healthy and has balance
+        stubChainWithBalance(CHAIN_BASE, AMOUNT, false);
+        stubChainWithBalance(CHAIN_ETHEREUM, AMOUNT, true);
+        stubChainWithBalance(CHAIN_SOLANA, AMOUNT, false);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(1.0);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        var expected = ChainSelectionResult.builder()
+                .selectedChain(CHAIN_ETHEREUM)
+                .transferId(TRANSFER_ID)
+                .candidates(result.candidates())
+                .build();
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFields("candidates")
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void selectChain_noWalletForChain_chainExcluded() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        // Base has no wallet at all
+        given(walletRepository.findByChainIdAndPurpose(CHAIN_BASE, WalletPurpose.ON_RAMP))
+                .willReturn(List.of());
+        stubChainWithBalance(CHAIN_ETHEREUM, AMOUNT, true);
+        stubChainWithBalance(CHAIN_SOLANA, AMOUNT, true);
+        given(chainHealthProvider.getHealthScore(CHAIN_ETHEREUM)).willReturn(1.0);
+        given(chainHealthProvider.getHealthScore(CHAIN_SOLANA)).willReturn(1.0);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_ETHEREUM, USDC)).willReturn(2.50);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_SOLANA, USDC)).willReturn(0.005);
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        assertThat(result.candidates().stream().map(c -> c.chainId().value()).toList())
+                .doesNotContain("base");
+    }
+
+    @Test
+    void selectChain_scoringFormula_correctCalculation() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        // Only Base is available to make the test deterministic
+        stubChainWithBalance(CHAIN_BASE, AMOUNT, true);
+        stubChainWithBalance(CHAIN_ETHEREUM, AMOUNT, false);
+        stubChainWithBalance(CHAIN_SOLANA, AMOUNT, false);
+        given(chainHealthProvider.getHealthScore(CHAIN_BASE)).willReturn(1.0);
+        given(chainFeeProvider.estimateFeeUsd(CHAIN_BASE, USDC)).willReturn(0.01);
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        // Expected score: 0.4*(1/0.01) + 0.35*(1/12) + 0.25*1.0
+        // = 0.4*100 + 0.35*0.08333 + 0.25
+        // = 40.0 + 0.02917 + 0.25 = 40.27917
+        double expectedScore = 0.4 * (1.0 / 0.01) + 0.35 * (1.0 / 12) + 0.25 * 1.0;
+
+        var expectedCandidate = ChainCandidate.builder()
+                .chainId(CHAIN_BASE)
+                .feeUsd(0.01)
+                .finalitySeconds(12)
+                .healthScore(1.0)
+                .score(expectedScore)
+                .selected(true)
+                .build();
+
+        assertThat(result.candidates()).hasSize(1);
+        assertThat(result.candidates().getFirst()).usingRecursiveComparison()
+                .withComparatorForType(Double::compare, Double.class)
+                .isEqualTo(expectedCandidate);
+    }
+
+    @Test
+    void selectChain_resultContainsSelectedFlag() {
+        var weights = ChainSelectionWeights.defaults();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        stubAllChainsHealthy();
+        stubAllChainsFees();
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        // Exactly one candidate should have selected=true
+        long selectedCount = result.candidates().stream().filter(ChainCandidate::selected).count();
+        assertThat(selectedCount).isEqualTo(1L);
+        // The selected candidate's chainId should match result.selectedChain()
+        var selectedCandidate = result.candidates().stream()
+                .filter(ChainCandidate::selected)
+                .findFirst()
+                .orElseThrow();
+        assertThat(selectedCandidate.chainId()).isEqualTo(result.selectedChain());
+    }
+
+    @Test
+    void selectChain_costWeightZero_speedDominates() {
+        // Zero cost weight, high speed weight → fastest chain wins
+        var weights = ChainSelectionWeights.builder()
+                .costWeight(0.0)
+                .speedWeight(0.75)
+                .reliabilityWeight(0.25)
+                .build();
+        var sut = engineWith(weights);
+
+        stubAllChainsWithSufficientBalance();
+        stubAllChainsHealthy();
+        stubAllChainsFees();
+
+        var result = sut.selectChain(aSelectionRequest());
+
+        // Solana has 5s finality (fastest) → highest speed score → should win
+        var expected = ChainSelectionResult.builder()
+                .selectedChain(CHAIN_SOLANA)
+                .transferId(TRANSFER_ID)
+                .candidates(result.candidates())
+                .build();
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFields("candidates")
+                .isEqualTo(expected);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/testFixtures/java/com/stablecoin/payments/custody/fixtures/ChainSelectionFixtures.java
+++ b/blockchain-custody/blockchain-custody/src/testFixtures/java/com/stablecoin/payments/custody/fixtures/ChainSelectionFixtures.java
@@ -1,0 +1,82 @@
+package com.stablecoin.payments.custody.fixtures;
+
+import com.stablecoin.payments.custody.domain.model.ChainConfig;
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.ChainSelectionWeights;
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+import com.stablecoin.payments.custody.domain.service.ChainSelectionEngine.ChainSelectionRequest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Test fixtures for chain selection engine tests.
+ */
+public final class ChainSelectionFixtures {
+
+    private ChainSelectionFixtures() {}
+
+    public static final UUID TRANSFER_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    public static final StablecoinTicker USDC = StablecoinTicker.of("USDC");
+    public static final BigDecimal AMOUNT = new BigDecimal("1000.00");
+
+    public static final ChainId CHAIN_BASE = new ChainId("base");
+    public static final ChainId CHAIN_ETHEREUM = new ChainId("ethereum");
+    public static final ChainId CHAIN_SOLANA = new ChainId("solana");
+
+    /**
+     * Default weights (cost=0.4, speed=0.35, reliability=0.25).
+     */
+    public static ChainSelectionWeights defaultWeights() {
+        return ChainSelectionWeights.defaults();
+    }
+
+    /**
+     * Base chain configuration: fast and cheap (L2).
+     */
+    public static ChainConfig baseConfig() {
+        return new ChainConfig(
+                CHAIN_BASE, 1, 12, "ETH",
+                List.of("https://base-rpc.example.com"), "https://basescan.org");
+    }
+
+    /**
+     * Ethereum chain configuration: slow and expensive (L1).
+     */
+    public static ChainConfig ethereumConfig() {
+        return new ChainConfig(
+                CHAIN_ETHEREUM, 32, 300, "ETH",
+                List.of("https://eth-rpc.example.com"), "https://etherscan.io");
+    }
+
+    /**
+     * Solana chain configuration: fastest and cheapest.
+     */
+    public static ChainConfig solanaConfig() {
+        return new ChainConfig(
+                CHAIN_SOLANA, 1, 5, "SOL",
+                List.of("https://sol-rpc.example.com"), "https://explorer.solana.com");
+    }
+
+    /**
+     * A selection request with default values (no preferred chain).
+     */
+    public static ChainSelectionRequest aSelectionRequest() {
+        return new ChainSelectionRequest(TRANSFER_ID, USDC, AMOUNT, null);
+    }
+
+    /**
+     * A selection request with a preferred chain.
+     */
+    public static ChainSelectionRequest aSelectionRequestWithPreferredChain(String preferredChain) {
+        return new ChainSelectionRequest(TRANSFER_ID, USDC, AMOUNT, preferredChain);
+    }
+
+    /**
+     * A selection request with a specific amount.
+     */
+    public static ChainSelectionRequest aSelectionRequestWithAmount(BigDecimal amount) {
+        return new ChainSelectionRequest(TRANSFER_ID, USDC, amount, null);
+    }
+}


### PR DESCRIPTION
## Summary
- `ChainSelectionEngine` domain service — weighted scoring model: `score = costWeight*(1/fee) + speedWeight*(1/finality) + reliabilityWeight*healthScore`
- `ChainSelectionWeights` immutable record with configurable weights via `@ConfigurationProperties(prefix = "app.custody.chain-selection")`
- MVP candidates: Base (12s, $0.01), Ethereum (300s, $2.50), Solana (5s, $0.005)
- Filters by: wallet liquidity (`hasSufficientBalance`), chain health (`ChainHealthProvider`), stablecoin availability
- Preferred chain override (if healthy), else argmax(score)
- New domain ports: `ChainHealthProvider`, `ChainFeeProvider`, `ChainSelectionLogRepository`
- `ChainSelectionLogPersistenceAdapter` — JdbcTemplate insert with Jackson 3 JSONB serialization
- Fallback providers in `FallbackAdaptersConfig` (all healthy, static fees)
- 15 unit tests covering all scoring scenarios

## Test plan
- [x] 15 new unit tests all pass (cost wins, speed wins, balance filtering, health exclusion, preferred chain, scoring formula, etc.)
- [x] All 264 S4 unit tests green (249 existing + 15 new)
- [x] Spotless formatting clean

Closes STA-136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chain selection engine with configurable weighting (cost, speed, reliability), preferred-chain support and automatic fallback to best alternative.
  * Persisted chain selection decisions with detailed evaluation metrics for auditing and troubleshooting.
  * Added development/test fallback providers for chain health and fee estimates.

* **Tests**
  * Added comprehensive test suite and fixtures covering selection logic, preferences, exclusions, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->