### PR TITLE
feat(s4): EVM RPC adapter — JSON-RPC for Base + Ethereum (STA-139)

### DIFF
--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/config/FallbackAdaptersConfig.java
@@ -4,16 +4,19 @@ import com.stablecoin.payments.custody.domain.model.ChainId;
 import com.stablecoin.payments.custody.domain.model.StablecoinTicker;
 import com.stablecoin.payments.custody.domain.port.ChainFeeProvider;
 import com.stablecoin.payments.custody.domain.port.ChainHealthProvider;
+import com.stablecoin.payments.custody.domain.port.ChainRpcProvider;
 import com.stablecoin.payments.custody.domain.port.CustodyEngine;
 import com.stablecoin.payments.custody.domain.port.NonceRepository;
 import com.stablecoin.payments.custody.domain.port.SignRequest;
 import com.stablecoin.payments.custody.domain.port.SignResult;
+import com.stablecoin.payments.custody.domain.port.TransactionReceipt;
 import com.stablecoin.payments.custody.domain.port.TransactionStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -94,6 +97,37 @@ public class FallbackAdaptersConfig {
                         "0x" + UUID.randomUUID().toString().replace("-", ""),
                         10
                 );
+            }
+        };
+    }
+
+    /**
+     * Fallback chain RPC provider for dev/test environments without EVM RPC nodes.
+     * Returns deterministic mock data.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public ChainRpcProvider fallbackChainRpcProvider() {
+        log.info("Using fallback ChainRpcProvider (returns mock receipts)");
+        return new ChainRpcProvider() {
+            @Override
+            public TransactionReceipt getTransactionReceipt(ChainId chainId, String txHash) {
+                log.warn("[FALLBACK-RPC] Dev receipt for txHash={}", txHash);
+                return new TransactionReceipt(
+                        txHash, 100L, true,
+                        BigDecimal.valueOf(21000), BigDecimal.valueOf(20), 10);
+            }
+
+            @Override
+            public long getLatestBlockNumber(ChainId chainId) {
+                log.warn("[FALLBACK-RPC] Dev block number for chain={}", chainId.value());
+                return 1000L;
+            }
+
+            @Override
+            public BigDecimal getTokenBalance(ChainId chainId, String address, String tokenContract) {
+                log.warn("[FALLBACK-RPC] Dev balance for address={}", address);
+                return BigDecimal.valueOf(500000);
             }
         };
     }

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmChainProperties.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmChainProperties.java
@@ -1,0 +1,36 @@
+package com.stablecoin.payments.custody.infrastructure.provider.evm;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "app.custody.evm")
+public record EvmChainProperties(
+        boolean enabled,
+        Map<String, ChainRpcConfig> chains
+) {
+
+    public EvmChainProperties {
+        if (chains == null) {
+            chains = Map.of();
+        }
+    }
+
+    public record ChainRpcConfig(
+            String rpcUrl,
+            long chainId,
+            String usdcContractAddress,
+            int connectTimeoutMs,
+            int readTimeoutMs
+    ) {
+
+        public ChainRpcConfig {
+            if (connectTimeoutMs <= 0) {
+                connectTimeoutMs = 5000;
+            }
+            if (readTimeoutMs <= 0) {
+                readTimeoutMs = 10000;
+            }
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmRpcAdapter.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmRpcAdapter.java
@@ -1,0 +1,211 @@
+package com.stablecoin.payments.custody.infrastructure.provider.evm;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.port.ChainRpcProvider;
+import com.stablecoin.payments.custody.domain.port.TransactionReceipt;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "app.custody.evm.enabled", havingValue = "true")
+@EnableConfigurationProperties(EvmChainProperties.class)
+public class EvmRpcAdapter implements ChainRpcProvider {
+
+    private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+    private static final int USDC_DECIMALS = 6;
+    private static final String BALANCE_OF_SELECTOR = "0x70a08231";
+
+    private final Map<String, RestClient> restClients;
+    private final EvmChainProperties properties;
+
+    public EvmRpcAdapter(EvmChainProperties properties) {
+        this.properties = properties;
+        this.restClients = new ConcurrentHashMap<>();
+
+        properties.chains().forEach((chainName, config) -> {
+            var httpClient = HttpClient.newBuilder()
+                    .version(Version.HTTP_1_1)
+                    .connectTimeout(Duration.ofMillis(config.connectTimeoutMs()))
+                    .build();
+
+            var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+            requestFactory.setReadTimeout(Duration.ofMillis(config.readTimeoutMs()));
+
+            var client = RestClient.builder()
+                    .baseUrl(config.rpcUrl())
+                    .requestFactory(requestFactory)
+                    .build();
+
+            restClients.put(chainName, client);
+            log.info("[EVM-RPC] Configured RestClient for chain={} rpcUrl={} chainId={}",
+                    chainName, config.rpcUrl(), config.chainId());
+        });
+    }
+
+    @Override
+    @CircuitBreaker(name = "evmRpc", fallbackMethod = "getTransactionReceiptFallback")
+    public TransactionReceipt getTransactionReceipt(ChainId chainId, String txHash) {
+        log.info("[EVM-RPC] Getting transaction receipt chain={} txHash={}", chainId.value(), txHash);
+
+        var receiptResult = callJsonRpc(chainId, "eth_getTransactionReceipt", txHash);
+        if (receiptResult == null || receiptResult.isNull()) {
+            log.info("[EVM-RPC] Transaction receipt not found (pending) chain={} txHash={}",
+                    chainId.value(), txHash);
+            return null;
+        }
+
+        var blockNumber = hexToLong(receiptResult.get("blockNumber").asText());
+        var status = receiptResult.get("status").asText();
+        var gasUsed = new BigDecimal(hexToBigInteger(receiptResult.get("gasUsed").asText()));
+        var effectiveGasPrice = new BigDecimal(hexToBigInteger(receiptResult.get("effectiveGasPrice").asText()));
+        var success = "0x1".equals(status);
+
+        var latestBlock = getLatestBlockNumber(chainId);
+        var confirmations = (int) (latestBlock - blockNumber);
+
+        log.info("[EVM-RPC] Receipt parsed chain={} txHash={} block={} success={} confirmations={}",
+                chainId.value(), txHash, blockNumber, success, confirmations);
+
+        return new TransactionReceipt(txHash, blockNumber, success, gasUsed, effectiveGasPrice, confirmations);
+    }
+
+    @Override
+    @CircuitBreaker(name = "evmRpc", fallbackMethod = "getLatestBlockNumberFallback")
+    public long getLatestBlockNumber(ChainId chainId) {
+        log.info("[EVM-RPC] Getting latest block number chain={}", chainId.value());
+
+        var result = callJsonRpc(chainId, "eth_blockNumber");
+        var blockNumber = hexToLong(result.asText());
+
+        log.info("[EVM-RPC] Latest block chain={} blockNumber={}", chainId.value(), blockNumber);
+        return blockNumber;
+    }
+
+    @Override
+    @CircuitBreaker(name = "evmRpc", fallbackMethod = "getTokenBalanceFallback")
+    public BigDecimal getTokenBalance(ChainId chainId, String address, String tokenContract) {
+        log.info("[EVM-RPC] Getting token balance chain={} address={} contract={}",
+                chainId.value(), address, tokenContract);
+
+        var callData = encodeBalanceOfCall(address);
+        var callParam = Map.of("to", tokenContract, "data", callData);
+        var result = callJsonRpc(chainId, "eth_call", callParam, "latest");
+
+        var rawBalance = hexToBigInteger(result.asText());
+        var balance = new BigDecimal(rawBalance).divide(
+                BigDecimal.TEN.pow(USDC_DECIMALS), USDC_DECIMALS, RoundingMode.HALF_UP);
+
+        log.info("[EVM-RPC] Token balance chain={} address={} balance={}",
+                chainId.value(), address, balance);
+        return balance;
+    }
+
+    JsonNode callJsonRpc(ChainId chainId, String method, Object... params) {
+        var client = restClients.get(chainId.value());
+        if (client == null) {
+            throw new IllegalArgumentException(
+                    "No RPC client configured for chain: %s".formatted(chainId.value()));
+        }
+
+        var request = new JsonRpcRequest(method, params);
+
+        var response = client.post()
+                .uri("")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(String.class);
+
+        try {
+            var responseNode = JSON_MAPPER.readTree(response);
+
+            if (responseNode.has("error") && !responseNode.get("error").isNull()) {
+                var error = responseNode.get("error");
+                var code = error.has("code") ? error.get("code").asInt() : -1;
+                var message = error.has("message") ? error.get("message").asText() : "Unknown RPC error";
+                throw new EvmRpcException(
+                        "JSON-RPC error on %s: code=%d message=%s".formatted(method, code, message));
+            }
+
+            return responseNode.get("result");
+        } catch (EvmRpcException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new EvmRpcException("Failed to parse JSON-RPC response for %s".formatted(method), ex);
+        }
+    }
+
+    static long hexToLong(String hex) {
+        if (hex == null || hex.isBlank()) {
+            throw new EvmRpcException("Cannot convert null/blank hex string to long");
+        }
+        var stripped = hex.startsWith("0x") ? hex.substring(2) : hex;
+        return Long.parseLong(stripped, 16);
+    }
+
+    static BigInteger hexToBigInteger(String hex) {
+        if (hex == null || hex.isBlank()) {
+            throw new EvmRpcException("Cannot convert null/blank hex string to BigInteger");
+        }
+        var stripped = hex.startsWith("0x") ? hex.substring(2) : hex;
+        return new BigInteger(stripped, 16);
+    }
+
+    static String encodeBalanceOfCall(String address) {
+        var cleanAddress = address.startsWith("0x") ? address.substring(2) : address;
+        var paddedAddress = "0".repeat(64 - cleanAddress.length()) + cleanAddress.toLowerCase();
+        return BALANCE_OF_SELECTOR + paddedAddress;
+    }
+
+    @SuppressWarnings("unused")
+    private TransactionReceipt getTransactionReceiptFallback(ChainId chainId, String txHash, Exception ex) {
+        log.error("[EVM-RPC] Circuit breaker open — getTransactionReceipt failed chain={} txHash={}",
+                chainId.value(), txHash, ex);
+        throw new IllegalStateException("EVM RPC unavailable for getTransactionReceipt", ex);
+    }
+
+    @SuppressWarnings("unused")
+    private long getLatestBlockNumberFallback(ChainId chainId, Exception ex) {
+        log.error("[EVM-RPC] Circuit breaker open — getLatestBlockNumber failed chain={}",
+                chainId.value(), ex);
+        throw new IllegalStateException("EVM RPC unavailable for getLatestBlockNumber", ex);
+    }
+
+    @SuppressWarnings("unused")
+    private BigDecimal getTokenBalanceFallback(ChainId chainId, String address, String tokenContract,
+                                               Exception ex) {
+        log.error("[EVM-RPC] Circuit breaker open — getTokenBalance failed chain={} address={}",
+                chainId.value(), address, ex);
+        throw new IllegalStateException("EVM RPC unavailable for getTokenBalance", ex);
+    }
+
+    record JsonRpcRequest(String jsonrpc, String method, Object[] params, int id) {
+
+        JsonRpcRequest(String method, Object... params) {
+            this("2.0", method, params, 1);
+        }
+    }
+
+    record JsonRpcResponse(String jsonrpc, int id, JsonNode result, JsonRpcError error) {
+
+        record JsonRpcError(int code, String message) {}
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmRpcException.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmRpcException.java
@@ -1,0 +1,12 @@
+package com.stablecoin.payments.custody.infrastructure.provider.evm;
+
+public class EvmRpcException extends RuntimeException {
+
+    public EvmRpcException(String message) {
+        super(message);
+    }
+
+    public EvmRpcException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/resources/application.yml
+++ b/blockchain-custody/blockchain-custody/src/main/resources/application.yml
@@ -111,6 +111,21 @@ app:
       api-secret: ${FIREBLOCKS_API_SECRET:}
       vault-account-id: ${FIREBLOCKS_VAULT_ACCOUNT_ID:0}
       timeout-seconds: 30
+    evm:
+      enabled: false  # disabled by default for dev/test — enable in production
+      chains:
+        base:
+          rpc-url: ${BASE_RPC_URL:https://base-sepolia.g.alchemy.com/v2/demo}
+          chain-id: 84532
+          usdc-contract-address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+          connect-timeout-ms: 5000
+          read-timeout-ms: 10000
+        ethereum:
+          rpc-url: ${ETH_RPC_URL:https://eth-sepolia.g.alchemy.com/v2/demo}
+          chain-id: 11155111
+          usdc-contract-address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+          connect-timeout-ms: 5000
+          read-timeout-ms: 10000
   chains:
     base:
       min-confirmations: 1

--- a/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmRpcAdapterTest.java
+++ b/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/infrastructure/provider/evm/EvmRpcAdapterTest.java
@@ -1,0 +1,264 @@
+package com.stablecoin.payments.custody.infrastructure.provider.evm;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.port.TransactionReceipt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class EvmRpcAdapterTest {
+
+    private static final String USDC_CONTRACT = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+    private static final ChainId BASE_CHAIN = new ChainId("base");
+    private static final String TX_HASH = "0xabc123def456789012345678901234567890123456789012345678901234abcd";
+
+    private EvmRpcAdapter adapter;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        var properties = new EvmChainProperties(true, Map.of(
+                "base", new EvmChainProperties.ChainRpcConfig(
+                        wmRuntimeInfo.getHttpBaseUrl(), 84532L,
+                        USDC_CONTRACT, 5000, 10000)
+        ));
+        adapter = new EvmRpcAdapter(properties);
+    }
+
+    @Nested
+    @DisplayName("getTransactionReceipt")
+    class GetTransactionReceipt {
+
+        @Test
+        @DisplayName("should return parsed transaction receipt with confirmations")
+        void shouldGetTransactionReceiptSuccessfully() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_getTransactionReceipt")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":{
+                                "blockNumber":"0x64",
+                                "status":"0x1",
+                                "gasUsed":"0x5208",
+                                "effectiveGasPrice":"0x4a817c800",
+                                "transactionHash":"%s"
+                            }}""".formatted(TX_HASH))));
+
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_blockNumber")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":"0x84"}""")));
+
+            // when
+            var result = adapter.getTransactionReceipt(BASE_CHAIN, TX_HASH);
+
+            // then
+            var expected = new TransactionReceipt(
+                    TX_HASH, 100L, true,
+                    new BigDecimal("21000"), new BigDecimal("20000000000"), 32);
+            assertThat(result).usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should return null when receipt not found (pending transaction)")
+        void shouldReturnNullWhenReceiptNotFound() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_getTransactionReceipt")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":null}""")));
+
+            // when
+            var result = adapter.getTransactionReceipt(BASE_CHAIN, TX_HASH);
+
+            // then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("should calculate confirmations as latestBlock minus txBlock")
+        void shouldCalculateConfirmationsCorrectly() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_getTransactionReceipt")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":{
+                                "blockNumber":"0x64",
+                                "status":"0x1",
+                                "gasUsed":"0x5208",
+                                "effectiveGasPrice":"0x3b9aca00",
+                                "transactionHash":"%s"
+                            }}""".formatted(TX_HASH))));
+
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_blockNumber")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":"0x84"}""")));
+
+            // when
+            var result = adapter.getTransactionReceipt(BASE_CHAIN, TX_HASH);
+
+            // then — block 0x64 = 100, latest 0x84 = 132, confirmations = 32
+            var expected = new TransactionReceipt(
+                    TX_HASH, 100L, true,
+                    new BigDecimal("21000"), new BigDecimal("1000000000"), 32);
+            assertThat(result).usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("getLatestBlockNumber")
+    class GetLatestBlockNumber {
+
+        @Test
+        @DisplayName("should parse hex block number to long")
+        void shouldGetLatestBlockNumber() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_blockNumber")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":"0x1a4"}""")));
+
+            // when
+            var result = adapter.getLatestBlockNumber(BASE_CHAIN);
+
+            // then
+            assertThat(result).isEqualTo(420L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTokenBalance")
+    class GetTokenBalance {
+
+        @Test
+        @DisplayName("should convert hex balance to BigDecimal with USDC decimals")
+        void shouldGetTokenBalance() {
+            // given — 0x5F5E100 = 100000000 raw units / 10^6 = 100.000000 USDC
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_call")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":"0x5F5E100"}""")));
+
+            // when
+            var result = adapter.getTokenBalance(BASE_CHAIN,
+                    "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD53", USDC_CONTRACT);
+
+            // then
+            var expected = new BigDecimal("100.000000");
+            assertThat(result).usingComparator(BigDecimal::compareTo).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should return zero balance when hex result is 0x0")
+        void shouldReturnZeroBalance() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_call")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":"0x0"}""")));
+
+            // when
+            var result = adapter.getTokenBalance(BASE_CHAIN,
+                    "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD53", USDC_CONTRACT);
+
+            // then
+            assertThat(result).usingComparator(BigDecimal::compareTo)
+                    .isEqualTo(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP));
+        }
+    }
+
+    @Nested
+    @DisplayName("Error handling")
+    class ErrorHandling {
+
+        @Test
+        @DisplayName("should throw EvmRpcException on JSON-RPC error response")
+        void shouldThrowOnRpcError() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_blockNumber")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}""")));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getLatestBlockNumber(BASE_CHAIN))
+                    .isInstanceOf(EvmRpcException.class)
+                    .hasMessageContaining("Method not found");
+        }
+
+        @Test
+        @DisplayName("should throw on server error (500)")
+        void shouldThrowOnConnectionFailure() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("eth_blockNumber")))
+                    .willReturn(serverError()));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getLatestBlockNumber(BASE_CHAIN))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("should throw when chain is not configured")
+        void shouldThrowWhenChainNotConfigured() {
+            // given
+            var unknownChain = new ChainId("ethereum");
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getLatestBlockNumber(unknownChain))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("No RPC client configured for chain: ethereum");
+        }
+    }
+
+    @Nested
+    @DisplayName("Hex conversion utilities")
+    class HexConversion {
+
+        @Test
+        @DisplayName("should convert hex string to long")
+        void shouldConvertHexToLong() {
+            // when
+            var result = EvmRpcAdapter.hexToLong("0x64");
+
+            // then
+            assertThat(result).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("should encode balanceOf call with padded address")
+        void shouldEncodeBalanceOfCall() {
+            // given
+            var address = "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD53";
+
+            // when
+            var result = EvmRpcAdapter.encodeBalanceOfCall(address);
+
+            // then
+            assertThat(result).startsWith("0x70a08231");
+            assertThat(result).hasSize(10 + 64); // 0x + 8 selector + 64 padded address
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **EvmRpcAdapter** implements `ChainRpcProvider` — raw JSON-RPC via RestClient (HTTP/1.1), no web3j dependency
- `eth_getTransactionReceipt` — parses block number, status, gas, calculates confirmations
- `eth_blockNumber` — latest block for confirmation counting
- `eth_call` with `balanceOf(address)` — USDC ERC-20 balance queries (6 decimal conversion)
- **EvmChainProperties** — `@ConfigurationProperties` for Base Sepolia (chain 84532) + Ethereum Sepolia (chain 11155111)
- `@CircuitBreaker(name = "evmRpc")` on all methods with re-throw fallbacks
- `@ConditionalOnProperty(app.custody.evm.enabled=true)` activation
- **FallbackAdaptersConfig** updated with `ChainRpcProvider` fallback bean

## Test plan
- [x] 11 WireMock-based unit tests (receipt parsing, null receipt, confirmations, block number, token balance, zero balance, RPC error, server error, unconfigured chain)
- [x] Single-assert pattern with `usingRecursiveComparison()`
- [x] All existing S4 tests still green

Closes STA-139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EVM blockchain network support for Ethereum and Base chains with RPC connectivity for querying transaction receipts, latest block numbers, and token balances.
  * Introduced fallback mechanism for RPC operations when primary connections are unavailable.

* **Chores**
  * Added configuration for EVM chains including RPC endpoints and timeout settings.

* **Tests**
  * Added comprehensive unit tests for EVM RPC operations and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->