### PR TITLE
fix(infra): harden Testcontainers shutdown hooks with safeStop

### DIFF
--- a/api-gateway-iam/api-gateway-iam/src/integration-test/java/com/stablecoin/payments/gateway/iam/AbstractIntegrationTest.java
+++ b/api-gateway-iam/api-gateway-iam/src/integration-test/java/com/stablecoin/payments/gateway/iam/AbstractIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -33,14 +34,31 @@ public abstract class AbstractIntegrationTest {
                     .withExposedPorts(6379);
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
-        REDIS.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+            REDIS.start();
+        } catch (RuntimeException ex) {
+            safeStop(REDIS);
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            REDIS.stop();
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(REDIS);
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/AbstractIntegrationTest.java
+++ b/blockchain-custody/blockchain-custody/src/integration-test/java/com/stablecoin/payments/custody/AbstractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -28,12 +29,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/AbstractIntegrationTest.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/integration-test/java/com/stablecoin/payments/compliance/AbstractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -28,12 +29,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/fiat-off-ramp/fiat-off-ramp/src/integration-test/java/com/stablecoin/payments/offramp/AbstractIntegrationTest.java
+++ b/fiat-off-ramp/fiat-off-ramp/src/integration-test/java/com/stablecoin/payments/offramp/AbstractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -28,12 +29,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/fiat-on-ramp/fiat-on-ramp/src/integration-test/java/com/stablecoin/payments/onramp/AbstractIntegrationTest.java
+++ b/fiat-on-ramp/fiat-on-ramp/src/integration-test/java/com/stablecoin/payments/onramp/AbstractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -28,12 +29,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/AbstractIntegrationTest.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/java/com/stablecoin/payments/fx/AbstractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -30,12 +31,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/ledger-accounting/ledger-accounting/src/integration-test/java/com/stablecoin/payments/ledger/AbstractIntegrationTest.java
+++ b/ledger-accounting/ledger-accounting/src/integration-test/java/com/stablecoin/payments/ledger/AbstractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -28,12 +29,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/merchant-iam/merchant-iam/src/integration-test/java/com/stablecoin/payments/merchant/iam/AbstractIntegrationTest.java
+++ b/merchant-iam/merchant-iam/src/integration-test/java/com/stablecoin/payments/merchant/iam/AbstractIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.UUID;
@@ -46,16 +47,34 @@ public abstract class AbstractIntegrationTest {
                     .withExposedPorts(6379);
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
-        MAILPIT.start();
-        REDIS.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+            MAILPIT.start();
+            REDIS.start();
+        } catch (RuntimeException ex) {
+            safeStop(REDIS);
+            safeStop(MAILPIT);
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            REDIS.stop();
-            MAILPIT.stop();
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(REDIS);
+            safeStop(MAILPIT);
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired

--- a/merchant-onboarding/merchant-onboarding/src/integration-test/java/com/stablecoin/payments/merchant/onboarding/AbstractIntegrationTest.java
+++ b/merchant-onboarding/merchant-onboarding/src/integration-test/java/com/stablecoin/payments/merchant/onboarding/AbstractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -28,12 +29,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @DynamicPropertySource

--- a/payment-orchestrator/payment-orchestrator/src/integration-test/java/com/stablecoin/payments/orchestrator/AbstractIntegrationTest.java
+++ b/payment-orchestrator/payment-orchestrator/src/integration-test/java/com/stablecoin/payments/orchestrator/AbstractIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("resource")
@@ -29,12 +30,28 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
 
     static {
-        POSTGRES.start();
-        KAFKA.start();
+        try {
+            POSTGRES.start();
+            KAFKA.start();
+        } catch (RuntimeException ex) {
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+            throw ex;
+        }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            KAFKA.stop();
-            POSTGRES.stop();
-        }));
+            safeStop(KAFKA);
+            safeStop(POSTGRES);
+        }, "testcontainers-shutdown"));
+    }
+
+    private static void safeStop(Startable container) {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
     }
 
     @Autowired


### PR DESCRIPTION
## Summary
- Add `safeStop(Startable)` helper to all 10 `AbstractIntegrationTest` classes
- Wrap each `container.stop()` in try/catch so one failure doesn't skip remaining cleanups
- Wrap startup sequence in try/catch to stop already-started containers on failure
- Name shutdown threads `"testcontainers-shutdown"` for diagnostics

Addresses CodeRabbit review on PR #189.

## Test plan
- [x] All 10 AbstractIntegrationTest files updated with consistent pattern
- [x] Spotless check passes
- [x] Unit tests pass across all 10 services
- [ ] Integration tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test container lifecycle: guarded startup with best-effort cleanup on failures.
  * Updated shutdown behavior to perform safer, resilient container stops and avoid masking errors.
  * Added centralized best-effort stop utility for more reliable test teardown.
  * No changes to public APIs or exported signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->