### PR TITLE
feat(s4): Solana RPC adapter — JSON-RPC for Devnet USDC (STA-140)

### DIFF
--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaChainProperties.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaChainProperties.java
@@ -1,0 +1,32 @@
+package com.stablecoin.payments.custody.infrastructure.provider.solana;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.custody.solana")
+public record SolanaChainProperties(
+        boolean enabled,
+        String rpcUrl,
+        String usdcMintAddress,
+        String commitment,
+        Integer connectTimeoutMs,
+        Integer readTimeoutMs
+) {
+
+    public SolanaChainProperties {
+        if (rpcUrl == null || rpcUrl.isBlank()) {
+            rpcUrl = "https://api.devnet.solana.com";
+        }
+        if (usdcMintAddress == null || usdcMintAddress.isBlank()) {
+            usdcMintAddress = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        }
+        if (commitment == null || commitment.isBlank()) {
+            commitment = "confirmed";
+        }
+        if (connectTimeoutMs == null || connectTimeoutMs <= 0) {
+            connectTimeoutMs = 5000;
+        }
+        if (readTimeoutMs == null || readTimeoutMs <= 0) {
+            readTimeoutMs = 10000;
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaRpcAdapter.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaRpcAdapter.java
@@ -1,0 +1,196 @@
+package com.stablecoin.payments.custody.infrastructure.provider.solana;
+
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.port.ChainRpcProvider;
+import com.stablecoin.payments.custody.domain.port.TransactionReceipt;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "app.custody.solana.enabled", havingValue = "true")
+@EnableConfigurationProperties(SolanaChainProperties.class)
+public class SolanaRpcAdapter implements ChainRpcProvider {
+
+    private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+    private static final int USDC_DECIMALS = 6;
+    private static final ChainId SOLANA_CHAIN = new ChainId("solana");
+
+    private final RestClient restClient;
+    private final SolanaChainProperties properties;
+
+    public SolanaRpcAdapter(SolanaChainProperties properties) {
+        this.properties = properties;
+
+        var httpClient = HttpClient.newBuilder()
+                .version(Version.HTTP_1_1)
+                .connectTimeout(Duration.ofMillis(properties.connectTimeoutMs()))
+                .build();
+
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofMillis(properties.readTimeoutMs()));
+
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.rpcUrl())
+                .requestFactory(requestFactory)
+                .build();
+
+        log.info("[SOLANA-RPC] Configured RestClient rpcUrl={} commitment={} usdcMint={}",
+                properties.rpcUrl(), properties.commitment(), properties.usdcMintAddress());
+    }
+
+    @Override
+    @CircuitBreaker(name = "solanaRpc", fallbackMethod = "getTransactionReceiptFallback")
+    public TransactionReceipt getTransactionReceipt(ChainId chainId, String txHash) {
+        log.info("[SOLANA-RPC] Getting transaction chain={} signature={}", chainId.value(), txHash);
+
+        var commitmentConfig = Map.of(
+                "encoding", "jsonParsed",
+                "commitment", properties.commitment(),
+                "maxSupportedTransactionVersion", 0
+        );
+        var result = callJsonRpc("getTransaction", txHash, commitmentConfig);
+        if (result == null || result.isNull()) {
+            log.info("[SOLANA-RPC] Transaction not found (pending) chain={} signature={}",
+                    chainId.value(), txHash);
+            return null;
+        }
+
+        var slot = result.get("slot").asLong();
+        var meta = result.get("meta");
+        var fee = meta != null && meta.has("fee") ? new BigDecimal(meta.get("fee").asLong()) : BigDecimal.ZERO;
+        var success = meta == null || !meta.has("err") || meta.get("err").isNull();
+
+        var latestSlot = getLatestBlockNumber(chainId);
+        var confirmations = (int) (latestSlot - slot);
+
+        log.info("[SOLANA-RPC] Transaction parsed chain={} signature={} slot={} success={} confirmations={}",
+                chainId.value(), txHash, slot, success, confirmations);
+
+        return new TransactionReceipt(txHash, slot, success, fee, BigDecimal.ZERO, confirmations);
+    }
+
+    @Override
+    @CircuitBreaker(name = "solanaRpc", fallbackMethod = "getLatestBlockNumberFallback")
+    public long getLatestBlockNumber(ChainId chainId) {
+        log.info("[SOLANA-RPC] Getting current slot chain={}", chainId.value());
+
+        var commitmentConfig = Map.of("commitment", properties.commitment());
+        var result = callJsonRpc("getSlot", commitmentConfig);
+        var slot = result.asLong();
+
+        log.info("[SOLANA-RPC] Current slot chain={} slot={}", chainId.value(), slot);
+        return slot;
+    }
+
+    @Override
+    @CircuitBreaker(name = "solanaRpc", fallbackMethod = "getTokenBalanceFallback")
+    public BigDecimal getTokenBalance(ChainId chainId, String address, String tokenContract) {
+        log.info("[SOLANA-RPC] Getting SPL token balance chain={} owner={} mint={}",
+                chainId.value(), address, tokenContract);
+
+        var mintFilter = Map.of("mint", tokenContract);
+        var encodingConfig = Map.of("encoding", "jsonParsed");
+        var result = callJsonRpc("getTokenAccountsByOwner", address, mintFilter, encodingConfig);
+
+        if (result == null || result.isNull()) {
+            log.info("[SOLANA-RPC] No token accounts found chain={} owner={}", chainId.value(), address);
+            return BigDecimal.ZERO.setScale(USDC_DECIMALS, RoundingMode.HALF_UP);
+        }
+
+        var accounts = result.get("value");
+        if (accounts == null || !accounts.isArray() || accounts.isEmpty()) {
+            log.info("[SOLANA-RPC] Empty token accounts chain={} owner={}", chainId.value(), address);
+            return BigDecimal.ZERO.setScale(USDC_DECIMALS, RoundingMode.HALF_UP);
+        }
+
+        var totalBalance = BigDecimal.ZERO;
+        for (var account : accounts) {
+            var tokenAmount = account.get("account")
+                    .get("data")
+                    .get("parsed")
+                    .get("info")
+                    .get("tokenAmount");
+            var uiAmountString = tokenAmount.get("uiAmountString").asText();
+            totalBalance = totalBalance.add(new BigDecimal(uiAmountString));
+        }
+
+        var balance = totalBalance.setScale(USDC_DECIMALS, RoundingMode.HALF_UP);
+        log.info("[SOLANA-RPC] SPL token balance chain={} owner={} balance={}",
+                chainId.value(), address, balance);
+        return balance;
+    }
+
+    JsonNode callJsonRpc(String method, Object... params) {
+        var request = new JsonRpcRequest(method, params);
+
+        var response = restClient.post()
+                .uri("")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(String.class);
+
+        try {
+            var responseNode = JSON_MAPPER.readTree(response);
+
+            if (responseNode.has("error") && !responseNode.get("error").isNull()) {
+                var error = responseNode.get("error");
+                var code = error.has("code") ? error.get("code").asInt() : -1;
+                var message = error.has("message") ? error.get("message").asText() : "Unknown RPC error";
+                throw new SolanaRpcException(
+                        "JSON-RPC error on %s: code=%d message=%s".formatted(method, code, message));
+            }
+
+            return responseNode.get("result");
+        } catch (SolanaRpcException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new SolanaRpcException("Failed to parse JSON-RPC response for %s".formatted(method), ex);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private TransactionReceipt getTransactionReceiptFallback(ChainId chainId, String txHash, Exception ex) {
+        log.error("[SOLANA-RPC] Circuit breaker open - getTransactionReceipt failed chain={} signature={}",
+                chainId.value(), txHash, ex);
+        throw new IllegalStateException("Solana RPC unavailable for getTransactionReceipt", ex);
+    }
+
+    @SuppressWarnings("unused")
+    private long getLatestBlockNumberFallback(ChainId chainId, Exception ex) {
+        log.error("[SOLANA-RPC] Circuit breaker open - getLatestBlockNumber failed chain={}",
+                chainId.value(), ex);
+        throw new IllegalStateException("Solana RPC unavailable for getSlot", ex);
+    }
+
+    @SuppressWarnings("unused")
+    private BigDecimal getTokenBalanceFallback(ChainId chainId, String address, String tokenContract,
+                                               Exception ex) {
+        log.error("[SOLANA-RPC] Circuit breaker open - getTokenBalance failed chain={} owner={}",
+                chainId.value(), address, ex);
+        throw new IllegalStateException("Solana RPC unavailable for getTokenBalance", ex);
+    }
+
+    record JsonRpcRequest(String jsonrpc, String method, Object[] params, int id) {
+
+        JsonRpcRequest(String method, Object... params) {
+            this("2.0", method, params, 1);
+        }
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaRpcException.java
+++ b/blockchain-custody/blockchain-custody/src/main/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaRpcException.java
@@ -1,0 +1,12 @@
+package com.stablecoin.payments.custody.infrastructure.provider.solana;
+
+public class SolanaRpcException extends RuntimeException {
+
+    public SolanaRpcException(String message) {
+        super(message);
+    }
+
+    public SolanaRpcException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/blockchain-custody/blockchain-custody/src/main/resources/application.yml
+++ b/blockchain-custody/blockchain-custody/src/main/resources/application.yml
@@ -126,6 +126,13 @@ app:
           usdc-contract-address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
           connect-timeout-ms: 5000
           read-timeout-ms: 10000
+    solana:
+      enabled: false  # disabled by default for dev/test — enable in production
+      rpc-url: ${SOL_RPC_URL:https://api.devnet.solana.com}
+      usdc-mint-address: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+      commitment: confirmed
+      connect-timeout-ms: 5000
+      read-timeout-ms: 10000
   chains:
     base:
       min-confirmations: 1

--- a/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaRpcAdapterTest.java
+++ b/blockchain-custody/blockchain-custody/src/test/java/com/stablecoin/payments/custody/infrastructure/provider/solana/SolanaRpcAdapterTest.java
@@ -1,0 +1,365 @@
+package com.stablecoin.payments.custody.infrastructure.provider.solana;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.stablecoin.payments.custody.domain.model.ChainId;
+import com.stablecoin.payments.custody.domain.port.TransactionReceipt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class SolanaRpcAdapterTest {
+
+    private static final ChainId SOLANA_CHAIN = new ChainId("solana");
+    private static final String USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+    private static final String TX_SIGNATURE = "5UfDuX7WXYZsyfBJGR6Lo9bLxLYbGo4cHbsiNPQeia7p4owLWbSMQoFgs4GZpmJQ4D3mYwYrLzH8vUxBnkGir1Mi";
+    private static final String OWNER_ADDRESS = "7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv";
+
+    private SolanaRpcAdapter adapter;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        var properties = new SolanaChainProperties(
+                true,
+                wmRuntimeInfo.getHttpBaseUrl(),
+                USDC_MINT,
+                "confirmed",
+                5000,
+                10000
+        );
+        adapter = new SolanaRpcAdapter(properties);
+    }
+
+    @Nested
+    @DisplayName("getTransactionReceipt")
+    class GetTransactionReceipt {
+
+        @Test
+        @DisplayName("should return parsed transaction receipt with confirmations from slot delta")
+        void shouldGetTransactionReceiptSuccessfully() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTransaction")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":{
+                                "slot":100,
+                                "blockTime":1700000000,
+                                "meta":{
+                                    "err":null,
+                                    "fee":5000,
+                                    "status":{"Ok":null}
+                                },
+                                "transaction":{
+                                    "signatures":["%s"]
+                                }
+                            }}""".formatted(TX_SIGNATURE))));
+
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getSlot")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":132}""")));
+
+            // when
+            var result = adapter.getTransactionReceipt(SOLANA_CHAIN, TX_SIGNATURE);
+
+            // then
+            var expected = new TransactionReceipt(
+                    TX_SIGNATURE, 100L, true,
+                    new BigDecimal("5000"), BigDecimal.ZERO, 32);
+            assertThat(result).usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should return null when transaction not found (pending)")
+        void shouldReturnNullWhenTransactionNotFound() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTransaction")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":null}""")));
+
+            // when
+            var result = adapter.getTransactionReceipt(SOLANA_CHAIN, TX_SIGNATURE);
+
+            // then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("should detect failed transaction when meta.err is not null")
+        void shouldDetectFailedTransaction() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTransaction")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":{
+                                "slot":200,
+                                "blockTime":1700000100,
+                                "meta":{
+                                    "err":{"InstructionError":[0,"InsufficientFunds"]},
+                                    "fee":5000,
+                                    "status":{"Err":{"InstructionError":[0,"InsufficientFunds"]}}
+                                },
+                                "transaction":{
+                                    "signatures":["%s"]
+                                }
+                            }}""".formatted(TX_SIGNATURE))));
+
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getSlot")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":210}""")));
+
+            // when
+            var result = adapter.getTransactionReceipt(SOLANA_CHAIN, TX_SIGNATURE);
+
+            // then
+            var expected = new TransactionReceipt(
+                    TX_SIGNATURE, 200L, false,
+                    new BigDecimal("5000"), BigDecimal.ZERO, 10);
+            assertThat(result).usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("getLatestBlockNumber (getSlot)")
+    class GetLatestBlockNumber {
+
+        @Test
+        @DisplayName("should return current slot number")
+        void shouldGetCurrentSlot() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getSlot")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":285630456}""")));
+
+            // when
+            var result = adapter.getLatestBlockNumber(SOLANA_CHAIN);
+
+            // then
+            assertThat(result).isEqualTo(285630456L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTokenBalance (getTokenAccountsByOwner)")
+    class GetTokenBalance {
+
+        @Test
+        @DisplayName("should return USDC balance from SPL token account")
+        void shouldGetTokenBalance() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTokenAccountsByOwner")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":{
+                                "context":{"slot":100},
+                                "value":[{
+                                    "pubkey":"TokenAccountPubkey",
+                                    "account":{
+                                        "data":{
+                                            "parsed":{
+                                                "info":{
+                                                    "mint":"%s",
+                                                    "owner":"%s",
+                                                    "tokenAmount":{
+                                                        "amount":"100000000",
+                                                        "decimals":6,
+                                                        "uiAmount":100.0,
+                                                        "uiAmountString":"100"
+                                                    }
+                                                },
+                                                "type":"account"
+                                            },
+                                            "program":"spl-token",
+                                            "space":165
+                                        },
+                                        "executable":false,
+                                        "lamports":2039280,
+                                        "owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                                        "rentEpoch":0
+                                    }
+                                }]
+                            }}""".formatted(USDC_MINT, OWNER_ADDRESS))));
+
+            // when
+            var result = adapter.getTokenBalance(SOLANA_CHAIN, OWNER_ADDRESS, USDC_MINT);
+
+            // then
+            var expected = new BigDecimal("100.000000");
+            assertThat(result).usingComparator(BigDecimal::compareTo).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should return zero when no token accounts found")
+        void shouldReturnZeroWhenNoTokenAccounts() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTokenAccountsByOwner")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":{
+                                "context":{"slot":100},
+                                "value":[]
+                            }}""")));
+
+            // when
+            var result = adapter.getTokenBalance(SOLANA_CHAIN, OWNER_ADDRESS, USDC_MINT);
+
+            // then
+            assertThat(result).usingComparator(BigDecimal::compareTo)
+                    .isEqualTo(BigDecimal.ZERO.setScale(6, RoundingMode.HALF_UP));
+        }
+
+        @Test
+        @DisplayName("should aggregate balance from multiple token accounts")
+        void shouldAggregateMultipleTokenAccounts() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTokenAccountsByOwner")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"result":{
+                                "context":{"slot":100},
+                                "value":[{
+                                    "pubkey":"TokenAccount1",
+                                    "account":{
+                                        "data":{
+                                            "parsed":{
+                                                "info":{
+                                                    "mint":"%s",
+                                                    "owner":"%s",
+                                                    "tokenAmount":{
+                                                        "amount":"75000000",
+                                                        "decimals":6,
+                                                        "uiAmount":75.0,
+                                                        "uiAmountString":"75"
+                                                    }
+                                                },
+                                                "type":"account"
+                                            },
+                                            "program":"spl-token",
+                                            "space":165
+                                        },
+                                        "executable":false,
+                                        "lamports":2039280,
+                                        "owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                                        "rentEpoch":0
+                                    }
+                                },{
+                                    "pubkey":"TokenAccount2",
+                                    "account":{
+                                        "data":{
+                                            "parsed":{
+                                                "info":{
+                                                    "mint":"%s",
+                                                    "owner":"%s",
+                                                    "tokenAmount":{
+                                                        "amount":"25000000",
+                                                        "decimals":6,
+                                                        "uiAmount":25.0,
+                                                        "uiAmountString":"25"
+                                                    }
+                                                },
+                                                "type":"account"
+                                            },
+                                            "program":"spl-token",
+                                            "space":165
+                                        },
+                                        "executable":false,
+                                        "lamports":2039280,
+                                        "owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                                        "rentEpoch":0
+                                    }
+                                }]
+                            }}""".formatted(USDC_MINT, OWNER_ADDRESS, USDC_MINT, OWNER_ADDRESS))));
+
+            // when
+            var result = adapter.getTokenBalance(SOLANA_CHAIN, OWNER_ADDRESS, USDC_MINT);
+
+            // then
+            var expected = new BigDecimal("100.000000");
+            assertThat(result).usingComparator(BigDecimal::compareTo).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("Error handling")
+    class ErrorHandling {
+
+        @Test
+        @DisplayName("should throw SolanaRpcException on JSON-RPC error response")
+        void shouldThrowOnRpcError() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getSlot")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}""")));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getLatestBlockNumber(SOLANA_CHAIN))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("Method not found");
+        }
+
+        @Test
+        @DisplayName("should throw on server error (500)")
+        void shouldThrowOnConnectionFailure() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getSlot")))
+                    .willReturn(serverError()));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getLatestBlockNumber(SOLANA_CHAIN))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("should throw SolanaRpcException when transaction RPC returns error")
+        void shouldThrowOnTransactionRpcError() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTransaction")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"error":{"code":-32009,"message":"Transaction version (0) is not supported"}}""")));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getTransactionReceipt(SOLANA_CHAIN, TX_SIGNATURE))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("Transaction version (0) is not supported");
+        }
+
+        @Test
+        @DisplayName("should throw SolanaRpcException when token balance RPC returns error")
+        void shouldThrowOnTokenBalanceRpcError() {
+            // given
+            stubFor(post("/")
+                    .withRequestBody(matchingJsonPath("$.method", equalTo("getTokenAccountsByOwner")))
+                    .willReturn(okJson("""
+                            {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid param: could not find mint"}}""")));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getTokenBalance(SOLANA_CHAIN, OWNER_ADDRESS, USDC_MINT))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("Invalid param: could not find mint");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **SolanaRpcAdapter** implements `ChainRpcProvider` for Solana using raw JSON-RPC over RestClient (same pattern as EvmRpcAdapter)
- Maps Solana concepts to domain: `getTransaction` → `TransactionReceipt`, `getSlot` → block number, `getTokenAccountsByOwner` → SPL token balance
- `@CircuitBreaker(name = "solanaRpc")` with fallback methods, `@ConditionalOnProperty(app.custody.solana.enabled=true)`
- `SolanaChainProperties` with Devnet defaults (USDC mint `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`, `confirmed` commitment)
- 11 WireMock tests: tx receipt (success/pending/failed), getSlot, token balance (single/zero/multi-account), 4 error handling

## Test plan
- [x] 11 new WireMock unit tests all pass
- [x] All existing S4 tests still green (339 total)
- [x] `spotlessCheck` passes
- [ ] CI green

Closes STA-140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Solana blockchain operations including transaction receipt retrieval, block number queries, and token balance lookups.
  * Solana integration is disabled by default and can be configured via settings.

* **Tests**
  * Added comprehensive test coverage for Solana blockchain functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->