### PR TITLE
feat(infra): add Spring Cloud Vault secrets management (STA-219)

### DIFF
--- a/api-gateway-iam/api-gateway-iam/src/main/resources/application-integration-test.yml
+++ b/api-gateway-iam/api-gateway-iam/src/main/resources/application-integration-test.yml
@@ -25,6 +25,8 @@ spring:
       port: 6379
 
   cloud:
+    vault:
+      enabled: false
     stream:
       kafka:
         binder:

--- a/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
+++ b/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s10_api_gateway_iam}
@@ -62,13 +67,6 @@ spring:
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
 
 app:
   idempotency:

--- a/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
+++ b/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
+++ b/api-gateway-iam/api-gateway-iam/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: api-gateway-iam
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s10_api_gateway_iam}
     username: ${DB_USER:sp_user}

--- a/blockchain-custody/blockchain-custody/src/integration-test/resources/application-integration-test.yml
+++ b/blockchain-custody/blockchain-custody/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/blockchain-custody/blockchain-custody/src/main/resources/application.yml
+++ b/blockchain-custody/blockchain-custody/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/blockchain-custody/blockchain-custody/src/main/resources/application.yml
+++ b/blockchain-custody/blockchain-custody/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: blockchain-custody
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s4_blockchain_custody}
     username: ${DB_USER:dev}

--- a/compliance-travel-rule/compliance-travel-rule/src/integration-test/resources/application-integration-test.yml
+++ b/compliance-travel-rule/compliance-travel-rule/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/compliance-travel-rule/compliance-travel-rule/src/main/resources/application.yml
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/compliance-travel-rule/compliance-travel-rule/src/main/resources/application.yml
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/resources/application.yml
@@ -17,6 +17,16 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
+      bindings:
+        compliance-result-out-0:
+          destination: compliance.result
+        sanctions-hit-out-0:
+          destination: sanctions.hit
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s2_compliance}
@@ -51,18 +61,6 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
-      bindings:
-        compliance-result-out-0:
-          destination: compliance.result
-        sanctions-hit-out-0:
-          destination: sanctions.hit
 
 namastack:
   outbox:

--- a/compliance-travel-rule/compliance-travel-rule/src/main/resources/application.yml
+++ b/compliance-travel-rule/compliance-travel-rule/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: compliance-travel-rule
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s2_compliance}
     username: ${DB_USER:sp_user}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -194,6 +194,23 @@ services:
       retries: 10
 
   # ─────────────────────────────────────────────
+  # Vault init — seeds KV v2 secrets for local dev
+  # ─────────────────────────────────────────────
+  vault-init:
+    image: hashicorp/vault:latest
+    container_name: sp-vault-init
+    depends_on:
+      vault:
+        condition: service_healthy
+    environment:
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root-token
+    volumes:
+      - ./infra/local/vault/init-vault.sh:/vault/init-vault.sh
+    entrypoint: ["/bin/sh", "/vault/init-vault.sh"]
+    restart: "no"
+
+  # ─────────────────────────────────────────────
   # Mailhog — captures outbound email (replaces SendGrid in dev)
   # ─────────────────────────────────────────────
   mailpit:

--- a/fiat-off-ramp/fiat-off-ramp/src/integration-test/resources/application-integration-test.yml
+++ b/fiat-off-ramp/fiat-off-ramp/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/fiat-off-ramp/fiat-off-ramp/src/main/resources/application.yml
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/fiat-off-ramp/fiat-off-ramp/src/main/resources/application.yml
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: fiat-off-ramp
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s5_fiat_off_ramp}
     username: ${DB_USER:sp_user}

--- a/fiat-off-ramp/fiat-off-ramp/src/main/resources/application.yml
+++ b/fiat-off-ramp/fiat-off-ramp/src/main/resources/application.yml
@@ -17,6 +17,18 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
+      bindings:
+        fiat-payout-initiated-out-0:
+          destination: fiat.payout.initiated
+        fiat-payout-completed-out-0:
+          destination: fiat.payout.completed
+        fiat-payout-failed-out-0:
+          destination: fiat.payout.failed
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s5_fiat_off_ramp}
@@ -51,20 +63,6 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
-      bindings:
-        fiat-payout-initiated-out-0:
-          destination: fiat.payout.initiated
-        fiat-payout-completed-out-0:
-          destination: fiat.payout.completed
-        fiat-payout-failed-out-0:
-          destination: fiat.payout.failed
 
 namastack:
   outbox:

--- a/fiat-on-ramp/fiat-on-ramp/src/integration-test/resources/application-integration-test.yml
+++ b/fiat-on-ramp/fiat-on-ramp/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
@@ -17,6 +17,16 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
+      bindings:
+        fiat-collected-out-0:
+          destination: fiat.collected
+        fiat-collection-failed-out-0:
+          destination: fiat.collection.failed
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s3_fiat_on_ramp}
@@ -51,18 +61,6 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
-      bindings:
-        fiat-collected-out-0:
-          destination: fiat.collected
-        fiat-collection-failed-out-0:
-          destination: fiat.collection.failed
 
 namastack:
   outbox:

--- a/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
+++ b/fiat-on-ramp/fiat-on-ramp/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: fiat-on-ramp
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s3_fiat_on_ramp}
     username: ${DB_USER:sp_user}

--- a/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/resources/application-integration-test.yml
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/application.yml
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/application.yml
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5433/fx_rates}
@@ -56,13 +61,6 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
 
 namastack:
   outbox:

--- a/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/application.yml
+++ b/fx-liquidity-engine/fx-liquidity-engine/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: fx-liquidity-engine
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5433/fx_rates}
     username: ${DB_USER:sp_user}

--- a/infra/local/vault/init-vault.sh
+++ b/infra/local/vault/init-vault.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Vault initialisation script for local development (Docker Compose).
+#
+# Seeds the KV v2 secrets engine with per-service credentials and shared
+# infrastructure secrets.  Designed to run idempotently — re-running this
+# script simply overwrites existing values.
+#
+# Prerequisites:
+#   - Vault must be running in dev mode (VAULT_DEV_ROOT_TOKEN_ID=dev-root-token)
+#   - The `vault` CLI must be available (inside the Vault container)
+#
+# Usage:
+#   docker compose exec vault /bin/sh /vault/init-vault.sh
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+export VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+export VAULT_TOKEN="${VAULT_TOKEN:-dev-root-token}"
+
+echo "==> Waiting for Vault to be ready..."
+until vault status > /dev/null 2>&1; do
+  sleep 1
+done
+echo "==> Vault is ready"
+
+# ---------------------------------------------------------------------------
+# Enable KV v2 secrets engine (idempotent — ignores "already mounted" error)
+# ---------------------------------------------------------------------------
+vault secrets enable -path=secret -version=2 kv 2>/dev/null || true
+echo "==> KV v2 secrets engine enabled at secret/"
+
+# ---------------------------------------------------------------------------
+# Shared secrets (default-context = "application")
+# Every service reads from secret/application as a fallback.
+# ---------------------------------------------------------------------------
+vault kv put secret/application \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.kafka.bootstrap-servers=localhost:9092 \
+  spring.data.redis.password=""
+
+echo "==> Shared secrets seeded at secret/application"
+
+# ---------------------------------------------------------------------------
+# S1 Payment Orchestrator
+# ---------------------------------------------------------------------------
+vault kv put secret/payment-orchestrator \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s1_payment_orchestrator
+
+echo "==> Secrets seeded for payment-orchestrator"
+
+# ---------------------------------------------------------------------------
+# S2 Compliance & Travel Rule
+# ---------------------------------------------------------------------------
+vault kv put secret/compliance-travel-rule \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s2_compliance \
+  app.compliance.worldcheck.api-key=dev-worldcheck-key \
+  app.compliance.chainalysis.api-key=dev-chainalysis-key
+
+echo "==> Secrets seeded for compliance-travel-rule"
+
+# ---------------------------------------------------------------------------
+# S3 Fiat On-Ramp
+# ---------------------------------------------------------------------------
+vault kv put secret/fiat-on-ramp \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s3_fiat_on_ramp \
+  app.psp.stripe.api-key=sk_test_dev_vault_key \
+  app.psp.stripe.webhook.webhook-secret=whsec_test_dev_vault
+
+echo "==> Secrets seeded for fiat-on-ramp"
+
+# ---------------------------------------------------------------------------
+# S4 Blockchain & Custody
+# ---------------------------------------------------------------------------
+vault kv put secret/blockchain-custody \
+  spring.datasource.username=dev \
+  spring.datasource.password=dev \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s4_blockchain_custody \
+  app.custody.fireblocks.api-key=fireblocks-dev-key \
+  app.custody.fireblocks.api-secret=dev-fireblocks-secret \
+  app.custody.dev.evm-private-key=dev-evm-private-key
+
+echo "==> Secrets seeded for blockchain-custody"
+
+# ---------------------------------------------------------------------------
+# S5 Fiat Off-Ramp
+# ---------------------------------------------------------------------------
+vault kv put secret/fiat-off-ramp \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s5_fiat_off_ramp \
+  app.redemption.circle.api-key=SAND_API_KEY_VAULT \
+  app.payout.modulr.webhook.webhook-secret=dev-modulr-webhook-secret
+
+echo "==> Secrets seeded for fiat-off-ramp"
+
+# ---------------------------------------------------------------------------
+# S6 FX & Liquidity Engine
+# ---------------------------------------------------------------------------
+vault kv put secret/fx-liquidity-engine \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5433/fx_rates
+
+echo "==> Secrets seeded for fx-liquidity-engine"
+
+# ---------------------------------------------------------------------------
+# S7 Ledger & Accounting
+# ---------------------------------------------------------------------------
+vault kv put secret/ledger-accounting \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s7_ledger_accounting
+
+echo "==> Secrets seeded for ledger-accounting"
+
+# ---------------------------------------------------------------------------
+# S10 API Gateway & IAM
+# ---------------------------------------------------------------------------
+vault kv put secret/api-gateway-iam \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s10_api_gateway_iam \
+  api-gateway-iam.jwt.private-key-base64=dev-jwt-private-key-base64
+
+echo "==> Secrets seeded for api-gateway-iam"
+
+# ---------------------------------------------------------------------------
+# S11 Merchant Onboarding
+# ---------------------------------------------------------------------------
+vault kv put secret/merchant-onboarding \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s11_merchant_onboarding
+
+echo "==> Secrets seeded for merchant-onboarding"
+
+# ---------------------------------------------------------------------------
+# S13 Merchant IAM
+# ---------------------------------------------------------------------------
+vault kv put secret/merchant-iam \
+  spring.datasource.username=sp_user \
+  spring.datasource.password=sp_pass \
+  spring.datasource.url=jdbc:postgresql://localhost:5432/s13_merchant_iam \
+  merchant-iam.jwt.private-key-base64=dev-jwt-private-key-base64
+
+echo "==> Secrets seeded for merchant-iam"
+
+echo ""
+echo "==> Vault initialisation complete. All service secrets seeded."
+echo "==> Vault UI: http://localhost:8200  (token: dev-root-token)"

--- a/ledger-accounting/ledger-accounting/src/integration-test/resources/application-integration-test.yml
+++ b/ledger-accounting/ledger-accounting/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/ledger-accounting/ledger-accounting/src/main/resources/application.yml
+++ b/ledger-accounting/ledger-accounting/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/ledger-accounting/ledger-accounting/src/main/resources/application.yml
+++ b/ledger-accounting/ledger-accounting/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s7_ledger_accounting}
@@ -55,13 +60,6 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
 
 namastack:
   outbox:

--- a/ledger-accounting/ledger-accounting/src/main/resources/application.yml
+++ b/ledger-accounting/ledger-accounting/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: ledger-accounting
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s7_ledger_accounting}
     username: ${DB_USER:sp_user}

--- a/merchant-iam/merchant-iam/src/integration-test/resources/application-integration-test.yml
+++ b/merchant-iam/merchant-iam/src/integration-test/resources/application-integration-test.yml
@@ -17,6 +17,8 @@ spring:
       port: 6379
 
   cloud:
+    vault:
+      enabled: false
     stream:
       kafka:
         binder:

--- a/merchant-iam/merchant-iam/src/main/resources/application-integration-test.yml
+++ b/merchant-iam/merchant-iam/src/main/resources/application-integration-test.yml
@@ -17,6 +17,8 @@ spring:
       port: 6379
 
   cloud:
+    vault:
+      enabled: false
     stream:
       kafka:
         binder:

--- a/merchant-iam/merchant-iam/src/main/resources/application.yml
+++ b/merchant-iam/merchant-iam/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/merchant-iam/merchant-iam/src/main/resources/application.yml
+++ b/merchant-iam/merchant-iam/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: merchant-iam
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s13_merchant_iam}
     username: ${DB_USER:sp_user}

--- a/merchant-iam/merchant-iam/src/main/resources/application.yml
+++ b/merchant-iam/merchant-iam/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s13_merchant_iam}
@@ -62,13 +67,6 @@ spring:
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
 
   mail:
     host: ${MAIL_HOST:localhost}

--- a/merchant-onboarding/merchant-onboarding/src/integration-test/resources/application-integration-test.yml
+++ b/merchant-onboarding/merchant-onboarding/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
+++ b/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
+++ b/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: merchant-onboarding
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s11_merchant_onboarding}
     username: ${DB_USER:sp_user}

--- a/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
+++ b/merchant-onboarding/merchant-onboarding/src/main/resources/application.yml
@@ -17,6 +17,26 @@ spring:
         enabled: true
         backend: secret
         default-context: application
+    stream:
+      kafka:
+        binder:
+          brokers: ${KAFKA_BROKERS:localhost:9092}
+          auto-create-topics: false
+      bindings:
+        merchant-activated-out-0:
+          destination: merchant.activated
+        merchant-applied-out-0:
+          destination: merchant.applied
+        merchant-suspended-out-0:
+          destination: merchant.suspended
+        merchant-closed-out-0:
+          destination: merchant.closed
+        merchant-kyb-passed-out-0:
+          destination: merchant.kyb.passed
+        merchant-kyb-failed-out-0:
+          destination: merchant.kyb.failed
+        merchant-corridor-approved-out-0:
+          destination: merchant.corridor.approved
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s11_merchant_onboarding}
@@ -56,28 +76,6 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-  cloud:
-    stream:
-      kafka:
-        binder:
-          brokers: ${KAFKA_BROKERS:localhost:9092}
-          auto-create-topics: false
-      bindings:
-        merchant-activated-out-0:
-          destination: merchant.activated
-        merchant-applied-out-0:
-          destination: merchant.applied
-        merchant-suspended-out-0:
-          destination: merchant.suspended
-        merchant-closed-out-0:
-          destination: merchant.closed
-        merchant-kyb-passed-out-0:
-          destination: merchant.kyb.passed
-        merchant-kyb-failed-out-0:
-          destination: merchant.kyb.failed
-        merchant-corridor-approved-out-0:
-          destination: merchant.corridor.approved
 
 app:
   idempotency:

--- a/payment-orchestrator/payment-orchestrator/src/integration-test/resources/application-integration-test.yml
+++ b/payment-orchestrator/payment-orchestrator/src/integration-test/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  cloud:
+    vault:
+      enabled: false
   main:
     allow-bean-definition-overriding: true
   jpa:

--- a/payment-orchestrator/payment-orchestrator/src/main/resources/application.yml
+++ b/payment-orchestrator/payment-orchestrator/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
       enabled: ${app.vault.enabled:false}
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: http
+      scheme: ${VAULT_SCHEME:https}
       authentication: TOKEN
-      token: ${VAULT_TOKEN:dev-root-token}
+      token: ${VAULT_TOKEN:}
       kv:
         enabled: true
         backend: secret

--- a/payment-orchestrator/payment-orchestrator/src/main/resources/application.yml
+++ b/payment-orchestrator/payment-orchestrator/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: payment-orchestrator
 
+  config:
+    import: optional:vault://
+
+  cloud:
+    vault:
+      enabled: ${app.vault.enabled:false}
+      host: ${VAULT_HOST:localhost}
+      port: ${VAULT_PORT:8200}
+      scheme: http
+      authentication: TOKEN
+      token: ${VAULT_TOKEN:dev-root-token}
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/s1_payment_orchestrator}
     username: ${DB_USER:sp_user}

--- a/platform-infra/build.gradle.kts
+++ b/platform-infra/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.kafka:spring-kafka")
+    implementation("org.springframework.cloud:spring-cloud-starter-vault-config")
     implementation("io.namastack:namastack-outbox-starter-jdbc:$namastackVersion")
 
     // Feign — compileOnly so services without Feign are not forced to pull it in;

--- a/platform-infra/src/main/java/com/stablecoin/payments/platform/infrastructure/vault/VaultConfig.java
+++ b/platform-infra/src/main/java/com/stablecoin/payments/platform/infrastructure/vault/VaultConfig.java
@@ -1,0 +1,40 @@
+package com.stablecoin.payments.platform.infrastructure.vault;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Activates Spring Cloud Vault integration for centralised secrets management.
+ *
+ * <p>Spring Cloud Vault auto-configures a {@code VaultTemplate} and the
+ * {@code spring.config.import=optional:vault://} ConfigData source whenever its
+ * starter is on the classpath <b>and</b> Vault connectivity is configured.
+ *
+ * <p>This configuration class acts as the opt-in toggle:
+ * <ul>
+ *   <li>Production / staging: set {@code app.vault.enabled=true} and supply
+ *       {@code VAULT_TOKEN} (or use Kubernetes/AppRole auth).</li>
+ *   <li>Local dev: Vault runs in Docker Compose dev mode with a static
+ *       root token ({@code dev-root-token}).</li>
+ *   <li>Tests: defaults to disabled ({@code matchIfMissing = false}) so that
+ *       unit and integration tests never require a running Vault instance.</li>
+ * </ul>
+ *
+ * <p>Secrets are resolved through the KV v2 engine at
+ * {@code secret/{application-name}} and the shared context
+ * {@code secret/application}. Property names in Vault map directly to
+ * Spring property keys (e.g. {@code spring.datasource.password}).
+ *
+ * @see <a href="https://docs.spring.io/spring-cloud-vault/reference/">
+ *     Spring Cloud Vault Reference</a>
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = "app.vault.enabled", havingValue = "true", matchIfMissing = false)
+public class VaultConfig {
+
+    public VaultConfig() {
+        log.info("Vault secrets management enabled — resolving properties from HashiCorp Vault");
+    }
+}

--- a/platform-infra/src/test/java/com/stablecoin/payments/platform/infrastructure/vault/VaultConfigTest.java
+++ b/platform-infra/src/test/java/com/stablecoin/payments/platform/infrastructure/vault/VaultConfigTest.java
@@ -1,0 +1,38 @@
+package com.stablecoin.payments.platform.infrastructure.vault;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("VaultConfig")
+class VaultConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(VaultConfig.class));
+
+    @Test
+    @DisplayName("should register VaultConfig when app.vault.enabled=true")
+    void shouldRegisterWhenEnabled() {
+        contextRunner
+                .withPropertyValues("app.vault.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(VaultConfig.class));
+    }
+
+    @Test
+    @DisplayName("should not register VaultConfig when app.vault.enabled=false")
+    void shouldNotRegisterWhenDisabled() {
+        contextRunner
+                .withPropertyValues("app.vault.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(VaultConfig.class));
+    }
+
+    @Test
+    @DisplayName("should not register VaultConfig when property is absent (matchIfMissing=false)")
+    void shouldNotRegisterWhenPropertyAbsent() {
+        contextRunner
+                .run(context -> assertThat(context).doesNotHaveBean(VaultConfig.class));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Spring Cloud Vault integration for centralized secrets management across all 10 services
- `VaultConfig` — opt-in toggle (`app.vault.enabled=false` by default) — existing env-var workflow unaffected
- `spring.config.import: optional:vault://` in all service `application.yml` — services boot without Vault
- Vault init script seeds KV v2 secrets for all 10 services + shared `secret/application`
- `vault-init` Docker Compose service runs after Vault is healthy

## Files
- `VaultConfig.java` — `@ConditionalOnProperty(matchIfMissing=false)`, documents Vault architecture
- `VaultConfigTest.java` — 3 tests (enabled, disabled, absent)
- `init-vault.sh` — seeds per-service DB creds, API keys, JWT keys, webhook secrets
- `docker-compose.dev.yml` — `vault-init` service with health check dependency
- 10x `application.yml` — `spring.cloud.vault` + `spring.config.import` blocks
- `platform-infra/build.gradle.kts` — `spring-cloud-starter-vault-config` dependency

## Design Decisions
- **Opt-in**: `matchIfMissing=false` ensures zero impact on tests and existing dev workflow
- **`optional:vault://`**: ConfigData import is optional — no Vault needed for tests/CI
- **KV v2**: `secret/{spring.application.name}` for service-specific, `secret/application` for shared
- **Unblocks**: STA-216 (PII encryption) and STA-217 (inter-service auth)

## Test plan
- [x] 3 new VaultConfig tests pass
- [x] All existing tests pass across all 10 services
- [x] Pre-push quality gate passes (all subprojects)
- [ ] CI green

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Vault-backed configuration across services
  * Added a Vault initializer for local development
  * Reorganized Kafka binder configuration for a consistent layout

* **Chores**
  * Consolidated duplicate Kafka configuration blocks across services
  * Updated integration-test profiles to explicitly disable Vault

* **Tests**
  * Added unit tests validating Vault configuration enablement/disablement
<!-- end of auto-generated comment: release notes by coderabbit.ai -->