### PR TITLE
feat(s4): Fireblocks custody adapter — RS256 JWT auth (STA-138)

### DIFF
--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
@@ -4,7 +4,11 @@ import com.stablecoin.payments.custody.domain.model.ChainId;
 import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
 import com.stablecoin.payments.custody.domain.port.ChainFeeProvider;
 import com.stablecoin.payments.custody.domain.port.ChainHealthProvider;
+import com.stablecoin.payments.custody.domain.port.CustodyEngine;
 import com.stablecoin.payments.custody.domain.port.NonceRepository;
+import com.stablecoin.payments.custody.domain.port.SignRequest;
+import com.stablecoin.payments.custody.domain.port.SignResult;
+import com.stablecoin.payments.custody.domain.port.TransactionStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -62,6 +66,36 @@ public class FallbackAdaptersConfig {
     public NonceRepository fallbackNonceRepository() {
         log.info("Using fallback NonceRepository (in-memory, no advisory locks)");
         return new InMemoryNonceRepository();
+    }
+
+    /**
+     * Fallback custody engine for dev/test environments without Fireblocks.
+     * Returns deterministic dev results.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public CustodyEngine fallbackCustodyEngine() {
+        log.info("Using fallback CustodyEngine (dev mode)");
+        return new CustodyEngine() {
+            @Override
+            public SignResult signAndSubmit(SignRequest request) {
+                log.warn("[FALLBACK-CUSTODY] Dev custody for transferId={}", request.transferId());
+                return new SignResult(
+                        "0x" + UUID.randomUUID().toString().replace("-", ""),
+                        "dev-tx-" + UUID.randomUUID()
+                );
+            }
+
+            @Override
+            public TransactionStatus getTransactionStatus(String txId) {
+                log.warn("[FALLBACK-CUSTODY] Dev status for txId={}", txId);
+                return new TransactionStatus(
+                        "COMPLETED",
+                        "0x" + UUID.randomUUID().toString().replace("-", ""),
+                        10
+                );
+            }
+        };
     }
 
     static class InMemoryNonceRepository implements NonceRepository {

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCreateTransactionRequest.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCreateTransactionRequest.java
@@ -1,0 +1,17 @@
+package com.stablecoin.payments.custody.infrastructure.provider.fireblocks;
+
+record FireblocksCreateTransactionRequest(
+        String assetId,
+        TransferPeerPath source,
+        DestinationTransferPeerPath destination,
+        String amount,
+        String note,
+        String externalTxId
+) {
+
+    record TransferPeerPath(String type, String id) {}
+
+    record DestinationTransferPeerPath(String type, OneTimeAddress oneTimeAddress) {}
+
+    record OneTimeAddress(String address) {}
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCreateTransactionResponse.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCreateTransactionResponse.java
@@ -1,0 +1,3 @@
+package com.stablecoin.payments.custody.infrastructure.provider.fireblocks;
+
+record FireblocksCreateTransactionResponse(String id, String status) {}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCustodyAdapter.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCustodyAdapter.java
@@ -1,0 +1,229 @@
+package com.stablecoin.payments.custody.infrastructure.provider.fireblocks;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+import com.stablecoin.payments.custody.domain.port.CustodyEngine;
+import com.stablecoin.payments.custody.domain.port.SignRequest;
+import com.stablecoin.payments.custody.domain.port.SignResult;
+import com.stablecoin.payments.custody.domain.port.TransactionStatus;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.Signature;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "app.custody.provider", havingValue = "fireblocks")
+@EnableConfigurationProperties(FireblocksProperties.class)
+public class FireblocksCustodyAdapter implements CustodyEngine {
+
+    private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+    private static final Map<String, String> ASSET_ID_MAP = Map.of(
+            "base:USDC", "USDC_BASE",
+            "ethereum:USDC", "USDC",
+            "solana:USDC", "USDC_SOL"
+    );
+
+    private final RestClient restClient;
+    private final FireblocksProperties properties;
+    private final RSAPrivateKey privateKey;
+
+    public FireblocksCustodyAdapter(FireblocksProperties properties) {
+        this.properties = properties;
+
+        var httpClient = HttpClient.newBuilder()
+                .version(Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
+                .build();
+
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .requestFactory(requestFactory)
+                .build();
+
+        this.privateKey = parsePrivateKey(properties.apiSecret());
+    }
+
+    @Override
+    @CircuitBreaker(name = "fireblocks", fallbackMethod = "signAndSubmitFallback")
+    public SignResult signAndSubmit(SignRequest request) {
+        log.info("[FIREBLOCKS] Signing and submitting transfer transferId={} chain={} to={}",
+                request.transferId(), request.chainId().value(), request.toAddress());
+
+        var assetId = resolveAssetId(request.chainId(), request.stablecoin());
+        var vaultId = request.vaultAccountId() != null
+                ? request.vaultAccountId()
+                : properties.vaultAccountId();
+
+        var body = new FireblocksCreateTransactionRequest(
+                assetId,
+                new FireblocksCreateTransactionRequest.TransferPeerPath("VAULT_ACCOUNT", vaultId),
+                new FireblocksCreateTransactionRequest.DestinationTransferPeerPath(
+                        "ONE_TIME_ADDRESS",
+                        new FireblocksCreateTransactionRequest.OneTimeAddress(request.toAddress())
+                ),
+                request.amount().toPlainString(),
+                "transfer_" + request.transferId(),
+                request.transferId().toString()
+        );
+
+        var uri = "/v1/transactions";
+        var jwt = buildJwt(uri, body);
+
+        var response = restClient.post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwt)
+                .header("X-API-Key", properties.apiKey())
+                .body(body)
+                .retrieve()
+                .body(FireblocksCreateTransactionResponse.class);
+
+        log.info("[FIREBLOCKS] Transaction created transferId={} custodyTxId={} status={}",
+                request.transferId(), response.id(), response.status());
+
+        return new SignResult(null, response.id());
+    }
+
+    @Override
+    @CircuitBreaker(name = "fireblocks", fallbackMethod = "getTransactionStatusFallback")
+    public TransactionStatus getTransactionStatus(String txId) {
+        log.info("[FIREBLOCKS] Getting transaction status txId={}", txId);
+
+        var uri = "/v1/transactions/" + txId;
+        var jwt = buildJwt(uri, null);
+
+        var response = restClient.get()
+                .uri(uri)
+                .header("Authorization", "Bearer " + jwt)
+                .header("X-API-Key", properties.apiKey())
+                .retrieve()
+                .body(FireblocksTransactionStatusResponse.class);
+
+        log.info("[FIREBLOCKS] Transaction status txId={} status={} confirmations={}",
+                txId, response.status(), response.numOfConfirmations());
+
+        return new TransactionStatus(response.status(), response.txHash(), response.numOfConfirmations());
+    }
+
+    @SuppressWarnings("unused")
+    private SignResult signAndSubmitFallback(SignRequest request, Exception ex) {
+        log.error("[FIREBLOCKS] Circuit breaker open — signAndSubmit failed transferId={}",
+                request.transferId(), ex);
+        throw new IllegalStateException("Fireblocks custody unavailable", ex);
+    }
+
+    @SuppressWarnings("unused")
+    private TransactionStatus getTransactionStatusFallback(String txId, Exception ex) {
+        log.error("[FIREBLOCKS] Circuit breaker open — getTransactionStatus failed txId={}", txId, ex);
+        throw new IllegalStateException("Fireblocks custody unavailable", ex);
+    }
+
+    String resolveAssetId(ChainId chainId, StablecoinTicker stablecoin) {
+        var key = chainId.value() + ":" + stablecoin.ticker();
+        var assetId = ASSET_ID_MAP.get(key);
+        if (assetId == null) {
+            throw new IllegalArgumentException(
+                    "Unsupported chain/stablecoin combination: %s".formatted(key));
+        }
+        return assetId;
+    }
+
+    private RSAPrivateKey parsePrivateKey(String pem) {
+        if (pem == null || pem.isBlank()) {
+            log.warn("[FIREBLOCKS] No API secret configured — JWT signing will fail at runtime");
+            return null;
+        }
+        try {
+            var stripped = pem
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+            var decoded = Base64.getDecoder().decode(stripped);
+            var keySpec = new PKCS8EncodedKeySpec(decoded);
+            var keyFactory = KeyFactory.getInstance("RSA");
+            return (RSAPrivateKey) keyFactory.generatePrivate(keySpec);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to parse Fireblocks RSA private key", ex);
+        }
+    }
+
+    private String buildJwt(String uri, Object body) {
+        try {
+            var now = Instant.now();
+            var headerJson = """
+                    {"alg":"RS256","typ":"JWT"}""";
+            var bodyHash = sha256Hex(body != null ? serializeBody(body) : "");
+
+            var payloadJson = """
+                    {"sub":"%s","nonce":"%s","iat":%d,"exp":%d,"uri":"%s","bodyHash":"%s"}"""
+                    .formatted(
+                            properties.apiKey(),
+                            UUID.randomUUID().toString(),
+                            now.getEpochSecond(),
+                            now.getEpochSecond() + 30,
+                            uri,
+                            bodyHash
+                    );
+
+            var encoder = Base64.getUrlEncoder().withoutPadding();
+            var headerB64 = encoder.encodeToString(headerJson.getBytes(StandardCharsets.UTF_8));
+            var payloadB64 = encoder.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+
+            var signingInput = headerB64 + "." + payloadB64;
+            var signature = Signature.getInstance("SHA256withRSA");
+            signature.initSign(privateKey);
+            signature.update(signingInput.getBytes(StandardCharsets.UTF_8));
+            var signatureB64 = encoder.encodeToString(signature.sign());
+
+            return signingInput + "." + signatureB64;
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to build Fireblocks JWT", ex);
+        }
+    }
+
+    private String serializeBody(Object body) {
+        try {
+            return JSON_MAPPER.writeValueAsString(body);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to serialize request body", ex);
+        }
+    }
+
+    private String sha256Hex(String input) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            var hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            var hexString = new StringBuilder();
+            for (byte b : hash) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to compute SHA-256 hash", ex);
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksProperties.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksProperties.java
@@ -1,0 +1,31 @@
+package com.stablecoin.payments.custody.infrastructure.provider.fireblocks;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.custody.fireblocks")
+public record FireblocksProperties(
+        String baseUrl,
+        String apiKey,
+        String apiSecret,
+        String vaultAccountId,
+        int timeoutSeconds
+) {
+
+    public FireblocksProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            baseUrl = "https://api.fireblocks.io";
+        }
+        if (apiKey == null || apiKey.isBlank()) {
+            apiKey = "fireblocks-api-key";
+        }
+        if (apiSecret == null || apiSecret.isBlank()) {
+            apiSecret = "";
+        }
+        if (vaultAccountId == null || vaultAccountId.isBlank()) {
+            vaultAccountId = "0";
+        }
+        if (timeoutSeconds <= 0) {
+            timeoutSeconds = 30;
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksTransactionStatusResponse.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksTransactionStatusResponse.java
@@ -1,0 +1,8 @@
+package com.stablecoin.payments.custody.infrastructure.provider.fireblocks;
+
+record FireblocksTransactionStatusResponse(
+        String id,
+        String status,
+        String txHash,
+        Integer numOfConfirmations
+) {}

--- a/blockchain-custody/blockchain-custody/src/main/resources/application.yml
+++ b/blockchain-custody/blockchain-custody/src/main/resources/application.yml
@@ -104,7 +104,13 @@ app:
   security:
     enabled: false
   custody:
-    provider: dev
+    provider: dev  # 'fireblocks' in production
+    fireblocks:
+      base-url: ${FIREBLOCKS_BASE_URL:https://sandbox-api.fireblocks.io}
+      api-key: ${FIREBLOCKS_API_KEY:fireblocks-dev-key}
+      api-secret: ${FIREBLOCKS_API_SECRET:}
+      vault-account-id: ${FIREBLOCKS_VAULT_ACCOUNT_ID:0}
+      timeout-seconds: 30
   chains:
     base:
       min-confirmations: 1

--- a/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCustodyAdapterTest.java
+++ b/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/infrastructure/provider/fireblocks/FireblocksCustodyAdapterTest.java
@@ -1,0 +1,272 @@
+package com.stablecoin.payments.custody.infrastructure.provider.fireblocks;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.stablecoin.payments.custody.domain.port.SignResult;
+import com.stablecoin.payments.custody.domain.port.TransactionStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.stablecoin.payments.custody.fixtures.CustodyEngineFixtures.TRANSFER_ID;
+import static com.stablecoin.payments.custody.fixtures.CustodyEngineFixtures.VAULT_ACCOUNT_ID;
+import static com.stablecoin.payments.custody.fixtures.CustodyEngineFixtures.aSignRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FireblocksCustodyAdapterTest {
+
+    private static WireMockServer wireMock;
+    private static String testPrivateKeyPem;
+
+    private FireblocksCustodyAdapter adapter;
+
+    private static final String API_KEY = "fb-test-api-key";
+
+    @BeforeAll
+    static void startWireMock() throws Exception {
+        wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMock.start();
+
+        var keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        var keyPair = keyGen.generateKeyPair();
+        var privateKeyBytes = keyPair.getPrivate().getEncoded();
+        var base64Key = Base64.getEncoder().encodeToString(privateKeyBytes);
+        testPrivateKeyPem = "-----BEGIN PRIVATE KEY-----\n" + base64Key + "\n-----END PRIVATE KEY-----";
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMock.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        wireMock.resetAll();
+        var properties = new FireblocksProperties(
+                wireMock.baseUrl(),
+                API_KEY,
+                testPrivateKeyPem,
+                VAULT_ACCOUNT_ID,
+                10
+        );
+        adapter = new FireblocksCustodyAdapter(properties);
+    }
+
+    @Nested
+    @DisplayName("signAndSubmit")
+    class SignAndSubmit {
+
+        @Test
+        @DisplayName("should return SignResult on successful transaction creation")
+        void shouldReturnSignResultOnSuccess() {
+            // given
+            wireMock.stubFor(post(urlEqualTo("/v1/transactions"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "fb-tx-001",
+                                      "status": "SUBMITTED"
+                                    }
+                                    """)));
+
+            // when
+            var result = adapter.signAndSubmit(aSignRequest());
+
+            // then
+            var expected = new SignResult(null, "fb-tx-001");
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should send correct JSON body with assetId, source, destination, and amount")
+        void shouldSendCorrectRequestBodyToFireblocks() {
+            // given
+            wireMock.stubFor(post(urlEqualTo("/v1/transactions"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "fb-tx-verify",
+                                      "status": "SUBMITTED"
+                                    }
+                                    """)));
+
+            // when
+            adapter.signAndSubmit(aSignRequest());
+
+            // then
+            wireMock.verify(postRequestedFor(urlEqualTo("/v1/transactions"))
+                    .withRequestBody(containing("\"assetId\":\"USDC_BASE\""))
+                    .withRequestBody(containing("\"type\":\"VAULT_ACCOUNT\""))
+                    .withRequestBody(containing("\"id\":\"" + VAULT_ACCOUNT_ID + "\""))
+                    .withRequestBody(containing("\"address\":\"0xRecipientAddress\""))
+                    .withRequestBody(containing("\"amount\":\"1500.50\""))
+                    .withRequestBody(containing("\"externalTxId\":\"" + TRANSFER_ID + "\""))
+                    .withRequestBody(containing("\"note\":\"transfer_" + TRANSFER_ID + "\"")));
+        }
+
+        @Test
+        @DisplayName("should include Authorization Bearer and X-API-Key headers")
+        void shouldIncludeAuthHeadersOnSubmit() {
+            // given
+            wireMock.stubFor(post(urlEqualTo("/v1/transactions"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "fb-tx-auth",
+                                      "status": "SUBMITTED"
+                                    }
+                                    """)));
+
+            // when
+            adapter.signAndSubmit(aSignRequest());
+
+            // then
+            wireMock.verify(postRequestedFor(urlEqualTo("/v1/transactions"))
+                    .withHeader("Authorization", matching("Bearer .+\\..+\\..+"))
+                    .withHeader("X-API-Key", matching(API_KEY)));
+        }
+
+        @Test
+        @DisplayName("should throw when Fireblocks returns 400 error")
+        void shouldThrowOnApiError() {
+            // given
+            wireMock.stubFor(post(urlEqualTo("/v1/transactions"))
+                    .willReturn(aResponse()
+                            .withStatus(400)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "message": "Invalid asset ID",
+                                      "code": 1000
+                                    }
+                                    """)));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.signAndSubmit(aSignRequest()))
+                    .isInstanceOf(Exception.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTransactionStatus")
+    class GetTransactionStatus {
+
+        @Test
+        @DisplayName("should return TransactionStatus with COMPLETED status")
+        void shouldReturnCompletedTransactionStatus() {
+            // given
+            wireMock.stubFor(get(urlEqualTo("/v1/transactions/fb-tx-001"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "fb-tx-001",
+                                      "status": "COMPLETED",
+                                      "txHash": "0xabc123def456",
+                                      "numOfConfirmations": 12
+                                    }
+                                    """)));
+
+            // when
+            var result = adapter.getTransactionStatus("fb-tx-001");
+
+            // then
+            var expected = new TransactionStatus("COMPLETED", "0xabc123def456", 12);
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should return TransactionStatus with PENDING_SIGNATURE status")
+        void shouldReturnPendingTransactionStatus() {
+            // given
+            wireMock.stubFor(get(urlEqualTo("/v1/transactions/fb-tx-002"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "fb-tx-002",
+                                      "status": "PENDING_SIGNATURE",
+                                      "txHash": null,
+                                      "numOfConfirmations": 0
+                                    }
+                                    """)));
+
+            // when
+            var result = adapter.getTransactionStatus("fb-tx-002");
+
+            // then
+            var expected = new TransactionStatus("PENDING_SIGNATURE", null, 0);
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should throw when transaction not found")
+        void shouldThrowWhenTransactionNotFound() {
+            // given
+            wireMock.stubFor(get(urlEqualTo("/v1/transactions/fb-tx-unknown"))
+                    .willReturn(aResponse()
+                            .withStatus(404)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "message": "Transaction not found",
+                                      "code": 1001
+                                    }
+                                    """)));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getTransactionStatus("fb-tx-unknown"))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("should include Authorization Bearer and X-API-Key headers on GET")
+        void shouldIncludeAuthHeadersOnGetStatus() {
+            // given
+            wireMock.stubFor(get(urlEqualTo("/v1/transactions/fb-tx-auth"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                    {
+                                      "id": "fb-tx-auth",
+                                      "status": "BROADCASTING",
+                                      "txHash": "0xdef789",
+                                      "numOfConfirmations": 0
+                                    }
+                                    """)));
+
+            // when
+            adapter.getTransactionStatus("fb-tx-auth");
+
+            // then
+            wireMock.verify(getRequestedFor(urlEqualTo("/v1/transactions/fb-tx-auth"))
+                    .withHeader("Authorization", matching("Bearer .+\\..+\\..+"))
+                    .withHeader("X-API-Key", matching(API_KEY)));
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/testFixtures/java/com/stablecoin/payments/custody/fixtures/CustodyEngineFixtures.java
+++ b/blockchain-custody/blockchain-custody/src/testFixtures/java/com/stablecoin/payments/custody/fixtures/CustodyEngineFixtures.java
@@ -1,0 +1,32 @@
+package com.stablecoin.payments.custody.fixtures;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
+import com.stablecoin.payments.custody.domain.port.SignRequest;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public final class CustodyEngineFixtures {
+
+    private CustodyEngineFixtures() {}
+
+    public static final UUID TRANSFER_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    public static final String VAULT_ACCOUNT_ID = "42";
+
+    /**
+     * A sign request for Base USDC transfer.
+     */
+    public static SignRequest aSignRequest() {
+        return new SignRequest(
+                TRANSFER_ID,
+                new ChainId("base"),
+                "0xSenderAddress",
+                "0xRecipientAddress",
+                new BigDecimal("1500.50"),
+                StablecoinTicker.of("USDC"),
+                42L,
+                VAULT_ACCOUNT_ID
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `FireblocksCustodyAdapter` — production `CustodyEngine` port implementation
- RS256 JWT authentication using pure `java.security` APIs (SHA256withRSA, PKCS8)
- `signAndSubmit()` → POST `/v1/transactions` with asset ID mapping (Base/Ethereum/Solana USDC)
- `getTransactionStatus()` → GET `/v1/transactions/{txId}` with status polling
- `@CircuitBreaker(name = "fireblocks")` on both methods with fallback re-throw
- `@ConditionalOnProperty(app.custody.provider=fireblocks)` activation
- Fallback `CustodyEngine` in `FallbackAdaptersConfig` for dev/test
- 8 WireMock tests covering success, error, auth headers, request body verification

## Files Changed (9)
- `FireblocksProperties.java` — `@ConfigurationProperties` with defaults
- `FireblocksCustodyAdapter.java` — RS256 JWT + RestClient + HTTP/1.1
- 3 package-private ACL DTOs (request, response, status response)
- `FallbackAdaptersConfig.java` — added `fallbackCustodyEngine()`
- `application.yml` — Fireblocks config block
- `FireblocksCustodyAdapterTest.java` — 8 WireMock tests
- `CustodyEngineFixtures.java` — test fixtures

## Test plan
- [x] All 8 new Fireblocks adapter WireMock tests pass
- [x] All existing tests (architecture, domain, nonce manager, chain selection) still green
- [x] Spotless formatting verified
- [ ] CI pipeline green

Closes STA-138

🤖 Generated with [Claude Code](https://claude.com/claude-code)