### PR TITLE
feat(infra): add HTTP read timeout on all external REST clients (STA-240)

### DIFF
--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/chainalysis/ChainalysisAmlAdapter.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/chainalysis/ChainalysisAmlAdapter.java
@@ -41,11 +41,14 @@ public class ChainalysisAmlAdapter implements AmlProvider {
                 .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
                 .build();
 
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
         this.restClient = RestClient.builder()
                 .baseUrl(properties.baseUrl())
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Token " + properties.apiKey())
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .requestFactory(requestFactory)
                 .build();
     }
 

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoKycAdapter.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/onfido/OnfidoKycAdapter.java
@@ -42,11 +42,14 @@ public class OnfidoKycAdapter implements KycProvider {
                 .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
                 .build();
 
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
         this.restClient = RestClient.builder()
                 .baseUrl(properties.baseUrl())
                 .defaultHeader("Authorization", "Token token=" + properties.apiToken())
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .requestFactory(requestFactory)
                 .build();
 
         this.redisTemplate = redisTemplate;

--- a/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/worldcheck/WorldCheckSanctionsAdapter.java
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/java/com/stablecoin/payments/compliance/infrastructure/provider/worldcheck/WorldCheckSanctionsAdapter.java
@@ -37,11 +37,14 @@ public class WorldCheckSanctionsAdapter implements SanctionsProvider {
                 .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
                 .build();
 
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
         this.restClient = RestClient.builder()
                 .baseUrl(properties.baseUrl())
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.apiKey())
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .requestFactory(requestFactory)
                 .build();
     }
 

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/infrastructure/provider/refinitiv/RefinitivRateAdapter.java
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/java/com/stablecoin/payments/fx/infrastructure/provider/refinitiv/RefinitivRateAdapter.java
@@ -35,10 +35,13 @@ public class RefinitivRateAdapter implements RateProvider {
                 .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
                 .build();
 
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
         this.restClient = RestClient.builder()
                 .baseUrl(properties.baseUrl())
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.apiKey())
-                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .requestFactory(requestFactory)
                 .build();
     }
 

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/CompaniesHouseAdapter.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/CompaniesHouseAdapter.java
@@ -3,11 +3,15 @@ package com.stablecoin.payments.merchant.onboarding.infrastructure.kyb;
 import com.stablecoin.payments.merchant.onboarding.domain.merchant.CompanyRegistryProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
@@ -21,6 +25,7 @@ import java.util.Optional;
 @Slf4j
 @Component
 @ConditionalOnProperty(name = "app.company-registry.provider", havingValue = "companies-house")
+@EnableConfigurationProperties(CompaniesHouseProperties.class)
 public class CompaniesHouseAdapter implements CompanyRegistryProvider {
 
   private final RestClient restClient;
@@ -28,7 +33,16 @@ public class CompaniesHouseAdapter implements CompanyRegistryProvider {
   public CompaniesHouseAdapter(CompaniesHouseProperties properties) {
     var basicAuth = Base64.getEncoder().encodeToString((properties.apiKey() + ":").getBytes(StandardCharsets.UTF_8));
 
+    var httpClient = HttpClient.newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
+        .build();
+
+    var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+    requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
     this.restClient = RestClient.builder().baseUrl(properties.baseUrl())
+        .requestFactory(requestFactory)
         .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth).build();
   }
 

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/CompaniesHouseProperties.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/CompaniesHouseProperties.java
@@ -3,11 +3,14 @@ package com.stablecoin.payments.merchant.onboarding.infrastructure.kyb;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "companies-house")
-public record CompaniesHouseProperties(String apiKey, String baseUrl) {
+public record CompaniesHouseProperties(String apiKey, String baseUrl, int timeoutSeconds) {
 
   public CompaniesHouseProperties {
     if (baseUrl == null || baseUrl.isBlank()) {
       baseUrl = "https://api.company-information.service.gov.uk";
+    }
+    if (timeoutSeconds <= 0) {
+      timeoutSeconds = 30;
     }
   }
 }

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/OnfidoKybAdapter.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/OnfidoKybAdapter.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.net.http.HttpClient;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -41,9 +42,16 @@ public class OnfidoKybAdapter implements KybProvider {
 
   public OnfidoKybAdapter(OnfidoProperties properties) {
     this.properties = properties;
-    var httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+    var httpClient = HttpClient.newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .connectTimeout(Duration.ofSeconds(properties.timeoutSeconds()))
+        .build();
+
+    var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+    requestFactory.setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds()));
+
     this.restClient = RestClient.builder().baseUrl(properties.baseUrl())
-        .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+        .requestFactory(requestFactory)
         .defaultHeader(HttpHeaders.AUTHORIZATION, "Token token=" + properties.apiToken())
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).build();
   }

--- a/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/OnfidoProperties.java
+++ b/merchant-onboarding/merchant-onboarding/src/main/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/OnfidoProperties.java
@@ -3,7 +3,8 @@ package com.stablecoin.payments.merchant.onboarding.infrastructure.kyb;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "onfido")
-public record OnfidoProperties(String apiToken, String baseUrl, String webhookSecret, String region) {
+public record OnfidoProperties(String apiToken, String baseUrl, String webhookSecret, String region,
+                                int timeoutSeconds) {
 
   public OnfidoProperties {
     if (baseUrl == null || baseUrl.isBlank()) {
@@ -11,6 +12,9 @@ public record OnfidoProperties(String apiToken, String baseUrl, String webhookSe
     }
     if (region == null || region.isBlank()) {
       region = "EU";
+    }
+    if (timeoutSeconds <= 0) {
+      timeoutSeconds = 30;
     }
   }
 }

--- a/merchant-onboarding/merchant-onboarding/src/test/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/OnfidoKybAdapterTest.java
+++ b/merchant-onboarding/merchant-onboarding/src/test/java/com/stablecoin/payments/merchant/onboarding/infrastructure/kyb/OnfidoKybAdapterTest.java
@@ -20,7 +20,7 @@ class OnfidoKybAdapterTest {
     @Test
     @DisplayName("should return standard document types")
     void shouldReturnStandardDocumentTypes() {
-      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU");
+      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU", 30);
       // We can't easily call submit/getResult without a real HTTP server,
       // but getRequiredDocuments is pure logic
       var adapter = new OnfidoKybAdapter(properties);
@@ -34,7 +34,7 @@ class OnfidoKybAdapterTest {
     @Test
     @DisplayName("should return same documents regardless of country")
     void shouldReturnSameDocumentsRegardlessOfCountry() {
-      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU");
+      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU", 30);
       var adapter = new OnfidoKybAdapter(properties);
 
       var gbDocs = adapter.getRequiredDocuments("GB", null);
@@ -51,7 +51,7 @@ class OnfidoKybAdapterTest {
     @Test
     @DisplayName("should return null for non-check webhook events")
     void shouldReturnNullForNonCheckWebhookEvents() {
-      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU");
+      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU", 30);
       var adapter = new OnfidoKybAdapter(properties);
       var payload = Map.<String, Object>of("resource_type", "report", "action", "report.completed", "object",
           Map.of("id", "report-123", "status", "complete", "href", "https://api.onfido.com/reports/123"));
@@ -64,7 +64,7 @@ class OnfidoKybAdapterTest {
     @Test
     @DisplayName("should return null for non-completed check action")
     void shouldReturnNullForNonCompletedCheckAction() {
-      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU");
+      var properties = new OnfidoProperties("test-token", "https://api.eu.onfido.com/v3.6", null, "EU", 30);
       var adapter = new OnfidoKybAdapter(properties);
       var payload = Map.<String, Object>of("resource_type", "check", "action", "check.started", "object",
           Map.of("id", "check-123", "status", "in_progress", "href", "https://api.onfido.com/checks/123"));


### PR DESCRIPTION
## Summary
- Add explicit HTTP read timeouts to all external REST client adapters across S2, S6, and S11
- Previously only connect timeout was set via `HttpClient.connectTimeout()` — read timeout was unbounded
- Uses `JdkClientHttpRequestFactory.setReadTimeout()` to enforce read timeouts matching the existing connect timeout
- Add `timeoutSeconds` property to `CompaniesHouseProperties` and `OnfidoProperties` (S11) with 30s default
- Add `@EnableConfigurationProperties` to `CompaniesHouseAdapter`

## Affected adapters
| Service | Adapter |
|---------|---------|
| S2 Compliance | `ChainalysisAmlAdapter`, `OnfidoKycAdapter`, `WorldCheckSanctionsAdapter` |
| S6 FX Engine | `RefinitivRateAdapter` |
| S11 Onboarding | `CompaniesHouseAdapter`, `OnfidoKybAdapter` |

## Test plan
- [x] Existing adapter unit tests updated for new `OnfidoProperties` constructor
- [x] All adapters consistently apply both connect and read timeouts
- [ ] Verify timeout behavior under slow external API responses

Closes STA-240

🤖 Generated with [Claude Code](https://claude.com/claude-code)