### PR TITLE
feat(s5): domain model — PayoutOrder aggregate, state machine, events, ports (STA-147)

### DIFF
--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/FiatPayoutCompletedEvent.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/FiatPayoutCompletedEvent.java
@@ -1,0 +1,16 @@
+package com.stablecoin.payments.offramp.domain.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatPayoutCompletedEvent(
+        UUID payoutId,
+        UUID paymentId,
+        UUID correlationId,
+        BigDecimal fiatAmount,
+        String targetCurrency,
+        String paymentRail,
+        String partnerReference,
+        Instant completedAt
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/FiatPayoutFailedEvent.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/FiatPayoutFailedEvent.java
@@ -1,0 +1,13 @@
+package com.stablecoin.payments.offramp.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatPayoutFailedEvent(
+        UUID payoutId,
+        UUID paymentId,
+        UUID correlationId,
+        String reason,
+        String errorCode,
+        Instant failedAt
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/FiatPayoutInitiatedEvent.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/FiatPayoutInitiatedEvent.java
@@ -1,0 +1,16 @@
+package com.stablecoin.payments.offramp.domain.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FiatPayoutInitiatedEvent(
+        UUID payoutId,
+        UUID paymentId,
+        UUID correlationId,
+        BigDecimal fiatAmount,
+        String targetCurrency,
+        String paymentRail,
+        String partner,
+        Instant initiatedAt
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/StablecoinRedeemedEvent.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/event/StablecoinRedeemedEvent.java
@@ -1,0 +1,17 @@
+package com.stablecoin.payments.offramp.domain.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record StablecoinRedeemedEvent(
+        UUID redemptionId,
+        UUID payoutId,
+        UUID paymentId,
+        UUID correlationId,
+        String stablecoin,
+        BigDecimal redeemedAmount,
+        BigDecimal fiatReceived,
+        String fiatCurrency,
+        Instant redeemedAt
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/PayoutNotFoundException.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/PayoutNotFoundException.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.offramp.domain.exception;
+
+import java.util.UUID;
+
+/**
+ * Thrown when a payout order cannot be found by the given identifier.
+ */
+public class PayoutNotFoundException extends RuntimeException {
+
+    public static final String ERROR_CODE = "FR-1003";
+
+    public PayoutNotFoundException(String identifier) {
+        super("Payout order not found: " + identifier);
+    }
+
+    public PayoutNotFoundException(UUID payoutId) {
+        super("Payout order not found: " + payoutId);
+    }
+
+    public String errorCode() {
+        return ERROR_CODE;
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/PayoutNotRefundableException.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/PayoutNotRefundableException.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.offramp.domain.exception;
+
+import java.util.UUID;
+
+/**
+ * Thrown when a payout order cannot be refunded (e.g., stablecoin already redeemed,
+ * fiat already disbursed).
+ */
+public class PayoutNotRefundableException extends RuntimeException {
+
+    public static final String ERROR_CODE = "FR-2001";
+
+    public PayoutNotRefundableException(UUID payoutId, String reason) {
+        super("Payout order %s is not refundable: %s".formatted(payoutId, reason));
+    }
+
+    public String errorCode() {
+        return ERROR_CODE;
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/PayoutPartnerException.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/PayoutPartnerException.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.offramp.domain.exception;
+
+import java.util.UUID;
+
+/**
+ * Thrown when an off-ramp partner interaction fails (e.g., Modulr SEPA transfer failure).
+ */
+public class PayoutPartnerException extends RuntimeException {
+
+    public static final String ERROR_CODE = "FR-2003";
+
+    public PayoutPartnerException(UUID payoutId, String partner, String reason) {
+        super("Payout partner %s failed for payout %s: %s".formatted(partner, payoutId, reason));
+    }
+
+    public PayoutPartnerException(UUID payoutId, String partner, String reason, Throwable cause) {
+        super("Payout partner %s failed for payout %s: %s".formatted(partner, payoutId, reason), cause);
+    }
+
+    public String errorCode() {
+        return ERROR_CODE;
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/RedemptionFailedException.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/exception/RedemptionFailedException.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.offramp.domain.exception;
+
+import java.util.UUID;
+
+/**
+ * Thrown when stablecoin redemption fails.
+ */
+public class RedemptionFailedException extends RuntimeException {
+
+    public static final String ERROR_CODE = "FR-2002";
+
+    public RedemptionFailedException(UUID payoutId, String reason) {
+        super("Stablecoin redemption failed for payout %s: %s".formatted(payoutId, reason));
+    }
+
+    public RedemptionFailedException(UUID payoutId, String reason, Throwable cause) {
+        super("Stablecoin redemption failed for payout %s: %s".formatted(payoutId, reason), cause);
+    }
+
+    public String errorCode() {
+        return ERROR_CODE;
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/AccountType.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/AccountType.java
@@ -1,0 +1,7 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public enum AccountType {
+    IBAN,
+    SORT_CODE,
+    ROUTING
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/BankAccount.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/BankAccount.java
@@ -1,0 +1,24 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public record BankAccount(
+        String accountNumber,
+        String bankCode,
+        AccountType accountType,
+        String country
+) {
+
+    public BankAccount {
+        if (accountNumber == null || accountNumber.isBlank()) {
+            throw new IllegalArgumentException("Account number is required");
+        }
+        if (bankCode == null || bankCode.isBlank()) {
+            throw new IllegalArgumentException("Bank code is required");
+        }
+        if (accountType == null) {
+            throw new IllegalArgumentException("Account type is required");
+        }
+        if (country == null || country.isBlank()) {
+            throw new IllegalArgumentException("Country is required");
+        }
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/MobileMoneyAccount.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/MobileMoneyAccount.java
@@ -1,0 +1,20 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public record MobileMoneyAccount(
+        MobileMoneyProvider provider,
+        String phoneNumber,
+        String country
+) {
+
+    public MobileMoneyAccount {
+        if (provider == null) {
+            throw new IllegalArgumentException("Provider is required");
+        }
+        if (phoneNumber == null || phoneNumber.isBlank()) {
+            throw new IllegalArgumentException("Phone number is required");
+        }
+        if (country == null || country.isBlank()) {
+            throw new IllegalArgumentException("Country is required");
+        }
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/MobileMoneyProvider.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/MobileMoneyProvider.java
@@ -1,0 +1,8 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public enum MobileMoneyProvider {
+    M_PESA,
+    GCASH,
+    AIRTEL_MONEY,
+    MTN_MOBILE_MONEY
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/Money.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/Money.java
@@ -1,0 +1,15 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+import java.math.BigDecimal;
+
+public record Money(BigDecimal amount, String currency) {
+
+    public Money {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Amount must be positive");
+        }
+        if (currency == null || currency.isBlank()) {
+            throw new IllegalArgumentException("Currency must not be blank");
+        }
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/OffRampTransaction.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/OffRampTransaction.java
@@ -1,0 +1,67 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Entity recording off-ramp partner transaction events (audit trail).
+ * <p>
+ * Each interaction with an off-ramp partner (Modulr, CurrencyCloud, Safaricom, etc.)
+ * creates a new OffRampTransaction record for auditability.
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record OffRampTransaction(
+        UUID offRampTxnId,
+        UUID payoutId,
+        String partnerName,
+        String eventType,
+        BigDecimal amount,
+        String currency,
+        String status,
+        String rawResponse,
+        Instant receivedAt
+) {
+
+    /**
+     * Creates a new OffRampTransaction.
+     */
+    public static OffRampTransaction create(UUID payoutId, String partnerName,
+                                            String eventType, BigDecimal amount,
+                                            String currency, String status,
+                                            String rawResponse) {
+        if (payoutId == null) {
+            throw new IllegalArgumentException("payoutId is required");
+        }
+        if (partnerName == null || partnerName.isBlank()) {
+            throw new IllegalArgumentException("partnerName is required");
+        }
+        if (eventType == null || eventType.isBlank()) {
+            throw new IllegalArgumentException("eventType is required");
+        }
+        if (amount == null) {
+            throw new IllegalArgumentException("amount is required");
+        }
+        if (currency == null || currency.isBlank()) {
+            throw new IllegalArgumentException("currency is required");
+        }
+        if (status == null || status.isBlank()) {
+            throw new IllegalArgumentException("status is required");
+        }
+
+        return OffRampTransaction.builder()
+                .offRampTxnId(UUID.randomUUID())
+                .payoutId(payoutId)
+                .partnerName(partnerName)
+                .eventType(eventType)
+                .amount(amount)
+                .currency(currency)
+                .status(status)
+                .rawResponse(rawResponse != null ? rawResponse : "{}")
+                .receivedAt(Instant.now())
+                .build();
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PartnerIdentifier.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PartnerIdentifier.java
@@ -1,0 +1,13 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public record PartnerIdentifier(String partnerId, String partnerName) {
+
+    public PartnerIdentifier {
+        if (partnerId == null || partnerId.isBlank()) {
+            throw new IllegalArgumentException("Partner ID is required");
+        }
+        if (partnerName == null || partnerName.isBlank()) {
+            throw new IllegalArgumentException("Partner name is required");
+        }
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PaymentRail.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PaymentRail.java
@@ -1,0 +1,9 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public enum PaymentRail {
+    SEPA,
+    FASTER_PAYMENTS,
+    PIX,
+    UPI,
+    M_PESA
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutOrder.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutOrder.java
@@ -1,0 +1,364 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+import com.stablecoin.payments.offramp.domain.statemachine.StateMachine;
+import com.stablecoin.payments.offramp.domain.statemachine.StateTransition;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.COMPLETED;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.MANUAL_REVIEW;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.PAYOUT_FAILED;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.PAYOUT_INITIATED;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.PAYOUT_PROCESSING;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.PENDING;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.REDEEMED;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.REDEEMING;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.REDEMPTION_FAILED;
+import static com.stablecoin.payments.offramp.domain.model.PayoutStatus.STABLECOIN_HELD;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.COMPLETE_HOLD;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.COMPLETE_PAYOUT;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.COMPLETE_REDEMPTION;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.ESCALATE_MANUAL_REVIEW;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.FAIL_PAYOUT;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.FAIL_REDEMPTION;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.HOLD_STABLECOIN;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.INITIATE_PAYOUT;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.MARK_PAYOUT_PROCESSING;
+import static com.stablecoin.payments.offramp.domain.model.PayoutTrigger.START_REDEMPTION;
+
+/**
+ * Aggregate root for a fiat off-ramp payout order.
+ * <p>
+ * Enforces the payout lifecycle via an internal state machine:
+ * {@code PENDING -> REDEEMING -> REDEEMED -> PAYOUT_INITIATED -> PAYOUT_PROCESSING -> COMPLETED}.
+ * <p>
+ * For HOLD_STABLECOIN type: {@code PENDING -> STABLECOIN_HELD -> COMPLETED}.
+ * <p>
+ * Failure paths lead to REDEMPTION_FAILED or PAYOUT_FAILED, both of which can escalate to MANUAL_REVIEW.
+ * <p>
+ * Immutable record — all state transitions return new instances via {@code toBuilder()}.
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record PayoutOrder(
+        UUID payoutId,
+        UUID paymentId,
+        UUID correlationId,
+        UUID transferId,
+        PayoutType payoutType,
+        StablecoinTicker stablecoin,
+        BigDecimal redeemedAmount,
+        String targetCurrency,
+        BigDecimal fiatAmount,
+        BigDecimal appliedFxRate,
+        UUID recipientId,
+        String recipientAccountHash,
+        BankAccount bankAccount,
+        MobileMoneyAccount mobileMoneyAccount,
+        PaymentRail paymentRail,
+        PartnerIdentifier offRampPartner,
+        PayoutStatus status,
+        String partnerReference,
+        Instant partnerSettledAt,
+        String failureReason,
+        String errorCode,
+        Instant createdAt,
+        Instant updatedAt
+) {
+
+    private static final Set<PayoutStatus> TERMINAL_STATES = Set.of(COMPLETED, MANUAL_REVIEW);
+
+    /** Fiat payout tolerance: fiat_amount must match redeemed * fx_rate within ±0.01 */
+    private static final BigDecimal FIAT_AMOUNT_TOLERANCE = new BigDecimal("0.01");
+
+    private static final StateMachine<PayoutStatus, PayoutTrigger> STATE_MACHINE =
+            new StateMachine<>(List.of(
+                    // -- Fiat happy path ------------------------------------------
+                    new StateTransition<>(PENDING, START_REDEMPTION, REDEEMING),
+                    new StateTransition<>(REDEEMING, COMPLETE_REDEMPTION, REDEEMED),
+                    new StateTransition<>(REDEEMED, INITIATE_PAYOUT, PAYOUT_INITIATED),
+                    new StateTransition<>(PAYOUT_INITIATED, MARK_PAYOUT_PROCESSING, PAYOUT_PROCESSING),
+                    new StateTransition<>(PAYOUT_PROCESSING, COMPLETE_PAYOUT, COMPLETED),
+
+                    // -- Redemption failure ----------------------------------------
+                    new StateTransition<>(REDEEMING, FAIL_REDEMPTION, REDEMPTION_FAILED),
+                    new StateTransition<>(REDEMPTION_FAILED, ESCALATE_MANUAL_REVIEW, MANUAL_REVIEW),
+
+                    // -- Payout failure --------------------------------------------
+                    new StateTransition<>(PAYOUT_INITIATED, FAIL_PAYOUT, PAYOUT_FAILED),
+                    new StateTransition<>(PAYOUT_PROCESSING, FAIL_PAYOUT, PAYOUT_FAILED),
+                    new StateTransition<>(PAYOUT_FAILED, ESCALATE_MANUAL_REVIEW, MANUAL_REVIEW),
+
+                    // -- Hold stablecoin path --------------------------------------
+                    new StateTransition<>(PENDING, HOLD_STABLECOIN, STABLECOIN_HELD),
+                    new StateTransition<>(STABLECOIN_HELD, COMPLETE_HOLD, COMPLETED)
+            ));
+
+    // -- Factory Method ---------------------------------------------------
+
+    /**
+     * Creates a new payout order in PENDING state.
+     */
+    public static PayoutOrder create(UUID paymentId, UUID correlationId, UUID transferId,
+                                     PayoutType payoutType, StablecoinTicker stablecoin,
+                                     BigDecimal redeemedAmount, String targetCurrency,
+                                     BigDecimal appliedFxRate, UUID recipientId,
+                                     String recipientAccountHash,
+                                     BankAccount bankAccount, MobileMoneyAccount mobileMoneyAccount,
+                                     PaymentRail paymentRail, PartnerIdentifier offRampPartner) {
+        if (paymentId == null) {
+            throw new IllegalArgumentException("paymentId is required");
+        }
+        if (correlationId == null) {
+            throw new IllegalArgumentException("correlationId is required");
+        }
+        if (transferId == null) {
+            throw new IllegalArgumentException("transferId is required");
+        }
+        if (payoutType == null) {
+            throw new IllegalArgumentException("payoutType is required");
+        }
+        if (stablecoin == null) {
+            throw new IllegalArgumentException("stablecoin is required");
+        }
+        if (redeemedAmount == null || redeemedAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("redeemedAmount must be positive");
+        }
+        if (targetCurrency == null || targetCurrency.isBlank()) {
+            throw new IllegalArgumentException("targetCurrency is required");
+        }
+        if (appliedFxRate == null || appliedFxRate.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("appliedFxRate must be positive");
+        }
+        if (recipientId == null) {
+            throw new IllegalArgumentException("recipientId is required");
+        }
+        if (recipientAccountHash == null || recipientAccountHash.isBlank()) {
+            throw new IllegalArgumentException("recipientAccountHash is required");
+        }
+        if (paymentRail == null) {
+            throw new IllegalArgumentException("paymentRail is required");
+        }
+        if (offRampPartner == null) {
+            throw new IllegalArgumentException("offRampPartner is required");
+        }
+        if (bankAccount == null && mobileMoneyAccount == null) {
+            throw new IllegalArgumentException("Either bankAccount or mobileMoneyAccount is required");
+        }
+
+        var now = Instant.now();
+        return PayoutOrder.builder()
+                .payoutId(UUID.randomUUID())
+                .paymentId(paymentId)
+                .correlationId(correlationId)
+                .transferId(transferId)
+                .payoutType(payoutType)
+                .stablecoin(stablecoin)
+                .redeemedAmount(redeemedAmount)
+                .targetCurrency(targetCurrency)
+                .appliedFxRate(appliedFxRate)
+                .recipientId(recipientId)
+                .recipientAccountHash(recipientAccountHash)
+                .bankAccount(bankAccount)
+                .mobileMoneyAccount(mobileMoneyAccount)
+                .paymentRail(paymentRail)
+                .offRampPartner(offRampPartner)
+                .status(PENDING)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+
+    // -- State Transition Methods -----------------------------------------
+
+    /**
+     * Starts the stablecoin redemption process. Transitions PENDING -> REDEEMING.
+     */
+    public PayoutOrder startRedemption() {
+        assertNotTerminal();
+        var nextState = STATE_MACHINE.transition(status, START_REDEMPTION);
+        return toBuilder()
+                .status(nextState)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Completes the redemption and records the fiat amount received.
+     * Transitions REDEEMING -> REDEEMED.
+     * <p>
+     * Invariant: fiatAmount must match redeemedAmount * appliedFxRate within ±0.01 tolerance.
+     */
+    public PayoutOrder completeRedemption(BigDecimal receivedFiatAmount) {
+        assertNotTerminal();
+        if (receivedFiatAmount == null || receivedFiatAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Received fiat amount must be positive");
+        }
+        validateFiatAmountTolerance(receivedFiatAmount);
+
+        var nextState = STATE_MACHINE.transition(status, COMPLETE_REDEMPTION);
+        return toBuilder()
+                .status(nextState)
+                .fiatAmount(receivedFiatAmount)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Fails the redemption. Transitions REDEEMING -> REDEMPTION_FAILED.
+     */
+    public PayoutOrder failRedemption(String reason) {
+        var nextState = STATE_MACHINE.transition(status, FAIL_REDEMPTION);
+        return toBuilder()
+                .status(nextState)
+                .failureReason(reason)
+                .errorCode("FR-2002")
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Initiates the fiat payout with a partner. Transitions REDEEMED -> PAYOUT_INITIATED.
+     * <p>
+     * Invariant: cannot initiate payout unless stablecoin has been redeemed (status == REDEEMED).
+     */
+    public PayoutOrder initiatePayout(String partnerRef) {
+        assertNotTerminal();
+        if (partnerRef == null || partnerRef.isBlank()) {
+            throw new IllegalArgumentException("Partner reference is required");
+        }
+        var nextState = STATE_MACHINE.transition(status, INITIATE_PAYOUT);
+        return toBuilder()
+                .status(nextState)
+                .partnerReference(partnerRef)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Marks the payout as processing (partner acknowledged). Transitions PAYOUT_INITIATED -> PAYOUT_PROCESSING.
+     */
+    public PayoutOrder markPayoutProcessing() {
+        assertNotTerminal();
+        var nextState = STATE_MACHINE.transition(status, MARK_PAYOUT_PROCESSING);
+        return toBuilder()
+                .status(nextState)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Completes the payout. Transitions PAYOUT_PROCESSING -> COMPLETED.
+     */
+    public PayoutOrder completePayout(String partnerRef, Instant settledAt) {
+        assertNotTerminal();
+        if (settledAt == null) {
+            throw new IllegalArgumentException("Settlement timestamp is required");
+        }
+        var nextState = STATE_MACHINE.transition(status, COMPLETE_PAYOUT);
+        return toBuilder()
+                .status(nextState)
+                .partnerReference(partnerRef != null ? partnerRef : partnerReference)
+                .partnerSettledAt(settledAt)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Fails the payout. Can be triggered from PAYOUT_INITIATED or PAYOUT_PROCESSING.
+     */
+    public PayoutOrder failPayout(String reason) {
+        var nextState = STATE_MACHINE.transition(status, FAIL_PAYOUT);
+        return toBuilder()
+                .status(nextState)
+                .failureReason(reason)
+                .errorCode("FR-2003")
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Escalates to manual review. Can be triggered from REDEMPTION_FAILED or PAYOUT_FAILED.
+     */
+    public PayoutOrder escalateToManualReview() {
+        var nextState = STATE_MACHINE.transition(status, ESCALATE_MANUAL_REVIEW);
+        return toBuilder()
+                .status(nextState)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Holds stablecoin without redemption. Transitions PENDING -> STABLECOIN_HELD.
+     * Only valid for HOLD_STABLECOIN payout type.
+     */
+    public PayoutOrder holdStablecoin() {
+        assertNotTerminal();
+        if (payoutType != PayoutType.HOLD_STABLECOIN) {
+            throw new IllegalStateException(
+                    "holdStablecoin() is only valid for HOLD_STABLECOIN payout type, current: " + payoutType);
+        }
+        var nextState = STATE_MACHINE.transition(status, HOLD_STABLECOIN);
+        return toBuilder()
+                .status(nextState)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    /**
+     * Completes the hold. Transitions STABLECOIN_HELD -> COMPLETED.
+     */
+    public PayoutOrder completeHold() {
+        assertNotTerminal();
+        var nextState = STATE_MACHINE.transition(status, COMPLETE_HOLD);
+        return toBuilder()
+                .status(nextState)
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    // -- Query Methods ----------------------------------------------------
+
+    /**
+     * Returns true if this payout order is in a terminal state (COMPLETED or MANUAL_REVIEW).
+     */
+    public boolean isTerminal() {
+        return TERMINAL_STATES.contains(status);
+    }
+
+    /**
+     * Returns true if a given trigger can be applied from the current state.
+     */
+    public boolean canApply(PayoutTrigger trigger) {
+        return STATE_MACHINE.canTransition(status, trigger);
+    }
+
+    // -- Invariant Guards -------------------------------------------------
+
+    private void assertNotTerminal() {
+        if (isTerminal()) {
+            throw new IllegalStateException(
+                    "PayoutOrder %s is in terminal state %s and cannot be modified"
+                            .formatted(payoutId, status));
+        }
+    }
+
+    /**
+     * Validates that the fiat amount matches redeemedAmount * appliedFxRate within tolerance.
+     */
+    private void validateFiatAmountTolerance(BigDecimal receivedFiatAmount) {
+        var expectedFiat = redeemedAmount.multiply(appliedFxRate);
+        var difference = receivedFiatAmount.subtract(expectedFiat).abs();
+        if (difference.compareTo(FIAT_AMOUNT_TOLERANCE) > 0) {
+            throw new IllegalArgumentException(
+                    "Fiat amount %s exceeds tolerance ±%s from expected %s (redeemed %s * rate %s)"
+                            .formatted(receivedFiatAmount, FIAT_AMOUNT_TOLERANCE,
+                                    expectedFiat, redeemedAmount, appliedFxRate));
+        }
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutStatus.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutStatus.java
@@ -1,0 +1,14 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public enum PayoutStatus {
+    PENDING,
+    REDEEMING,
+    REDEEMED,
+    REDEMPTION_FAILED,
+    PAYOUT_INITIATED,
+    PAYOUT_PROCESSING,
+    COMPLETED,
+    PAYOUT_FAILED,
+    MANUAL_REVIEW,
+    STABLECOIN_HELD
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutTrigger.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutTrigger.java
@@ -1,0 +1,14 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public enum PayoutTrigger {
+    START_REDEMPTION,
+    COMPLETE_REDEMPTION,
+    FAIL_REDEMPTION,
+    INITIATE_PAYOUT,
+    MARK_PAYOUT_PROCESSING,
+    COMPLETE_PAYOUT,
+    FAIL_PAYOUT,
+    ESCALATE_MANUAL_REVIEW,
+    HOLD_STABLECOIN,
+    COMPLETE_HOLD
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutType.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/PayoutType.java
@@ -1,0 +1,6 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+public enum PayoutType {
+    FIAT,
+    HOLD_STABLECOIN
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/StablecoinRedemption.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/StablecoinRedemption.java
@@ -1,0 +1,70 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Entity representing a stablecoin redemption for a payout order.
+ * <p>
+ * Created when Circle (or another redemption provider) confirms the
+ * conversion from stablecoin to fiat currency.
+ */
+@Builder(toBuilder = true, access = AccessLevel.PACKAGE)
+public record StablecoinRedemption(
+        UUID redemptionId,
+        UUID payoutId,
+        StablecoinTicker stablecoin,
+        BigDecimal redeemedAmount,
+        BigDecimal fiatReceived,
+        String fiatCurrency,
+        String partner,
+        String partnerReference,
+        Instant redeemedAt
+) {
+
+    /**
+     * Creates a new StablecoinRedemption.
+     */
+    public static StablecoinRedemption create(UUID payoutId, StablecoinTicker stablecoin,
+                                              BigDecimal redeemedAmount, BigDecimal fiatReceived,
+                                              String fiatCurrency, String partner,
+                                              String partnerReference) {
+        if (payoutId == null) {
+            throw new IllegalArgumentException("payoutId is required");
+        }
+        if (stablecoin == null) {
+            throw new IllegalArgumentException("stablecoin is required");
+        }
+        if (redeemedAmount == null || redeemedAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("redeemedAmount must be positive");
+        }
+        if (fiatReceived == null || fiatReceived.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("fiatReceived must be positive");
+        }
+        if (fiatCurrency == null || fiatCurrency.isBlank()) {
+            throw new IllegalArgumentException("fiatCurrency is required");
+        }
+        if (partner == null || partner.isBlank()) {
+            throw new IllegalArgumentException("partner is required");
+        }
+        if (partnerReference == null || partnerReference.isBlank()) {
+            throw new IllegalArgumentException("partnerReference is required");
+        }
+
+        return StablecoinRedemption.builder()
+                .redemptionId(UUID.randomUUID())
+                .payoutId(payoutId)
+                .stablecoin(stablecoin)
+                .redeemedAmount(redeemedAmount)
+                .fiatReceived(fiatReceived)
+                .fiatCurrency(fiatCurrency)
+                .partner(partner)
+                .partnerReference(partnerReference)
+                .redeemedAt(Instant.now())
+                .build();
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/StablecoinTicker.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/model/StablecoinTicker.java
@@ -1,0 +1,40 @@
+package com.stablecoin.payments.offramp.domain.model;
+
+import java.util.Map;
+
+public record StablecoinTicker(String ticker, String issuer, int decimals) {
+
+    private static final Map<String, StablecoinInfo> SUPPORTED = Map.of(
+            "USDC", new StablecoinInfo("circle", 6),
+            "USDT", new StablecoinInfo("tether", 6),
+            "EURC", new StablecoinInfo("circle_euro", 6),
+            "PYUSD", new StablecoinInfo("paypal", 6),
+            "RLUSD", new StablecoinInfo("ripple", 6)
+    );
+
+    private record StablecoinInfo(String issuer, int decimals) {}
+
+    public StablecoinTicker {
+        if (ticker == null || ticker.isBlank()) {
+            throw new IllegalArgumentException("Ticker is required");
+        }
+        var info = SUPPORTED.get(ticker);
+        if (info == null) {
+            throw new IllegalArgumentException(
+                    "Unsupported stablecoin: %s. Must be one of: %s".formatted(ticker, SUPPORTED.keySet()));
+        }
+        if (issuer == null || issuer.isBlank()) {
+            issuer = info.issuer();
+        }
+        if (decimals <= 0) {
+            decimals = info.decimals();
+        }
+    }
+
+    /**
+     * Factory that auto-fills issuer and decimals from the ticker.
+     */
+    public static StablecoinTicker of(String ticker) {
+        return new StablecoinTicker(ticker, null, 0);
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/OffRampTransactionRepository.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/OffRampTransactionRepository.java
@@ -1,0 +1,16 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+import com.stablecoin.payments.offramp.domain.model.OffRampTransaction;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OffRampTransactionRepository {
+
+    OffRampTransaction save(OffRampTransaction transaction);
+
+    Optional<OffRampTransaction> findById(UUID offRampTxnId);
+
+    List<OffRampTransaction> findByPayoutId(UUID payoutId);
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutEventPublisher.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutEventPublisher.java
@@ -1,0 +1,6 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+public interface PayoutEventPublisher {
+
+    void publish(Object event);
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutOrderRepository.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutOrderRepository.java
@@ -1,0 +1,23 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+import com.stablecoin.payments.offramp.domain.model.PayoutOrder;
+import com.stablecoin.payments.offramp.domain.model.PayoutStatus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PayoutOrderRepository {
+
+    PayoutOrder save(PayoutOrder order);
+
+    Optional<PayoutOrder> findById(UUID payoutId);
+
+    Optional<PayoutOrder> findByPaymentId(UUID paymentId);
+
+    Optional<PayoutOrder> findByPartnerReference(String partnerReference);
+
+    List<PayoutOrder> findByStatus(PayoutStatus status);
+
+    List<PayoutOrder> findByRecipientId(UUID recipientId);
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutPartnerGateway.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutPartnerGateway.java
@@ -1,0 +1,10 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+/**
+ * Port for fiat payout via off-ramp partners (e.g., Modulr SEPA, CurrencyCloud).
+ * Initiates the actual fiat disbursement to the recipient's bank or mobile money account.
+ */
+public interface PayoutPartnerGateway {
+
+    PayoutResult initiatePayout(PayoutRequest request);
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutRequest.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutRequest.java
@@ -1,0 +1,25 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+import com.stablecoin.payments.offramp.domain.model.BankAccount;
+import com.stablecoin.payments.offramp.domain.model.MobileMoneyAccount;
+import com.stablecoin.payments.offramp.domain.model.PartnerIdentifier;
+import com.stablecoin.payments.offramp.domain.model.PaymentRail;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Port DTO for initiating a fiat payout with an off-ramp partner.
+ * <p>
+ * This is different from the API PayoutRequest — this is the domain's
+ * outbound request to the partner gateway.
+ */
+public record PayoutRequest(
+        UUID payoutId,
+        BigDecimal fiatAmount,
+        String currency,
+        BankAccount bankAccount,
+        MobileMoneyAccount mobileMoneyAccount,
+        PaymentRail paymentRail,
+        PartnerIdentifier partnerIdentifier
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutResult.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/PayoutResult.java
@@ -1,0 +1,9 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+import java.time.Instant;
+
+public record PayoutResult(
+        String partnerReference,
+        String status,
+        Instant settledAt
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/RedemptionGateway.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/RedemptionGateway.java
@@ -1,0 +1,10 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+/**
+ * Port for stablecoin redemption (e.g., Circle USDC redemption).
+ * Converts stablecoins to fiat currency.
+ */
+public interface RedemptionGateway {
+
+    RedemptionResult redeem(RedemptionRequest request);
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/RedemptionRequest.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/RedemptionRequest.java
@@ -1,0 +1,10 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record RedemptionRequest(
+        UUID payoutId,
+        String stablecoin,
+        BigDecimal amount
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/RedemptionResult.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/RedemptionResult.java
@@ -1,0 +1,11 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record RedemptionResult(
+        String partnerReference,
+        BigDecimal fiatReceived,
+        String fiatCurrency,
+        Instant redeemedAt
+) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/StablecoinRedemptionRepository.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/port/StablecoinRedemptionRepository.java
@@ -1,0 +1,15 @@
+package com.stablecoin.payments.offramp.domain.port;
+
+import com.stablecoin.payments.offramp.domain.model.StablecoinRedemption;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface StablecoinRedemptionRepository {
+
+    StablecoinRedemption save(StablecoinRedemption redemption);
+
+    Optional<StablecoinRedemption> findById(UUID redemptionId);
+
+    Optional<StablecoinRedemption> findByPayoutId(UUID payoutId);
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/statemachine/StateMachine.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/statemachine/StateMachine.java
@@ -1,0 +1,25 @@
+package com.stablecoin.payments.offramp.domain.statemachine;
+
+import java.util.List;
+
+public class StateMachine<S, T> {
+
+    private final List<StateTransition<S, T>> transitions;
+
+    public StateMachine(List<StateTransition<S, T>> transitions) {
+        this.transitions = List.copyOf(transitions);
+    }
+
+    public S transition(S currentState, T trigger) {
+        return transitions.stream()
+                .filter(t -> t.from().equals(currentState) && t.trigger().equals(trigger))
+                .map(StateTransition::to)
+                .findFirst()
+                .orElseThrow(() -> StateMachineException.invalidTransition(currentState, trigger));
+    }
+
+    public boolean canTransition(S currentState, T trigger) {
+        return transitions.stream()
+                .anyMatch(t -> t.from().equals(currentState) && t.trigger().equals(trigger));
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/statemachine/StateMachineException.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/statemachine/StateMachineException.java
@@ -1,0 +1,13 @@
+package com.stablecoin.payments.offramp.domain.statemachine;
+
+public class StateMachineException extends RuntimeException {
+
+    private StateMachineException(String message) {
+        super(message);
+    }
+
+    public static <S, T> StateMachineException invalidTransition(S state, T trigger) {
+        return new StateMachineException(
+                "Invalid transition: state=%s trigger=%s".formatted(state, trigger));
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/statemachine/StateTransition.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/statemachine/StateTransition.java
@@ -1,0 +1,3 @@
+package com.stablecoin.payments.offramp.domain.statemachine;
+
+public record StateTransition<S, T>(S from, T trigger, S to) {}


### PR DESCRIPTION
## Summary
- PayoutOrder aggregate with 10-state machine (12 transitions), FIAT + HOLD_STABLECOIN paths
- StablecoinRedemption entity, OffRampTransaction entity
- 5 value objects: BankAccount, MobileMoneyAccount, PartnerIdentifier, Money, StablecoinTicker
- 4 domain events, 6 ports (3 repos + 2 gateways + 1 publisher), 4 port DTOs
- 4 domain exceptions (FR-1003, FR-2001, FR-2002, FR-2003)
- Generic StateMachine<S,T> reusable component
- 35 new files, 998 lines

## State Machine
```
PENDING → REDEEMING → REDEEMED → PAYOUT_INITIATED → PAYOUT_PROCESSING → COMPLETED
                    → REDEMPTION_FAILED → MANUAL_REVIEW
                                        → PAYOUT_FAILED → MANUAL_REVIEW
PENDING → STABLECOIN_HELD → COMPLETED (HOLD path)
```

## Test plan
- [x] All 8 ArchUnit tests pass (domain purity verified)
- [x] Spotless clean
- [ ] CI green

Closes STA-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive fiat off-ramp payment processing infrastructure supporting multiple payment methods (bank accounts, mobile money).
  * Implemented state machine-driven payout lifecycle management with support for redemption, processing, and completion workflows.
  * Introduced event-based architecture for publishing and tracking payout events.
  * Added integration framework for partner payment gateways and stablecoin redemption services.
  * Enabled support for various payment rails (SEPA, PIX, UPI, and more) and stablecoin types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->