### PR TITLE
fix(infra): add JVM shutdown hooks to stop Testcontainers after test execution

### DIFF
--- a/api-gateway-iam/api-gateway-iam/src/integration-test/java/com/stablecoin/payments/gateway/iam/AbstractIntegrationTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/integration-test/java/com/stablecoin/payments/gateway/iam/AbstractIntegrationTest.java
@@ -36,6 +36,11 @@ public abstract class AbstractIntegrationTest {
         POSTGRES.start();
         KAFKA.start();
         REDIS.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            REDIS.stop();
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/AbstractIntegrationTest.java
+++ b/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/AbstractIntegrationTest.java
@@ -30,6 +30,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/AbstractIntegrationTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/AbstractIntegrationTest.java
@@ -30,6 +30,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/fiat-off-ramp/fiat-off-ramp/src/integration-test/java/com/stablecoin/payments/offramp/AbstractIntegrationTest.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/integration-test/java/com/stablecoin/payments/offramp/AbstractIntegrationTest.java
@@ -30,6 +30,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/fiat-on-ramp/fiat-on-ramp/src/integration-test/java/com/stablecoin/payments/onramp/AbstractIntegrationTest.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/integration-test/java/com/stablecoin/payments/onramp/AbstractIntegrationTest.java
@@ -30,6 +30,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/AbstractIntegrationTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/AbstractIntegrationTest.java
@@ -32,6 +32,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/ledger-accounting/ledger-accounting/src/integration-test/java/com/stablecoin/payments/ledger/AbstractIntegrationTest.java
+++ b/ledger-accounting/ledger-accounting/src/integration-test/java/com/stablecoin/payments/ledger/AbstractIntegrationTest.java
@@ -30,6 +30,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/merchant-iam/merchant-iam/src/integration-test/java/com/stablecoin/payments/merchant/iam/AbstractIntegrationTest.java
+++ b/merchant-iam/merchant-iam/src/integration-test/java/com/stablecoin/payments/merchant/iam/AbstractIntegrationTest.java
@@ -50,6 +50,12 @@ public abstract class AbstractIntegrationTest {
         KAFKA.start();
         MAILPIT.start();
         REDIS.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            REDIS.stop();
+            MAILPIT.stop();
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired

--- a/merchant-onboarding/merchant-onboarding/src/integration-test/java/com/stablecoin/payments/merchant/onboarding/AbstractIntegrationTest.java
+++ b/merchant-onboarding/merchant-onboarding/src/integration-test/java/com/stablecoin/payments/merchant/onboarding/AbstractIntegrationTest.java
@@ -30,6 +30,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @DynamicPropertySource

--- a/payment-orchestrator/payment-orchestrator/src/integration-test/java/com/stablecoin/payments/orchestrator/AbstractIntegrationTest.java
+++ b/payment-orchestrator/payment-orchestrator/src/integration-test/java/com/stablecoin/payments/orchestrator/AbstractIntegrationTest.java
@@ -31,6 +31,10 @@ public abstract class AbstractIntegrationTest {
     static {
         POSTGRES.start();
         KAFKA.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            KAFKA.stop();
+            POSTGRES.stop();
+        }));
     }
 
     @Autowired


### PR DESCRIPTION
## Summary
- Add `Runtime.getRuntime().addShutdownHook()` to all 10 `AbstractIntegrationTest` classes
- Ensures Testcontainers (PostgreSQL, Kafka, Redis, Mailpit) are stopped when the JVM exits
- Fixes orphaned container accumulation (~30-50 containers / 5-15 GB leaked memory per test run)

## Test plan
- [x] Verified 21 orphaned containers cleaned up manually
- [x] Shutdown hooks added to all 10 services: S1, S2, S3, S4, S5, S6, S7, S10, S11, S13
- [ ] Run full `make test-integration` and verify `docker ps` shows 0 Testcontainers after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added graceful shutdown handling for test containers across all modules, ensuring external services (databases, message queues, etc.) are properly cleaned up when tests complete. Improves test reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->