### PR TITLE
feat(infra): add security response headers filter (STA-225)

### DIFF
--- a/platform-infra/src/main/java/com/stablecoin/payments/platform/infrastructure/security/SecurityHeadersFilter.java
+++ b/platform-infra/src/main/java/com/stablecoin/payments/platform/infrastructure/security/SecurityHeadersFilter.java
@@ -1,0 +1,61 @@
+package com.stablecoin.payments.platform.infrastructure.security;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@ConditionalOnProperty(name = "app.security.headers.enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(SecurityHeadersProperties.class)
+public class SecurityHeadersFilter implements Filter {
+
+    static final String HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+    static final String HEADER_X_FRAME_OPTIONS = "X-Frame-Options";
+    static final String HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+    static final String HEADER_X_XSS_PROTECTION = "X-XSS-Protection";
+    static final String HEADER_CACHE_CONTROL = "Cache-Control";
+    static final String HEADER_PRAGMA = "Pragma";
+    static final String HEADER_REFERRER_POLICY = "Referrer-Policy";
+    static final String HEADER_PERMISSIONS_POLICY = "Permissions-Policy";
+    static final String HEADER_STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
+
+    private final SecurityHeadersProperties properties;
+
+    public SecurityHeadersFilter(SecurityHeadersProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        if (response instanceof HttpServletResponse httpResponse) {
+            httpResponse.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
+            httpResponse.setHeader(HEADER_X_FRAME_OPTIONS, "DENY");
+            httpResponse.setHeader(HEADER_CONTENT_SECURITY_POLICY, "default-src 'none'");
+            httpResponse.setHeader(HEADER_X_XSS_PROTECTION, "0");
+            httpResponse.setHeader(HEADER_CACHE_CONTROL, "no-store");
+            httpResponse.setHeader(HEADER_PRAGMA, "no-cache");
+            httpResponse.setHeader(HEADER_REFERRER_POLICY, "strict-origin-when-cross-origin");
+            httpResponse.setHeader(HEADER_PERMISSIONS_POLICY, "camera=(), microphone=(), geolocation=()");
+
+            if (properties.hstsEnabled()) {
+                httpResponse.setHeader(HEADER_STRICT_TRANSPORT_SECURITY,
+                        "max-age=" + properties.hstsMaxAge() + "; includeSubDomains");
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/platform-infra/src/main/java/com/stablecoin/payments/platform/infrastructure/security/SecurityHeadersProperties.java
+++ b/platform-infra/src/main/java/com/stablecoin/payments/platform/infrastructure/security/SecurityHeadersProperties.java
@@ -1,0 +1,27 @@
+package com.stablecoin.payments.platform.infrastructure.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.security.headers")
+public record SecurityHeadersProperties(
+        Boolean enabled,
+        Boolean hstsEnabled,
+        Long hstsMaxAge
+) {
+
+    private static final boolean DEFAULT_ENABLED = true;
+    private static final boolean DEFAULT_HSTS_ENABLED = true;
+    private static final long DEFAULT_HSTS_MAX_AGE = 31_536_000L;
+
+    public SecurityHeadersProperties {
+        if (enabled == null) {
+            enabled = DEFAULT_ENABLED;
+        }
+        if (hstsEnabled == null) {
+            hstsEnabled = DEFAULT_HSTS_ENABLED;
+        }
+        if (hstsMaxAge == null) {
+            hstsMaxAge = DEFAULT_HSTS_MAX_AGE;
+        }
+    }
+}

--- a/platform-infra/src/test/java/com/stablecoin/payments/platform/infrastructure/security/SecurityHeadersFilterTest.java
+++ b/platform-infra/src/test/java/com/stablecoin/payments/platform/infrastructure/security/SecurityHeadersFilterTest.java
@@ -1,0 +1,136 @@
+package com.stablecoin.payments.platform.infrastructure.security;
+
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_CACHE_CONTROL;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_CONTENT_SECURITY_POLICY;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_PERMISSIONS_POLICY;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_PRAGMA;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_REFERRER_POLICY;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_STRICT_TRANSPORT_SECURITY;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_X_CONTENT_TYPE_OPTIONS;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_X_FRAME_OPTIONS;
+import static com.stablecoin.payments.platform.infrastructure.security.SecurityHeadersFilter.HEADER_X_XSS_PROTECTION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SecurityHeadersFilter")
+class SecurityHeadersFilterTest {
+
+    @Test
+    @DisplayName("should add all security headers when enabled with defaults")
+    void shouldAddAllSecurityHeadersWhenEnabledWithDefaults() throws ServletException, IOException {
+        // given
+        var properties = new SecurityHeadersProperties(true, true, 31_536_000L);
+        var filter = new SecurityHeadersFilter(properties);
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var filterChain = new MockFilterChain();
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(response.getHeaderNames())
+                .containsExactlyInAnyOrder(
+                        HEADER_X_CONTENT_TYPE_OPTIONS,
+                        HEADER_X_FRAME_OPTIONS,
+                        HEADER_CONTENT_SECURITY_POLICY,
+                        HEADER_X_XSS_PROTECTION,
+                        HEADER_CACHE_CONTROL,
+                        HEADER_PRAGMA,
+                        HEADER_REFERRER_POLICY,
+                        HEADER_PERMISSIONS_POLICY,
+                        HEADER_STRICT_TRANSPORT_SECURITY
+                );
+
+        assertThat(response.getHeader(HEADER_X_CONTENT_TYPE_OPTIONS)).isEqualTo("nosniff");
+        assertThat(response.getHeader(HEADER_X_FRAME_OPTIONS)).isEqualTo("DENY");
+        assertThat(response.getHeader(HEADER_CONTENT_SECURITY_POLICY)).isEqualTo("default-src 'none'");
+        assertThat(response.getHeader(HEADER_X_XSS_PROTECTION)).isEqualTo("0");
+        assertThat(response.getHeader(HEADER_CACHE_CONTROL)).isEqualTo("no-store");
+        assertThat(response.getHeader(HEADER_PRAGMA)).isEqualTo("no-cache");
+        assertThat(response.getHeader(HEADER_REFERRER_POLICY)).isEqualTo("strict-origin-when-cross-origin");
+        assertThat(response.getHeader(HEADER_PERMISSIONS_POLICY)).isEqualTo("camera=(), microphone=(), geolocation=()");
+        assertThat(response.getHeader(HEADER_STRICT_TRANSPORT_SECURITY)).isEqualTo("max-age=31536000; includeSubDomains");
+    }
+
+    @Test
+    @DisplayName("should not add HSTS header when hsts-enabled is false")
+    void shouldNotAddHstsHeaderWhenHstsDisabled() throws ServletException, IOException {
+        // given
+        var properties = new SecurityHeadersProperties(true, false, 31_536_000L);
+        var filter = new SecurityHeadersFilter(properties);
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var filterChain = new MockFilterChain();
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(response.getHeaderNames()).doesNotContain(HEADER_STRICT_TRANSPORT_SECURITY);
+        assertThat(response.getHeader(HEADER_X_CONTENT_TYPE_OPTIONS)).isEqualTo("nosniff");
+        assertThat(response.getHeader(HEADER_X_FRAME_OPTIONS)).isEqualTo("DENY");
+    }
+
+    @Test
+    @DisplayName("should use custom HSTS max-age when configured")
+    void shouldUseCustomHstsMaxAge() throws ServletException, IOException {
+        // given
+        var customMaxAge = 86_400L;
+        var properties = new SecurityHeadersProperties(true, true, customMaxAge);
+        var filter = new SecurityHeadersFilter(properties);
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var filterChain = new MockFilterChain();
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(response.getHeader(HEADER_STRICT_TRANSPORT_SECURITY)).isEqualTo("max-age=86400; includeSubDomains");
+    }
+
+    @Test
+    @DisplayName("should continue filter chain after adding headers")
+    void shouldContinueFilterChainAfterAddingHeaders() throws ServletException, IOException {
+        // given
+        var properties = new SecurityHeadersProperties(true, true, 31_536_000L);
+        var filter = new SecurityHeadersFilter(properties);
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var filterChain = new MockFilterChain();
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(filterChain.getRequest()).isEqualTo(request);
+        assertThat(filterChain.getResponse()).isEqualTo(response);
+    }
+
+    @Test
+    @DisplayName("should apply default property values when nulls provided")
+    void shouldApplyDefaultPropertyValuesWhenNullsProvided() throws ServletException, IOException {
+        // given
+        var properties = new SecurityHeadersProperties(null, null, null);
+        var filter = new SecurityHeadersFilter(properties);
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var filterChain = new MockFilterChain();
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(response.getHeader(HEADER_STRICT_TRANSPORT_SECURITY)).isEqualTo("max-age=31536000; includeSubDomains");
+        assertThat(response.getHeader(HEADER_X_CONTENT_TYPE_OPTIONS)).isEqualTo("nosniff");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SecurityHeadersFilter` (jakarta.servlet.Filter) in `platform-infra` — inherited by all 10 services
- Sets 9 security headers on every HTTP response: `X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`, `X-XSS-Protection`, `Cache-Control`, `Pragma`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`
- `SecurityHeadersProperties` — configurable HSTS toggle (disable for local HTTP dev) and max-age
- Works even when Spring Security is disabled in tests (servlet filter, not security filter)
- `@ConditionalOnProperty(app.security.headers.enabled)` — enabled by default

## Files
- `SecurityHeadersFilter.java` — `@Component @Order(HIGHEST_PRECEDENCE+1)`, 9 headers
- `SecurityHeadersProperties.java` — `@ConfigurationProperties` record with defaults
- `SecurityHeadersFilterTest.java` — 5 tests (all headers, no HSTS, custom max-age, chain continues, defaults)

## Test plan
- [x] 5 new tests pass
- [x] All existing platform-infra tests pass (15 total)
- [ ] CI green

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)