### PR TITLE
feat(s5): application controllers + PayoutCommandHandler (STA-154)

### DIFF
--- a/fiat-off-ramp/fiat-off-ramp-api/src/main/java/com/stablecoin/payments/offramp/api/PayoutRequest.java
+++ b/fiat-off-ramp/fiat-off-ramp-api/src/main/java/com/stablecoin/payments/offramp/api/PayoutRequest.java
@@ -20,5 +20,12 @@ public record PayoutRequest(
         @NotBlank String recipientAccountHash,
         @NotBlank String paymentRail,
         @NotBlank String offRampPartnerId,
-        @NotBlank String offRampPartnerName
+        @NotBlank String offRampPartnerName,
+        String bankAccountNumber,
+        String bankCode,
+        String bankAccountType,
+        String bankAccountCountry,
+        String mobileMoneyProvider,
+        String mobileMoneyPhoneNumber,
+        String mobileMoneyCountry
 ) {}

--- a/fiat-off-ramp/fiat-off-ramp-client/src/main/java/com/stablecoin/payments/offramp/client/FiatOffRampClient.java
+++ b/fiat-off-ramp/fiat-off-ramp-client/src/main/java/com/stablecoin/payments/offramp/client/FiatOffRampClient.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
@@ -18,4 +19,7 @@ public interface FiatOffRampClient {
 
     @GetMapping(value = "/v1/payouts/{payoutId}", produces = "application/json")
     PayoutResponse getPayout(@PathVariable("payoutId") UUID payoutId);
+
+    @GetMapping(value = "/v1/payouts", produces = "application/json")
+    PayoutResponse getPayoutByPaymentId(@RequestParam("paymentId") UUID paymentId);
 }

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/application/controller/GlobalExceptionHandler.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/application/controller/GlobalExceptionHandler.java
@@ -1,6 +1,10 @@
 package com.stablecoin.payments.offramp.application.controller;
 
 import com.stablecoin.payments.offramp.api.ApiError;
+import com.stablecoin.payments.offramp.domain.exception.PayoutNotFoundException;
+import com.stablecoin.payments.offramp.domain.exception.PayoutNotRefundableException;
+import com.stablecoin.payments.offramp.domain.exception.PayoutPartnerException;
+import com.stablecoin.payments.offramp.domain.exception.RedemptionFailedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
@@ -12,13 +16,16 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.stream.Collectors;
 
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 /**
  * Global exception handler for the Fiat Off-Ramp service.
- * Maps domain exceptions to appropriate HTTP responses with OF-XXXX error codes.
+ * Maps domain exceptions to appropriate HTTP responses with error codes.
  */
 @Slf4j
 @RestControllerAdvice
@@ -42,6 +49,38 @@ public class GlobalExceptionHandler {
         log.info("Type mismatch for parameter '{}': {}", ex.getName(), ex.getMessage());
         return ApiError.of("OF-0001", BAD_REQUEST.getReasonPhrase(),
                 "Invalid value for parameter '" + ex.getName() + "'");
+    }
+
+    @ResponseStatus(NOT_FOUND)
+    @ExceptionHandler(PayoutNotFoundException.class)
+    public ApiError handlePayoutNotFound(PayoutNotFoundException ex) {
+        log.info("Payout not found: {}", ex.getMessage());
+        return ApiError.of(PayoutNotFoundException.ERROR_CODE, NOT_FOUND.getReasonPhrase(),
+                ex.getMessage());
+    }
+
+    @ResponseStatus(UNPROCESSABLE_ENTITY)
+    @ExceptionHandler(RedemptionFailedException.class)
+    public ApiError handleRedemptionFailed(RedemptionFailedException ex) {
+        log.warn("Redemption failed: {}", ex.getMessage());
+        return ApiError.of(RedemptionFailedException.ERROR_CODE, UNPROCESSABLE_ENTITY.getReasonPhrase(),
+                ex.getMessage());
+    }
+
+    @ResponseStatus(BAD_GATEWAY)
+    @ExceptionHandler(PayoutPartnerException.class)
+    public ApiError handlePayoutPartnerError(PayoutPartnerException ex) {
+        log.warn("Payout partner error: {}", ex.getMessage());
+        return ApiError.of(PayoutPartnerException.ERROR_CODE, BAD_GATEWAY.getReasonPhrase(),
+                ex.getMessage());
+    }
+
+    @ResponseStatus(CONFLICT)
+    @ExceptionHandler(PayoutNotRefundableException.class)
+    public ApiError handlePayoutNotRefundable(PayoutNotRefundableException ex) {
+        log.info("Payout not refundable: {}", ex.getMessage());
+        return ApiError.of(PayoutNotRefundableException.ERROR_CODE, CONFLICT.getReasonPhrase(),
+                ex.getMessage());
     }
 
     @ResponseStatus(CONFLICT)

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/application/controller/PayoutController.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/application/controller/PayoutController.java
@@ -1,0 +1,137 @@
+package com.stablecoin.payments.offramp.application.controller;
+
+import com.stablecoin.payments.offramp.api.PayoutRequest;
+import com.stablecoin.payments.offramp.api.PayoutResponse;
+import com.stablecoin.payments.offramp.domain.model.AccountType;
+import com.stablecoin.payments.offramp.domain.model.BankAccount;
+import com.stablecoin.payments.offramp.domain.model.MobileMoneyAccount;
+import com.stablecoin.payments.offramp.domain.model.MobileMoneyProvider;
+import com.stablecoin.payments.offramp.domain.model.PartnerIdentifier;
+import com.stablecoin.payments.offramp.domain.model.PaymentRail;
+import com.stablecoin.payments.offramp.domain.model.PayoutOrder;
+import com.stablecoin.payments.offramp.domain.model.PayoutType;
+import com.stablecoin.payments.offramp.domain.model.StablecoinTicker;
+import com.stablecoin.payments.offramp.domain.service.PayoutCommandHandler;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * REST controller for payout order lifecycle management.
+ * <p>
+ * Thin HTTP handler that delegates all business logic to {@link PayoutCommandHandler}.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/v1/payouts")
+@RequiredArgsConstructor
+public class PayoutController {
+
+    private final PayoutCommandHandler payoutCommandHandler;
+
+    /**
+     * Initiates a new payout order.
+     * <p>
+     * Idempotent: returns 200 OK with the existing order if the same paymentId
+     * is submitted again. Returns 202 ACCEPTED on first creation.
+     */
+    @PostMapping
+    public ResponseEntity<PayoutResponse> initiatePayout(
+            @Valid @RequestBody PayoutRequest request) {
+        log.info("POST /v1/payouts paymentId={}", request.paymentId());
+
+        var stablecoin = StablecoinTicker.of(request.stablecoin());
+        var payoutType = PayoutType.valueOf(request.payoutType());
+        var paymentRail = PaymentRail.valueOf(request.paymentRail());
+        var partner = new PartnerIdentifier(request.offRampPartnerId(), request.offRampPartnerName());
+        var bankAccount = buildBankAccount(request);
+        var mobileMoneyAccount = buildMobileMoneyAccount(request);
+
+        var result = payoutCommandHandler.initiatePayout(
+                request.paymentId(),
+                request.correlationId(),
+                request.transferId(),
+                payoutType,
+                stablecoin,
+                request.redeemedAmount(),
+                request.targetCurrency(),
+                request.appliedFxRate(),
+                request.recipientId(),
+                request.recipientAccountHash(),
+                bankAccount,
+                mobileMoneyAccount,
+                paymentRail,
+                partner);
+
+        var response = toPayoutResponse(result.order());
+        var status = result.created() ? HttpStatus.ACCEPTED : HttpStatus.OK;
+
+        return ResponseEntity.status(status).body(response);
+    }
+
+    /**
+     * Retrieves a payout order by its ID.
+     */
+    @GetMapping("/{payoutId}")
+    public PayoutResponse getPayout(@PathVariable UUID payoutId) {
+        log.info("GET /v1/payouts/{}", payoutId);
+        return toPayoutResponse(payoutCommandHandler.getPayout(payoutId));
+    }
+
+    /**
+     * Retrieves a payout order by its associated payment ID.
+     */
+    @GetMapping
+    public PayoutResponse getPayoutByPaymentId(@RequestParam UUID paymentId) {
+        log.info("GET /v1/payouts?paymentId={}", paymentId);
+        return toPayoutResponse(payoutCommandHandler.getPayoutByPaymentId(paymentId));
+    }
+
+    private PayoutResponse toPayoutResponse(PayoutOrder order) {
+        return new PayoutResponse(
+                order.payoutId(),
+                order.paymentId(),
+                order.status().name(),
+                order.payoutType().name(),
+                order.fiatAmount(),
+                order.targetCurrency(),
+                order.paymentRail().name(),
+                order.offRampPartner().partnerName(),
+                order.partnerReference(),
+                order.partnerSettledAt(),
+                order.createdAt(),
+                order.partnerSettledAt());
+    }
+
+    private BankAccount buildBankAccount(PayoutRequest request) {
+        if (request.bankAccountNumber() == null || request.bankAccountNumber().isBlank()) {
+            return null;
+        }
+        return new BankAccount(
+                request.bankAccountNumber(),
+                request.bankCode(),
+                AccountType.valueOf(request.bankAccountType()),
+                request.bankAccountCountry());
+    }
+
+    private MobileMoneyAccount buildMobileMoneyAccount(PayoutRequest request) {
+        if (request.mobileMoneyProvider() == null || request.mobileMoneyProvider().isBlank()) {
+            return null;
+        }
+        return new MobileMoneyAccount(
+                MobileMoneyProvider.valueOf(request.mobileMoneyProvider()),
+                request.mobileMoneyPhoneNumber(),
+                request.mobileMoneyCountry());
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/service/PayoutCommandHandler.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/service/PayoutCommandHandler.java
@@ -1,0 +1,187 @@
+package com.stablecoin.payments.offramp.domain.service;
+
+import com.stablecoin.payments.offramp.domain.event.FiatPayoutInitiatedEvent;
+import com.stablecoin.payments.offramp.domain.event.StablecoinRedeemedEvent;
+import com.stablecoin.payments.offramp.domain.exception.PayoutNotFoundException;
+import com.stablecoin.payments.offramp.domain.model.BankAccount;
+import com.stablecoin.payments.offramp.domain.model.MobileMoneyAccount;
+import com.stablecoin.payments.offramp.domain.model.OffRampTransaction;
+import com.stablecoin.payments.offramp.domain.model.PartnerIdentifier;
+import com.stablecoin.payments.offramp.domain.model.PaymentRail;
+import com.stablecoin.payments.offramp.domain.model.PayoutOrder;
+import com.stablecoin.payments.offramp.domain.model.PayoutType;
+import com.stablecoin.payments.offramp.domain.model.StablecoinRedemption;
+import com.stablecoin.payments.offramp.domain.model.StablecoinTicker;
+import com.stablecoin.payments.offramp.domain.port.OffRampTransactionRepository;
+import com.stablecoin.payments.offramp.domain.port.PayoutEventPublisher;
+import com.stablecoin.payments.offramp.domain.port.PayoutOrderRepository;
+import com.stablecoin.payments.offramp.domain.port.PayoutPartnerGateway;
+import com.stablecoin.payments.offramp.domain.port.RedemptionGateway;
+import com.stablecoin.payments.offramp.domain.port.RedemptionRequest;
+import com.stablecoin.payments.offramp.domain.port.StablecoinRedemptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Domain command handler for payout order operations.
+ * <p>
+ * Orchestrates: idempotency check → create order → redeem stablecoin →
+ * initiate partner payout → record audit trail → publish events.
+ */
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PayoutCommandHandler {
+
+    private final PayoutOrderRepository payoutOrderRepository;
+    private final StablecoinRedemptionRepository stablecoinRedemptionRepository;
+    private final OffRampTransactionRepository offRampTransactionRepository;
+    private final RedemptionGateway redemptionGateway;
+    private final PayoutPartnerGateway payoutPartnerGateway;
+    private final PayoutEventPublisher eventPublisher;
+
+    /**
+     * Initiates a new payout order for a payment.
+     * <p>
+     * Idempotent: if a payout order already exists for the given paymentId,
+     * returns the existing order with {@code created = false}.
+     * <p>
+     * For HOLD_STABLECOIN type: skips redemption and payout, transitions directly
+     * to STABLECOIN_HELD → COMPLETED.
+     * <p>
+     * For FIAT type: redeems stablecoin via RedemptionGateway, then initiates
+     * fiat payout via PayoutPartnerGateway.
+     */
+    public PayoutResult initiatePayout(UUID paymentId, UUID correlationId, UUID transferId,
+                                       PayoutType payoutType, StablecoinTicker stablecoin,
+                                       BigDecimal redeemedAmount, String targetCurrency,
+                                       BigDecimal appliedFxRate, UUID recipientId,
+                                       String recipientAccountHash,
+                                       BankAccount bankAccount, MobileMoneyAccount mobileMoneyAccount,
+                                       PaymentRail paymentRail, PartnerIdentifier offRampPartner) {
+        // 1. Idempotency: check if payout order already exists for this paymentId
+        var existing = payoutOrderRepository.findByPaymentId(paymentId);
+        if (existing.isPresent()) {
+            log.info("Payout order already exists for paymentId={} payoutId={} status={}",
+                    paymentId, existing.get().payoutId(), existing.get().status());
+            return new PayoutResult(existing.get(), false);
+        }
+
+        // 2. Create new payout order in PENDING state
+        var order = PayoutOrder.create(paymentId, correlationId, transferId,
+                payoutType, stablecoin, redeemedAmount, targetCurrency,
+                appliedFxRate, recipientId, recipientAccountHash,
+                bankAccount, mobileMoneyAccount, paymentRail, offRampPartner);
+
+        // 3. HOLD_STABLECOIN path: skip redemption and payout
+        if (payoutType == PayoutType.HOLD_STABLECOIN) {
+            order = order.holdStablecoin().completeHold();
+            order = payoutOrderRepository.save(order);
+            log.info("Payout held as stablecoin payoutId={} paymentId={}",
+                    order.payoutId(), paymentId);
+            return new PayoutResult(order, true);
+        }
+
+        // 4. FIAT path: redeem stablecoin
+        order = order.startRedemption();
+        var redemptionResult = redemptionGateway.redeem(new RedemptionRequest(
+                order.payoutId(), stablecoin.ticker(), redeemedAmount));
+
+        // 5. Complete redemption with fiat amount
+        order = order.completeRedemption(redemptionResult.fiatReceived());
+
+        // 6. Record StablecoinRedemption
+        var redemption = StablecoinRedemption.create(
+                order.payoutId(), stablecoin, redeemedAmount,
+                redemptionResult.fiatReceived(), redemptionResult.fiatCurrency(),
+                offRampPartner.partnerName(), redemptionResult.partnerReference());
+        stablecoinRedemptionRepository.save(redemption);
+
+        // 7. Publish StablecoinRedeemedEvent via outbox
+        eventPublisher.publish(new StablecoinRedeemedEvent(
+                redemption.redemptionId(),
+                order.payoutId(),
+                paymentId,
+                correlationId,
+                stablecoin.ticker(),
+                redeemedAmount,
+                redemptionResult.fiatReceived(),
+                redemptionResult.fiatCurrency(),
+                redemptionResult.redeemedAt()));
+
+        // 8. Initiate fiat payout with partner
+        var payoutResult = payoutPartnerGateway.initiatePayout(
+                new com.stablecoin.payments.offramp.domain.port.PayoutRequest(
+                        order.payoutId(),
+                        order.fiatAmount(),
+                        targetCurrency,
+                        bankAccount,
+                        mobileMoneyAccount,
+                        paymentRail,
+                        offRampPartner));
+
+        // 9. Transition to PAYOUT_INITIATED
+        order = order.initiatePayout(payoutResult.partnerReference());
+
+        // 10. Record OffRampTransaction for audit trail
+        var offRampTxn = OffRampTransaction.create(
+                order.payoutId(),
+                offRampPartner.partnerName(),
+                "payout.initiated",
+                order.fiatAmount(),
+                targetCurrency,
+                payoutResult.status(),
+                null);
+        offRampTransactionRepository.save(offRampTxn);
+
+        // 11. Save payout order (final state)
+        order = payoutOrderRepository.save(order);
+
+        // 12. Publish FiatPayoutInitiatedEvent via outbox
+        eventPublisher.publish(new FiatPayoutInitiatedEvent(
+                order.payoutId(),
+                paymentId,
+                correlationId,
+                order.fiatAmount(),
+                targetCurrency,
+                paymentRail.name(),
+                offRampPartner.partnerName(),
+                Instant.now()));
+
+        log.info("Payout initiated payoutId={} paymentId={} partnerRef={}",
+                order.payoutId(), paymentId, payoutResult.partnerReference());
+
+        return new PayoutResult(order, true);
+    }
+
+    /**
+     * Retrieves a payout order by its ID.
+     *
+     * @param payoutId the payout order identifier
+     * @return the payout order
+     * @throws PayoutNotFoundException if the order is not found
+     */
+    public PayoutOrder getPayout(UUID payoutId) {
+        return payoutOrderRepository.findById(payoutId)
+                .orElseThrow(() -> new PayoutNotFoundException(payoutId));
+    }
+
+    /**
+     * Retrieves a payout order by its associated payment ID.
+     *
+     * @param paymentId the payment identifier
+     * @return the payout order
+     * @throws PayoutNotFoundException if the order is not found
+     */
+    public PayoutOrder getPayoutByPaymentId(UUID paymentId) {
+        return payoutOrderRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new PayoutNotFoundException(paymentId.toString()));
+    }
+}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/service/PayoutResult.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/java/com/stablecoin/payments/offramp/domain/service/PayoutResult.java
@@ -1,0 +1,9 @@
+package com.stablecoin.payments.offramp.domain.service;
+
+import com.stablecoin.payments.offramp.domain.model.PayoutOrder;
+
+/**
+ * Wrapper returned by {@link PayoutCommandHandler#initiatePayout}
+ * so the controller can distinguish 202 ACCEPTED (new) vs 200 OK (idempotent replay).
+ */
+public record PayoutResult(PayoutOrder order, boolean created) {}

--- a/fiat-off-ramp/fiat-off-ramp/src/test/java/com/stablecoin/payments/offramp/domain/service/PayoutCommandHandlerTest.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/test/java/com/stablecoin/payments/offramp/domain/service/PayoutCommandHandlerTest.java
@@ -1,0 +1,346 @@
+package com.stablecoin.payments.offramp.domain.service;
+
+import com.stablecoin.payments.offramp.domain.event.FiatPayoutInitiatedEvent;
+import com.stablecoin.payments.offramp.domain.event.StablecoinRedeemedEvent;
+import com.stablecoin.payments.offramp.domain.exception.PayoutNotFoundException;
+import com.stablecoin.payments.offramp.domain.model.OffRampTransaction;
+import com.stablecoin.payments.offramp.domain.model.PayoutOrder;
+import com.stablecoin.payments.offramp.domain.model.PayoutStatus;
+import com.stablecoin.payments.offramp.domain.model.PayoutType;
+import com.stablecoin.payments.offramp.domain.model.StablecoinRedemption;
+import com.stablecoin.payments.offramp.domain.port.OffRampTransactionRepository;
+import com.stablecoin.payments.offramp.domain.port.PayoutEventPublisher;
+import com.stablecoin.payments.offramp.domain.port.PayoutOrderRepository;
+import com.stablecoin.payments.offramp.domain.port.PayoutPartnerGateway;
+import com.stablecoin.payments.offramp.domain.port.PayoutResult;
+import com.stablecoin.payments.offramp.domain.port.RedemptionGateway;
+import com.stablecoin.payments.offramp.domain.port.RedemptionRequest;
+import com.stablecoin.payments.offramp.domain.port.RedemptionResult;
+import com.stablecoin.payments.offramp.domain.port.StablecoinRedemptionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.APPLIED_FX_RATE;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.CORRELATION_ID;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.EXPECTED_FIAT_AMOUNT;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.PAYMENT_ID;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.RECIPIENT_ACCOUNT_HASH;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.RECIPIENT_ID;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.REDEEMED_AMOUNT;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.TARGET_CURRENCY;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.TRANSFER_ID;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.aBankAccount;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.aPartnerIdentifier;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.aPendingOrder;
+import static com.stablecoin.payments.offramp.fixtures.PayoutOrderFixtures.aStablecoinTicker;
+import static com.stablecoin.payments.offramp.fixtures.TestUtils.eqIgnoring;
+import static com.stablecoin.payments.offramp.fixtures.TestUtils.eqIgnoringTimestamps;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PayoutCommandHandler")
+class PayoutCommandHandlerTest {
+
+    private static final String REDEMPTION_PARTNER_REF = "circle_redeem_ref_001";
+    private static final String PAYOUT_PARTNER_REF = "modulr_payout_ref_001";
+    private static final String FIAT_CURRENCY = "EUR";
+    private static final Instant REDEEMED_AT = Instant.parse("2026-03-10T10:00:00Z");
+
+    @Mock
+    private PayoutOrderRepository orderRepository;
+
+    @Mock
+    private StablecoinRedemptionRepository redemptionRepository;
+
+    @Mock
+    private OffRampTransactionRepository transactionRepository;
+
+    @Mock
+    private RedemptionGateway redemptionGateway;
+
+    @Mock
+    private PayoutPartnerGateway payoutPartnerGateway;
+
+    @Mock
+    private PayoutEventPublisher eventPublisher;
+
+    @InjectMocks
+    private PayoutCommandHandler handler;
+
+    @Nested
+    @DisplayName("initiatePayout — FIAT happy path")
+    class FiatHappyPath {
+
+        @Test
+        @DisplayName("should create order, redeem stablecoin, initiate payout, and publish events")
+        void shouldCreateOrderRedeemAndInitiatePayout() {
+            // Build expected final state: PENDING → REDEEMING → REDEEMED → PAYOUT_INITIATED
+            var pending = aPendingOrder();
+            var expectedFinal = pending.startRedemption()
+                    .completeRedemption(EXPECTED_FIAT_AMOUNT)
+                    .initiatePayout(PAYOUT_PARTNER_REF);
+
+            given(orderRepository.findByPaymentId(PAYMENT_ID))
+                    .willReturn(Optional.empty());
+            given(redemptionGateway.redeem(eqIgnoring(
+                    new RedemptionRequest(pending.payoutId(), "USDC", REDEEMED_AMOUNT),
+                    "payoutId")))
+                    .willReturn(new RedemptionResult(
+                            REDEMPTION_PARTNER_REF, EXPECTED_FIAT_AMOUNT, FIAT_CURRENCY, REDEEMED_AT));
+            given(payoutPartnerGateway.initiatePayout(eqIgnoring(
+                    new com.stablecoin.payments.offramp.domain.port.PayoutRequest(
+                            pending.payoutId(),
+                            EXPECTED_FIAT_AMOUNT,
+                            TARGET_CURRENCY,
+                            aBankAccount(),
+                            null,
+                            com.stablecoin.payments.offramp.domain.model.PaymentRail.SEPA,
+                            aPartnerIdentifier()),
+                    "payoutId")))
+                    .willReturn(new PayoutResult(PAYOUT_PARTNER_REF, "INITIATED", null));
+            given(orderRepository.save(eqIgnoring(expectedFinal, "payoutId")))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            handler.initiatePayout(
+                    PAYMENT_ID, CORRELATION_ID, TRANSFER_ID,
+                    PayoutType.FIAT, aStablecoinTicker(),
+                    REDEEMED_AMOUNT, TARGET_CURRENCY, APPLIED_FX_RATE,
+                    RECIPIENT_ID, RECIPIENT_ACCOUNT_HASH,
+                    aBankAccount(), null,
+                    com.stablecoin.payments.offramp.domain.model.PaymentRail.SEPA,
+                    aPartnerIdentifier());
+
+            then(orderRepository).should().save(eqIgnoring(expectedFinal, "payoutId"));
+        }
+
+        @Test
+        @DisplayName("should save StablecoinRedemption record")
+        void shouldSaveRedemptionRecord() {
+            stubFiatHappyPath();
+
+            callInitiatePayout();
+
+            var expectedRedemption = StablecoinRedemption.create(
+                    UUID.randomUUID(), aStablecoinTicker(), REDEEMED_AMOUNT,
+                    EXPECTED_FIAT_AMOUNT, FIAT_CURRENCY,
+                    aPartnerIdentifier().partnerName(), REDEMPTION_PARTNER_REF);
+            then(redemptionRepository).should().save(eqIgnoring(expectedRedemption, "redemptionId", "payoutId"));
+        }
+
+        @Test
+        @DisplayName("should save OffRampTransaction audit record")
+        void shouldSaveOffRampTransactionRecord() {
+            stubFiatHappyPath();
+
+            callInitiatePayout();
+
+            var expectedTxn = OffRampTransaction.create(
+                    UUID.randomUUID(), aPartnerIdentifier().partnerName(),
+                    "payout.initiated", EXPECTED_FIAT_AMOUNT, TARGET_CURRENCY,
+                    "INITIATED", null);
+            then(transactionRepository).should().save(eqIgnoring(expectedTxn, "offRampTxnId", "payoutId"));
+        }
+
+        @Test
+        @DisplayName("should publish StablecoinRedeemedEvent and FiatPayoutInitiatedEvent")
+        void shouldPublishEvents() {
+            stubFiatHappyPath();
+
+            callInitiatePayout();
+
+            var expectedRedeemedEvent = new StablecoinRedeemedEvent(
+                    UUID.randomUUID(), UUID.randomUUID(), PAYMENT_ID, CORRELATION_ID,
+                    "USDC", REDEEMED_AMOUNT, EXPECTED_FIAT_AMOUNT, FIAT_CURRENCY, REDEEMED_AT);
+            then(eventPublisher).should().publish(eqIgnoring(
+                    expectedRedeemedEvent, "redemptionId", "payoutId"));
+
+            var expectedInitiatedEvent = new FiatPayoutInitiatedEvent(
+                    UUID.randomUUID(), PAYMENT_ID, CORRELATION_ID,
+                    EXPECTED_FIAT_AMOUNT, TARGET_CURRENCY, "SEPA",
+                    aPartnerIdentifier().partnerName(), Instant.now());
+            then(eventPublisher).should().publish(eqIgnoring(
+                    expectedInitiatedEvent, "payoutId"));
+        }
+
+        @Test
+        @DisplayName("should return created=true for new payout")
+        void shouldReturnCreatedTrue() {
+            stubFiatHappyPath();
+
+            var result = callInitiatePayout();
+
+            assertThat(result.created()).isTrue();
+            assertThat(result.order().status()).isEqualTo(PayoutStatus.PAYOUT_INITIATED);
+        }
+
+        private void stubFiatHappyPath() {
+            var expectedFinal = aPendingOrder().startRedemption()
+                    .completeRedemption(EXPECTED_FIAT_AMOUNT)
+                    .initiatePayout(PAYOUT_PARTNER_REF);
+
+            given(orderRepository.findByPaymentId(PAYMENT_ID))
+                    .willReturn(Optional.empty());
+            given(redemptionGateway.redeem(eqIgnoring(
+                    new RedemptionRequest(UUID.randomUUID(), "USDC", REDEEMED_AMOUNT),
+                    "payoutId")))
+                    .willReturn(new RedemptionResult(
+                            REDEMPTION_PARTNER_REF, EXPECTED_FIAT_AMOUNT, FIAT_CURRENCY, REDEEMED_AT));
+            given(payoutPartnerGateway.initiatePayout(eqIgnoring(
+                    new com.stablecoin.payments.offramp.domain.port.PayoutRequest(
+                            UUID.randomUUID(), EXPECTED_FIAT_AMOUNT, TARGET_CURRENCY,
+                            aBankAccount(), null,
+                            com.stablecoin.payments.offramp.domain.model.PaymentRail.SEPA,
+                            aPartnerIdentifier()),
+                    "payoutId")))
+                    .willReturn(new PayoutResult(PAYOUT_PARTNER_REF, "INITIATED", null));
+            given(orderRepository.save(eqIgnoring(expectedFinal, "payoutId")))
+                    .willAnswer(inv -> inv.getArgument(0));
+        }
+
+        private com.stablecoin.payments.offramp.domain.service.PayoutResult callInitiatePayout() {
+            return handler.initiatePayout(
+                    PAYMENT_ID, CORRELATION_ID, TRANSFER_ID,
+                    PayoutType.FIAT, aStablecoinTicker(),
+                    REDEEMED_AMOUNT, TARGET_CURRENCY, APPLIED_FX_RATE,
+                    RECIPIENT_ID, RECIPIENT_ACCOUNT_HASH,
+                    aBankAccount(), null,
+                    com.stablecoin.payments.offramp.domain.model.PaymentRail.SEPA,
+                    aPartnerIdentifier());
+        }
+    }
+
+    @Nested
+    @DisplayName("initiatePayout — idempotency")
+    class Idempotency {
+
+        @Test
+        @DisplayName("should return existing order with created=false when paymentId already exists")
+        void shouldReturnExistingOrder() {
+            var existing = aPendingOrder();
+
+            given(orderRepository.findByPaymentId(PAYMENT_ID))
+                    .willReturn(Optional.of(existing));
+
+            var result = handler.initiatePayout(
+                    PAYMENT_ID, CORRELATION_ID, TRANSFER_ID,
+                    PayoutType.FIAT, aStablecoinTicker(),
+                    REDEEMED_AMOUNT, TARGET_CURRENCY, APPLIED_FX_RATE,
+                    RECIPIENT_ID, RECIPIENT_ACCOUNT_HASH,
+                    aBankAccount(), null,
+                    com.stablecoin.payments.offramp.domain.model.PaymentRail.SEPA,
+                    aPartnerIdentifier());
+
+            assertThat(result.created()).isFalse();
+            assertThat(result.order()).isEqualTo(existing);
+            then(redemptionGateway).shouldHaveNoInteractions();
+            then(payoutPartnerGateway).shouldHaveNoInteractions();
+            then(orderRepository).should(never()).save(eqIgnoringTimestamps(existing));
+        }
+    }
+
+    @Nested
+    @DisplayName("initiatePayout — HOLD_STABLECOIN path")
+    class HoldStablecoin {
+
+        @Test
+        @DisplayName("should skip redemption and payout, transition to COMPLETED via STABLECOIN_HELD")
+        void shouldHoldStablecoinAndComplete() {
+            var expectedOrder = PayoutOrder.create(
+                    PAYMENT_ID, CORRELATION_ID, TRANSFER_ID,
+                    PayoutType.HOLD_STABLECOIN, aStablecoinTicker(),
+                    REDEEMED_AMOUNT, TARGET_CURRENCY, APPLIED_FX_RATE,
+                    RECIPIENT_ID, RECIPIENT_ACCOUNT_HASH,
+                    aBankAccount(), null,
+                    com.stablecoin.payments.offramp.domain.model.PaymentRail.SEPA,
+                    aPartnerIdentifier()).holdStablecoin().completeHold();
+
+            given(orderRepository.findByPaymentId(PAYMENT_ID))
+                    .willReturn(Optional.empty());
+            given(orderRepository.save(eqIgnoring(expectedOrder, "payoutId")))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            var result = handler.initiatePayout(
+                    PAYMENT_ID, CORRELATION_ID, TRANSFER_ID,
+                    PayoutType.HOLD_STABLECOIN, aStablecoinTicker(),
+                    REDEEMED_AMOUNT, TARGET_CURRENCY, APPLIED_FX_RATE,
+                    RECIPIENT_ID, RECIPIENT_ACCOUNT_HASH,
+                    aBankAccount(), null,
+                    com.stablecoin.payments.offramp.domain.model.PaymentRail.SEPA,
+                    aPartnerIdentifier());
+
+            assertThat(result.created()).isTrue();
+            assertThat(result.order().status()).isEqualTo(PayoutStatus.COMPLETED);
+            then(orderRepository).should().save(eqIgnoring(expectedOrder, "payoutId"));
+            then(redemptionGateway).shouldHaveNoInteractions();
+            then(payoutPartnerGateway).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("getPayout")
+    class GetPayout {
+
+        @Test
+        @DisplayName("should return payout order by ID")
+        void shouldReturnPayoutById() {
+            var order = aPendingOrder();
+            given(orderRepository.findById(order.payoutId()))
+                    .willReturn(Optional.of(order));
+
+            var result = handler.getPayout(order.payoutId());
+
+            assertThat(result).isEqualTo(order);
+        }
+
+        @Test
+        @DisplayName("should throw PayoutNotFoundException when not found by ID")
+        void shouldThrowWhenNotFoundById() {
+            var payoutId = UUID.randomUUID();
+            given(orderRepository.findById(payoutId))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> handler.getPayout(payoutId))
+                    .isInstanceOf(PayoutNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPayoutByPaymentId")
+    class GetPayoutByPaymentId {
+
+        @Test
+        @DisplayName("should return payout order by payment ID")
+        void shouldReturnPayoutByPaymentId() {
+            var order = aPendingOrder();
+            given(orderRepository.findByPaymentId(PAYMENT_ID))
+                    .willReturn(Optional.of(order));
+
+            var result = handler.getPayoutByPaymentId(PAYMENT_ID);
+
+            assertThat(result).isEqualTo(order);
+        }
+
+        @Test
+        @DisplayName("should throw PayoutNotFoundException when not found by payment ID")
+        void shouldThrowWhenNotFoundByPaymentId() {
+            given(orderRepository.findByPaymentId(PAYMENT_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> handler.getPayoutByPaymentId(PAYMENT_ID))
+                    .isInstanceOf(PayoutNotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **PayoutController**: thin REST controller — `POST /v1/payouts` (202 ACCEPTED / 200 OK idempotent), `GET /v1/payouts/{id}`, `GET /v1/payouts?paymentId=`
- **PayoutCommandHandler**: domain orchestrator for FIAT path (redeem stablecoin → initiate partner payout → record audit → publish outbox events) and HOLD_STABLECOIN path (skip redemption, direct completion)
- **GlobalExceptionHandler**: added PayoutNotFoundException (404), RedemptionFailedException (422), PayoutPartnerException (502), PayoutNotRefundableException (409)
- **11 unit tests** covering happy path, idempotency, hold path, and query operations

## Design Decisions
- Controller → CommandHandler (direct, no intermediate service layer) per CLAUDE.md
- PayoutResult wrapper record for HTTP status distinction (created=true → 202, created=false → 200)
- All gateway stubs use `eqIgnoring(expected, "payoutId")` since payoutId is randomly generated

## Test plan
- [x] 11 PayoutCommandHandlerTest unit tests pass (FIAT happy path, idempotency, HOLD_STABLECOIN, getPayout, getPayoutByPaymentId)
- [x] All 212 service unit tests pass
- [x] Spotless formatting clean

Closes STA-154

🤖 Generated with [Claude Code](https://claude.com/claude-code)